### PR TITLE
fix: table-growth snapshots (unbound SQL parameter) and slow brain-init revival

### DIFF
--- a/backend/src/main/java/com/dbaagent/provider/postgres/PostgresIntrospectionProvider.java
+++ b/backend/src/main/java/com/dbaagent/provider/postgres/PostgresIntrospectionProvider.java
@@ -223,21 +223,31 @@ public class PostgresIntrospectionProvider implements IntrospectionProvider {
         TableStats stats = new TableStats();
         stats.setTableName(tableName);
 
+        // One placeholder, resolved once in a CTE, instead of repeating `?::regclass`
+        // in every expression. The previous form had NINE placeholders — the two
+        // subtractions use two each — while the binding loop ran `i <= 7`, so
+        // parameters 8 and 9 were never set and every call threw
+        // `No value specified for parameter 8`. That silently broke table-growth
+        // snapshots for every table on every Postgres connection
+        // (TableGrowthMonitoringService logs it per table and carries on).
+        //
+        // Counting placeholders by hand is exactly what failed here, so the count is
+        // now impossible to get wrong: bind one value and reference it by name.
         String query = """
+            WITH t AS (SELECT ?::regclass AS rel)
             SELECT
-                pg_size_pretty(pg_total_relation_size(?::regclass)) as total_size,
-                pg_total_relation_size(?::regclass) as total_bytes,
-                pg_size_pretty(pg_relation_size(?::regclass)) as data_size,
-                pg_relation_size(?::regclass) as data_bytes,
-                pg_size_pretty(pg_total_relation_size(?::regclass) - pg_relation_size(?::regclass)) as index_size,
-                (pg_total_relation_size(?::regclass) - pg_relation_size(?::regclass)) as index_bytes,
-                obj_description(?::regclass, 'pg_class') as comment
+                pg_size_pretty(pg_total_relation_size(rel)) as total_size,
+                pg_total_relation_size(rel) as total_bytes,
+                pg_size_pretty(pg_relation_size(rel)) as data_size,
+                pg_relation_size(rel) as data_bytes,
+                pg_size_pretty(pg_total_relation_size(rel) - pg_relation_size(rel)) as index_size,
+                (pg_total_relation_size(rel) - pg_relation_size(rel)) as index_bytes,
+                obj_description(rel, 'pg_class') as comment
+            FROM t
             """;
 
         try (PreparedStatement stmt = connection.prepareStatement(query)) {
-            for (int i = 1; i <= 7; i++) {
-                stmt.setString(i, tableName);
-            }
+            stmt.setString(1, tableName);
 
             try (ResultSet rs = stmt.executeQuery()) {
                 if (rs.next()) {

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -71,7 +71,19 @@ spring.batch.job.enabled=false
 
 # db-scheduler Configuration (distributed task scheduling)
 db-scheduler.enabled=true
-db-scheduler.heartbeat-interval=5m
+# The revival window for an execution whose owner died is
+# heartbeat-interval × missed-heartbeats-limit. At the old 5m × 6 that was THIRTY
+# MINUTES, during which a dead brain-init stage sits at a frozen percentage with no
+# error: the status endpoint keeps reporting the last stage it reached, so it is
+# indistinguishable from slow progress. smoke-test.sh gives up after 1200s (20m),
+# so any run where a stage died failed the smoke test even though init would have
+# completed fine once revived — observed exactly that, init finishing ~37m after
+# revival.
+#
+# 1m × 6 keeps the same six-missed-heartbeat tolerance — a live-but-slow execution
+# heartbeats from its own thread, so a long LLM call is never mistaken for death —
+# while bringing revival to ~6m, comfortably inside the smoke-test window.
+db-scheduler.heartbeat-interval=1m
 db-scheduler.missed-heartbeats-limit=6
 db-scheduler.polling-interval=10s
 db-scheduler.polling-strategy=fetch

--- a/backend/src/test/java/com/dbaagent/provider/postgres/PostgresIntrospectionProviderTest.java
+++ b/backend/src/test/java/com/dbaagent/provider/postgres/PostgresIntrospectionProviderTest.java
@@ -10,8 +10,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.sql.*;
 import java.util.List;
 
+import org.mockito.ArgumentCaptor;
+
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -169,6 +173,38 @@ class PostgresIntrospectionProviderTest {
         assertEquals(81920L, stats.getDataSize());
         assertEquals(40960L, stats.getIndexSize());
         assertEquals(122880L, stats.getSizeBytes());
+    }
+
+    @Test
+    void getTableStats_bindsEveryPlaceholderInTheStatsQuery() throws SQLException {
+        // The stats query carried NINE `?` placeholders (the two size subtractions use
+        // two each) while the binding loop ran `i <= 7`, so parameters 8 and 9 were
+        // never set and Postgres rejected every call with
+        //   No value specified for parameter 8
+        // silently killing table-growth snapshots for every table.
+        //
+        // getTableStats_returnsStats above passed throughout, because a mocked
+        // PreparedStatement does not enforce that placeholders are bound. This test
+        // compares the two directly, so the count can never drift again.
+        PreparedStatement rowCountStatement = mock(PreparedStatement.class);
+        ResultSet rowCountResultSet = mock(ResultSet.class);
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+
+        when(connection.prepareStatement(anyString())).thenReturn(preparedStatement, rowCountStatement);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(rowCountStatement.executeQuery()).thenReturn(rowCountResultSet);
+        when(resultSet.next()).thenReturn(true);
+        when(rowCountResultSet.next()).thenReturn(true);
+        when(rowCountResultSet.getObject("row_count")).thenReturn(1000L);
+
+        provider.getTableStats(connection, "public", "users");
+
+        verify(connection, atLeastOnce()).prepareStatement(sqlCaptor.capture());
+        String statsQuery = sqlCaptor.getAllValues().get(0);
+        int placeholders = (int) statsQuery.chars().filter(c -> c == '?').count();
+
+        assertTrue(placeholders > 0, "stats query should still be parameterised");
+        verify(preparedStatement, times(placeholders)).setString(anyInt(), eq("users"));
     }
 
     @Test


### PR DESCRIPTION
Two independent defects found while running the self-host install flow end to end. Both were silent — each one degraded a feature while the surrounding job reported success.

## 1. Table-growth snapshots never captured on Postgres

`PostgresIntrospectionProvider.getTableStats` built a query with **nine** `?` placeholders (the two size subtractions use two each) while the binding loop ran `for (i = 1; i <= 7)`. Parameters 8 and 9 were never set, so every call failed with:

```
No value specified for parameter 8
```

`TableGrowthMonitoringService` logs this per table and carries on, so the scheduled job "succeeded" while capturing nothing — for every table, on every Postgres connection.

The query now binds a single value and references it through a CTE, so the count cannot drift again.

**Verified against a live Postgres 18:** the old form reports 9 parameters via `pg_prepared_statements`; the new one reports 1 and returns correct sizes for `dba_batch_job_execution`, the exact table from the log. MySQL's `getTableStats` was checked and is unaffected (2 placeholders, 2 bound).

## 2. Dead brain-init stages took 30 minutes to revive

The reclaim window is `heartbeat-interval × missed-heartbeats-limit` = `5m × 6` = **30 minutes**.

During it a dead stage is invisible rather than failed: `init-status` keeps returning the last stage and percentage, with `completedAt` and `errorMessage` both null — a frozen run looks exactly like a slow one. `smoke-test.sh` waits 1200s (20m), *less than the revival window*, so any run where a stage died failed the smoke test even though initialization would have completed normally.

Observed exactly that: a stage stopped heartbeating, the smoke test timed out at 74%, and brain init then reached 100% about 37 minutes after the scheduler revived it.

`1m × 6` keeps the same six-missed-heartbeat tolerance and brings revival to ~6 minutes, inside the smoke-test window. Shortening the interval does not risk reclaiming healthy work — heartbeats come from the execution's own thread, so a long LLM call keeps heartbeating.

## Testing

- `PostgresIntrospectionProviderTest` — 11/11 pass.
- The new test compares placeholder count against bind count. It **fails against the pre-fix provider** with `Wanted 9 times`, while the other 10 tests still pass — which is why this reached production: `getTableStats_returnsStats` passed throughout, because a mocked `PreparedStatement` does not enforce that placeholders are bound.
- `application-test.properties` overrides `polling-interval` and `immediate-execution-enabled`, not the heartbeat keys, so tests are unaffected by change 2.

## Not addressed here

`TableGrowthMonitoringService.captureSnapshot` is `@Transactional` **and** `private`. Spring cannot proxy a private method, and both call sites reach it by self-invocation, so the annotation is inert — while its Javadoc claims it "ensures all repository operations use a single database connection, reducing connection pool pressure from 4-5 connections per table to just 1." That claim does not hold today. Left out of this PR because fixing it changes transaction boundaries and deserves its own review.