### PR TITLE
feat(oss): E2E fix proposal MVP — multi-schema Brain, Agent auth, onboarding

### DIFF
--- a/backend/src/main/java/com/dbaagent/controller/AgentBridgeController.java
+++ b/backend/src/main/java/com/dbaagent/controller/AgentBridgeController.java
@@ -5,10 +5,14 @@ import com.dbaagent.service.security.AccessControlService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -20,6 +24,8 @@ import java.util.Map;
 @RequestMapping("/agent")
 @RequiredArgsConstructor
 public class AgentBridgeController {
+    private static final Logger log = LoggerFactory.getLogger(AgentBridgeController.class);
+
     private final AccessControlService accessControlService;
     private final AgentBridgeService agentBridgeService;
 
@@ -33,8 +39,33 @@ public class AgentBridgeController {
         String username = accessControlService.requireCurrentUsername();
         String token = extractToken(request);
         String connectionId = body == null ? null : asString(body.get("connectionId"));
-        String profile = agentBridgeService.ensureProfile(username, token, connectionId);
-        return ResponseEntity.ok(Map.of("profile", profile, "username", username));
+
+        AgentBridgeService.ProfileBootstrap bootstrap;
+        try {
+            bootstrap = agentBridgeService.ensureProfile(username, token, connectionId);
+        } catch (AgentBridgeService.ProvisioningException e) {
+            log.warn("Agent session bootstrap failed for {}: {}", username, e.getMessage());
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(Map.of(
+                "error", "agent_provisioning_failed",
+                "message", "Could not provision the DeepSQL Agent for this user. "
+                    + "Check that the agent provisioner is running and reachable."
+            ));
+        }
+
+        // Boot health check: probe the exact token just provisioned against this
+        // backend's own API before telling the UI it's safe to chat. Without
+        // this, an expired/misrouted token surfaces only after several failed
+        // tool calls deep into a conversation (W1 "fail loud, early").
+        Map<String, Object> response = new HashMap<>();
+        response.put("profile", bootstrap.profile());
+        response.put("username", username);
+        boolean mcpAuthOk = agentBridgeService.probeMcpAuth(bootstrap.token());
+        response.put("mcpAuthOk", mcpAuthOk);
+        if (!mcpAuthOk) {
+            response.put("mcpAuthError", "The DeepSQL Agent could not authenticate against this API with its "
+                + "provisioned token. Reconnect or check the Agent runtime.");
+        }
+        return ResponseEntity.ok(response);
     }
 
     private String extractToken(HttpServletRequest request) {

--- a/backend/src/main/java/com/dbaagent/model/InitStage.java
+++ b/backend/src/main/java/com/dbaagent/model/InitStage.java
@@ -11,11 +11,16 @@ public enum InitStage {
     RAG_EMBEDDING,
     BRAIN_ANALYSIS,
     SEMANTIC_MODELING,
+    /**
+     * Schema coverage incomplete — Brain must not claim Complete 100%.
+     * Surfaced when indexed base tables are far below live user tables (W2b).
+     */
+    NEEDS_ATTENTION,
     COMPLETED,
     FAILED;
 
     public boolean isTerminal() {
-        return this == COMPLETED || this == FAILED;
+        return this == COMPLETED || this == FAILED || this == NEEDS_ATTENTION;
     }
 
     public InitStage next() {
@@ -29,7 +34,7 @@ public enum InitStage {
             case AI_DESCRIPTION -> RAG_EMBEDDING;
             case RAG_EMBEDDING -> BRAIN_ANALYSIS;
             case BRAIN_ANALYSIS -> SEMANTIC_MODELING;
-            case SEMANTIC_MODELING, COMPLETED, FAILED -> null;
+            case SEMANTIC_MODELING, COMPLETED, FAILED, NEEDS_ATTENTION -> null;
         };
     }
 }

--- a/backend/src/main/java/com/dbaagent/provider/postgres/PostgresIntrospectionProvider.java
+++ b/backend/src/main/java/com/dbaagent/provider/postgres/PostgresIntrospectionProvider.java
@@ -20,6 +20,35 @@ public class PostgresIntrospectionProvider implements IntrospectionProvider {
     private static final String DATABASE_TYPE = "postgres";
     private static final String DEFAULT_SCHEMA = "public";
 
+    /**
+     * Non-system Postgres schemas. Matches Brain classification services and
+     * docs/oss-ux/E2E_FIX_PROPOSAL.md W2a — never hardcode public alone.
+     */
+    static final String NON_SYSTEM_SCHEMA_SQL =
+        "NOT IN ('pg_catalog','information_schema','pg_toast') "
+        + "AND %1$s NOT LIKE 'pg_temp_%%' "
+        + "AND %1$s NOT LIKE 'pg_toast_temp_%%'";
+
+    static String nonSystemSchemaPredicate(String column) {
+        return column + " " + String.format(NON_SYSTEM_SCHEMA_SQL, column);
+    }
+
+    /** Map / snapshot key that survives duplicate table names across schemas. */
+    static String qualifiedTableKey(String schema, String table) {
+        String s = (schema == null || schema.isBlank()) ? DEFAULT_SCHEMA : schema;
+        String t = table == null ? "" : table;
+        return s + "." + t;
+    }
+
+    /** Display / relationship name: bare for public, schema.table otherwise. */
+    static String qualifyForConsumers(String schema, String table) {
+        String s = (schema == null || schema.isBlank()) ? DEFAULT_SCHEMA : schema;
+        if (DEFAULT_SCHEMA.equals(s)) {
+            return table;
+        }
+        return s + "." + table;
+    }
+
     @Value("${db.fetch-size:1000}")
     private int fetchSize;
 
@@ -43,8 +72,10 @@ public class PostgresIntrospectionProvider implements IntrospectionProvider {
     private List<DatabaseObject> getTablesAndViews(Connection connection) throws SQLException {
         List<DatabaseObject> objects = new ArrayList<>();
 
+        String schemaPred = nonSystemSchemaPredicate("t.schemaname");
+        String viewPred = nonSystemSchemaPredicate("v.schemaname");
         String query = """
-            SELECT t.tablename as name, 'table' as type,
+            SELECT t.schemaname as schema_name, t.tablename as name, 'table' as type,
                 CASE
                     WHEN s.n_live_tup > 0 THEN s.n_live_tup::bigint
                     WHEN s.n_live_tup = 0 AND c.reltuples = 0 THEN 0::bigint
@@ -55,25 +86,26 @@ public class PostgresIntrospectionProvider implements IntrospectionProvider {
             JOIN pg_namespace n ON n.nspname = t.schemaname
             JOIN pg_class c ON c.relnamespace = n.oid AND c.relname = t.tablename
             LEFT JOIN pg_stat_all_tables s ON s.relid = c.oid
-            WHERE t.schemaname = 'public' AND c.relkind IN ('r', 'p')
+            WHERE %s AND c.relkind IN ('r', 'p')
             UNION ALL
-            SELECT v.viewname as name, 'view' as type, 0 as row_count
-            FROM pg_views v WHERE v.schemaname = 'public'
-            ORDER BY type, name
-            """;
+            SELECT v.schemaname as schema_name, v.viewname as name, 'view' as type, 0 as row_count
+            FROM pg_views v WHERE %s
+            ORDER BY schema_name, type, name
+            """.formatted(schemaPred, viewPred);
 
         try (Statement stmt = connection.createStatement();
              ResultSet rs = stmt.executeQuery(query)) {
             while (rs.next()) {
                 DatabaseObject obj = new DatabaseObject();
+                String schemaName = rs.getString("schema_name");
                 obj.setName(rs.getString("name"));
-                obj.setSchema(DEFAULT_SCHEMA);
+                obj.setSchema(schemaName);
                 obj.setType(rs.getString("type"));
                 Long estimatedRowCount = getNullableLong(rs, "row_count");
                 obj.setRowCount("table".equals(obj.getType())
-                    ? resolveTableRowCount(connection, DEFAULT_SCHEMA, obj.getName(), estimatedRowCount)
+                    ? resolveTableRowCount(connection, schemaName, obj.getName(), estimatedRowCount)
                     : estimatedRowCount);
-                obj.setColumns(getTableColumns(connection, DEFAULT_SCHEMA, obj.getName()));
+                obj.setColumns(getTableColumns(connection, schemaName, obj.getName()));
                 objects.add(obj);
             }
         }
@@ -84,19 +116,19 @@ public class PostgresIntrospectionProvider implements IntrospectionProvider {
         List<DatabaseObject> objects = new ArrayList<>();
 
         String query = """
-            SELECT p.proname as name, pg_get_functiondef(p.oid) as definition
+            SELECT n.nspname as schema_name, p.proname as name, pg_get_functiondef(p.oid) as definition
             FROM pg_proc p
             JOIN pg_namespace n ON p.pronamespace = n.oid
-            WHERE n.nspname = 'public' AND p.prokind = 'f'
-            ORDER BY p.proname
-            """;
+            WHERE %s AND p.prokind = 'f'
+            ORDER BY n.nspname, p.proname
+            """.formatted(nonSystemSchemaPredicate("n.nspname"));
 
         try (Statement stmt = connection.createStatement();
              ResultSet rs = stmt.executeQuery(query)) {
                 while (rs.next()) {
                     DatabaseObject obj = new DatabaseObject();
                     obj.setName(rs.getString("name"));
-                    obj.setSchema(DEFAULT_SCHEMA);
+                    obj.setSchema(rs.getString("schema_name"));
                     obj.setType("function");
                     obj.setDefinition(rs.getString("definition"));
                     objects.add(obj);
@@ -109,19 +141,19 @@ public class PostgresIntrospectionProvider implements IntrospectionProvider {
         List<DatabaseObject> objects = new ArrayList<>();
 
         String query = """
-            SELECT p.proname as name, pg_get_functiondef(p.oid) as definition
+            SELECT n.nspname as schema_name, p.proname as name, pg_get_functiondef(p.oid) as definition
             FROM pg_proc p
             JOIN pg_namespace n ON p.pronamespace = n.oid
-            WHERE n.nspname = 'public' AND p.prokind = 'p'
-            ORDER BY p.proname
-            """;
+            WHERE %s AND p.prokind = 'p'
+            ORDER BY n.nspname, p.proname
+            """.formatted(nonSystemSchemaPredicate("n.nspname"));
 
         try (Statement stmt = connection.createStatement();
              ResultSet rs = stmt.executeQuery(query)) {
                 while (rs.next()) {
                     DatabaseObject obj = new DatabaseObject();
                     obj.setName(rs.getString("name"));
-                    obj.setSchema(DEFAULT_SCHEMA);
+                    obj.setSchema(rs.getString("schema_name"));
                     obj.setType("procedure");
                     obj.setDefinition(rs.getString("definition"));
                     objects.add(obj);
@@ -275,25 +307,25 @@ public class PostgresIntrospectionProvider implements IntrospectionProvider {
         SchemaMetadata schema = new SchemaMetadata();
         schema.setDatabaseName(database);
 
-        // Get all tables and views
-        String tablesQuery = "SELECT t.tablename, 'table' as type, " +
-            "pg_total_relation_size(quote_ident(t.schemaname)||'.'||quote_ident(t.tablename)) as size_bytes, " +
-            "CASE " +
-            "    WHEN s.n_live_tup > 0 THEN s.n_live_tup::bigint " +
-            "    WHEN s.n_live_tup = 0 AND c.reltuples = 0 THEN 0::bigint " +
-            "    WHEN c.reltuples >= 0 THEN c.reltuples::bigint " +
-            "    ELSE NULL " +
-            "END as row_count " +
-            "FROM pg_tables t " +
-            "JOIN pg_namespace n ON n.nspname = t.schemaname " +
-            "JOIN pg_class c ON c.relnamespace = n.oid AND c.relname = t.tablename " +
-            "LEFT JOIN pg_stat_all_tables s ON s.relid = c.oid " +
-            "WHERE t.schemaname = 'public' AND c.relkind IN ('r', 'p') " +
-            "UNION ALL " +
-            "SELECT v.viewname as tablename, 'view' as type, 0 as size_bytes, 0 as row_count " +
-            "FROM pg_views v " +
-            "WHERE v.schemaname = 'public' " +
-            "ORDER BY tablename";
+        // Get all tables and views across non-system schemas (W2a).
+        String tablesQuery = "SELECT t.schemaname, t.tablename, 'table' as type, "
+            + "pg_total_relation_size(quote_ident(t.schemaname)||'.'||quote_ident(t.tablename)) as size_bytes, "
+            + "CASE "
+            + "    WHEN s.n_live_tup > 0 THEN s.n_live_tup::bigint "
+            + "    WHEN s.n_live_tup = 0 AND c.reltuples = 0 THEN 0::bigint "
+            + "    WHEN c.reltuples >= 0 THEN c.reltuples::bigint "
+            + "    ELSE NULL "
+            + "END as row_count "
+            + "FROM pg_tables t "
+            + "JOIN pg_namespace n ON n.nspname = t.schemaname "
+            + "JOIN pg_class c ON c.relnamespace = n.oid AND c.relname = t.tablename "
+            + "LEFT JOIN pg_stat_all_tables s ON s.relid = c.oid "
+            + "WHERE " + nonSystemSchemaPredicate("t.schemaname") + " AND c.relkind IN ('r', 'p') "
+            + "UNION ALL "
+            + "SELECT v.schemaname, v.viewname as tablename, 'view' as type, 0 as size_bytes, 0 as row_count "
+            + "FROM pg_views v "
+            + "WHERE " + nonSystemSchemaPredicate("v.schemaname") + " "
+            + "ORDER BY schemaname, tablename";
 
         Map<String, TableMetadata> tableMap = new HashMap<>();
 
@@ -302,16 +334,17 @@ public class PostgresIntrospectionProvider implements IntrospectionProvider {
             try (ResultSet rs = stmt.executeQuery(tablesQuery)) {
                 while (rs.next()) {
                     TableMetadata table = new TableMetadata();
+                    String schemaName = rs.getString("schemaname");
                     table.setName(rs.getString("tablename"));
-                    table.setSchema(DEFAULT_SCHEMA);
+                    table.setSchema(schemaName);
                     table.setType(rs.getString("type"));
                     table.setSizeBytes(rs.getLong("size_bytes"));
                     Long estimatedRowCount = getNullableLong(rs, "row_count");
                     table.setRowCount("table".equals(table.getType())
-                        ? resolveTableRowCount(connection, DEFAULT_SCHEMA, table.getName(), estimatedRowCount)
+                        ? resolveTableRowCount(connection, schemaName, table.getName(), estimatedRowCount)
                         : estimatedRowCount);
                     schema.getTables().add(table);
-                    tableMap.put(table.getName(), table);
+                    tableMap.put(qualifiedTableKey(schemaName, table.getName()), table);
                 }
             }
         }
@@ -339,32 +372,34 @@ public class PostgresIntrospectionProvider implements IntrospectionProvider {
      * Batch load all columns for all tables in a single query (eliminates N+1).
      */
     private void scanPostgreSQLColumnsBatch(Connection connection, Map<String, TableMetadata> tableMap) throws SQLException {
-        // Get all columns with primary key info in a single query
-        String query = "SELECT c.table_name, c.column_name, c.data_type, c.character_maximum_length, " +
-            "c.is_nullable, c.column_default, c.ordinal_position, " +
-            "CASE WHEN pk.column_name IS NOT NULL THEN true ELSE false END as is_primary_key " +
-            "FROM information_schema.columns c " +
-            "LEFT JOIN ( " +
-            "  SELECT tc.table_name, ku.column_name " +
-            "  FROM information_schema.table_constraints tc " +
-            "  JOIN information_schema.key_column_usage ku " +
-            "  ON tc.constraint_name = ku.constraint_name AND tc.table_name = ku.table_name " +
-            "  WHERE tc.table_schema = 'public' AND tc.constraint_type = 'PRIMARY KEY' " +
-            ") pk ON c.table_name = pk.table_name AND c.column_name = pk.column_name " +
-            "WHERE c.table_schema = 'public' " +
-            "ORDER BY c.table_name, c.ordinal_position";
+        String schemaPred = nonSystemSchemaPredicate("c.table_schema");
+        String pkPred = nonSystemSchemaPredicate("tc.table_schema");
+        String query = "SELECT c.table_schema, c.table_name, c.column_name, c.data_type, c.character_maximum_length, "
+            + "c.is_nullable, c.column_default, c.ordinal_position, "
+            + "CASE WHEN pk.column_name IS NOT NULL THEN true ELSE false END as is_primary_key "
+            + "FROM information_schema.columns c "
+            + "LEFT JOIN ( "
+            + "  SELECT tc.table_schema, tc.table_name, ku.column_name "
+            + "  FROM information_schema.table_constraints tc "
+            + "  JOIN information_schema.key_column_usage ku "
+            + "  ON tc.constraint_name = ku.constraint_name AND tc.table_schema = ku.table_schema "
+            + "     AND tc.table_name = ku.table_name "
+            + "  WHERE " + pkPred + " AND tc.constraint_type = 'PRIMARY KEY' "
+            + ") pk ON c.table_schema = pk.table_schema AND c.table_name = pk.table_name "
+            + "   AND c.column_name = pk.column_name "
+            + "WHERE " + schemaPred + " "
+            + "ORDER BY c.table_schema, c.table_name, c.ordinal_position";
 
         try (Statement stmt = connection.createStatement()) {
             applyStatementSettings(stmt);
             try (ResultSet rs = stmt.executeQuery(query)) {
                 while (rs.next()) {
-                    String tableName = rs.getString("table_name");
-                    TableMetadata table = tableMap.get(tableName);
+                    String key = qualifiedTableKey(rs.getString("table_schema"), rs.getString("table_name"));
+                    TableMetadata table = tableMap.get(key);
                     if (table != null) {
                         ColumnMetadata column = new ColumnMetadata();
                         column.setName(rs.getString("column_name"));
                         column.setDataType(rs.getString("data_type"));
-                        // Use getLong with null check for character_maximum_length (PostgreSQL returns int4)
                         Object maxLen = rs.getObject("character_maximum_length");
                         column.setMaxLength(maxLen != null ? ((Number) maxLen).longValue() : null);
                         column.setNullable("YES".equals(rs.getString("is_nullable")));
@@ -382,27 +417,31 @@ public class PostgresIntrospectionProvider implements IntrospectionProvider {
      * Batch load all indexes for all tables in a single query (eliminates N+1).
      */
     private void scanPostgreSQLIndexesBatch(Connection connection, Map<String, TableMetadata> tableMap) throws SQLException {
-        String query = "SELECT i.tablename, i.indexname, i.indexdef, " +
-            "array_agg(a.attname ORDER BY array_position(ix.indkey, a.attnum)) as columns, " +
-            "ix.indisunique " +
-            "FROM pg_indexes i " +
-            "JOIN pg_class c ON c.relname = i.tablename AND c.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public') " +
-            "JOIN pg_index ix ON ix.indexrelid = (SELECT oid FROM pg_class WHERE relname = i.indexname AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')) " +
-            "JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = ANY(ix.indkey) " +
-            "WHERE i.schemaname = 'public' " +
-            "GROUP BY i.tablename, i.indexname, i.indexdef, ix.indisunique " +
-            "ORDER BY i.tablename, i.indexname";
+        String schemaPred = nonSystemSchemaPredicate("i.schemaname");
+        String query = "SELECT i.schemaname, i.tablename, i.indexname, i.indexdef, "
+            + "array_agg(a.attname ORDER BY array_position(ix.indkey, a.attnum)) as columns, "
+            + "ix.indisunique "
+            + "FROM pg_indexes i "
+            + "JOIN pg_namespace n ON n.nspname = i.schemaname "
+            + "JOIN pg_class c ON c.relname = i.tablename AND c.relnamespace = n.oid "
+            + "JOIN pg_class ic ON ic.relname = i.indexname AND ic.relnamespace = n.oid "
+            + "JOIN pg_index ix ON ix.indexrelid = ic.oid "
+            + "JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = ANY(ix.indkey) "
+            + "WHERE " + schemaPred + " "
+            + "GROUP BY i.schemaname, i.tablename, i.indexname, i.indexdef, ix.indisunique "
+            + "ORDER BY i.schemaname, i.tablename, i.indexname";
 
         try (Statement stmt = connection.createStatement()) {
             applyStatementSettings(stmt);
             try (ResultSet rs = stmt.executeQuery(query)) {
                 while (rs.next()) {
+                    String schemaName = rs.getString("schemaname");
                     String tableName = rs.getString("tablename");
-                    TableMetadata table = tableMap.get(tableName);
+                    TableMetadata table = tableMap.get(qualifiedTableKey(schemaName, tableName));
                     if (table != null) {
                         IndexMetadata index = new IndexMetadata();
                         index.setName(rs.getString("indexname"));
-                        index.setTableName(tableName);
+                        index.setTableName(qualifyForConsumers(schemaName, tableName));
                         index.setUnique(rs.getBoolean("indisunique"));
 
                         Array columnArray = rs.getArray("columns");
@@ -427,26 +466,28 @@ public class PostgresIntrospectionProvider implements IntrospectionProvider {
     }
 
     private void scanPostgreSQLForeignKeys(Connection connection, SchemaMetadata schema) throws SQLException {
-        String query = "SELECT tc.constraint_name, tc.table_name, " +
-            "kcu.column_name, ccu.table_name AS foreign_table_name, " +
-            "ccu.column_name AS foreign_column_name " +
-            "FROM information_schema.table_constraints AS tc " +
-            "JOIN information_schema.key_column_usage AS kcu " +
-            "ON tc.constraint_name = kcu.constraint_name " +
-            "JOIN information_schema.constraint_column_usage AS ccu " +
-            "ON ccu.constraint_name = tc.constraint_name " +
-            "WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_schema = 'public' " +
-            "ORDER BY tc.table_name, tc.constraint_name";
-        
+        String schemaPred = nonSystemSchemaPredicate("tc.table_schema");
+        String query = "SELECT tc.constraint_name, tc.table_schema, tc.table_name, "
+            + "kcu.column_name, ccu.table_schema AS foreign_table_schema, "
+            + "ccu.table_name AS foreign_table_name, "
+            + "ccu.column_name AS foreign_column_name "
+            + "FROM information_schema.table_constraints AS tc "
+            + "JOIN information_schema.key_column_usage AS kcu "
+            + "ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema "
+            + "JOIN information_schema.constraint_column_usage AS ccu "
+            + "ON ccu.constraint_name = tc.constraint_name AND ccu.constraint_schema = tc.constraint_schema "
+            + "WHERE tc.constraint_type = 'FOREIGN KEY' AND " + schemaPred + " "
+            + "ORDER BY tc.table_schema, tc.table_name, tc.constraint_name";
+
         try (Statement stmt = connection.createStatement()) {
             applyStatementSettings(stmt);
             try (ResultSet rs = stmt.executeQuery(query)) {
                 while (rs.next()) {
                     RelationshipMetadata rel = new RelationshipMetadata();
                     rel.setConstraintName(rs.getString("constraint_name"));
-                    rel.setFromTable(rs.getString("table_name"));
+                    rel.setFromTable(qualifyForConsumers(rs.getString("table_schema"), rs.getString("table_name")));
                     rel.setFromColumn(rs.getString("column_name"));
-                    rel.setToTable(rs.getString("foreign_table_name"));
+                    rel.setToTable(qualifyForConsumers(rs.getString("foreign_table_schema"), rs.getString("foreign_table_name")));
                     rel.setToColumn(rs.getString("foreign_column_name"));
                     rel.setRelationshipType("one-to-many");
                     schema.getRelationships().add(rel);
@@ -462,28 +503,30 @@ public class PostgresIntrospectionProvider implements IntrospectionProvider {
         String query = """
             SELECT
                 tc.constraint_name,
+                tc.table_schema as source_schema,
                 tc.table_name as source_table,
                 kcu.column_name as source_column,
+                ccu.table_schema as target_schema,
                 ccu.table_name as target_table,
                 ccu.column_name as target_column
             FROM information_schema.table_constraints tc
             JOIN information_schema.key_column_usage kcu
-                ON tc.constraint_name = kcu.constraint_name
+                ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
             JOIN information_schema.constraint_column_usage ccu
-                ON tc.constraint_name = ccu.constraint_name
+                ON tc.constraint_name = ccu.constraint_name AND tc.constraint_schema = ccu.constraint_schema
             WHERE tc.constraint_type = 'FOREIGN KEY'
-                AND tc.table_schema = 'public'
-            ORDER BY tc.table_name, tc.constraint_name
-            """;
+                AND %s
+            ORDER BY tc.table_schema, tc.table_name, tc.constraint_name
+            """.formatted(nonSystemSchemaPredicate("tc.table_schema"));
 
         try (Statement stmt = connection.createStatement();
              ResultSet rs = stmt.executeQuery(query)) {
             while (rs.next()) {
                 RelationshipMetadata rel = new RelationshipMetadata();
                 rel.setConstraintName(rs.getString("constraint_name"));
-                rel.setFromTable(rs.getString("source_table"));
+                rel.setFromTable(qualifyForConsumers(rs.getString("source_schema"), rs.getString("source_table")));
                 rel.setFromColumn(rs.getString("source_column"));
-                rel.setToTable(rs.getString("target_table"));
+                rel.setToTable(qualifyForConsumers(rs.getString("target_schema"), rs.getString("target_table")));
                 rel.setToColumn(rs.getString("target_column"));
                 relationships.add(rel);
             }
@@ -495,6 +538,13 @@ public class PostgresIntrospectionProvider implements IntrospectionProvider {
     @Override
     public List<ColumnDetail> getColumnDetails(Connection connection, String database, String tableName) throws SQLException {
         List<ColumnDetail> columns = new ArrayList<>();
+        String schemaName = DEFAULT_SCHEMA;
+        String bareTable = tableName;
+        if (tableName != null && tableName.contains(".")) {
+            int dot = tableName.indexOf('.');
+            schemaName = tableName.substring(0, dot);
+            bareTable = tableName.substring(dot + 1);
+        }
 
         String query = """
             SELECT
@@ -502,12 +552,13 @@ public class PostgresIntrospectionProvider implements IntrospectionProvider {
                 data_type, character_maximum_length, numeric_precision, numeric_scale,
                 udt_name
             FROM information_schema.columns
-            WHERE table_schema = 'public' AND table_name = ?
+            WHERE table_schema = ? AND table_name = ?
             ORDER BY ordinal_position
             """;
 
         try (PreparedStatement stmt = connection.prepareStatement(query)) {
-            stmt.setString(1, tableName);
+            stmt.setString(1, schemaName);
+            stmt.setString(2, bareTable);
             try (ResultSet rs = stmt.executeQuery()) {
                 while (rs.next()) {
                     ColumnDetail col = ColumnDetail.builder()
@@ -547,12 +598,21 @@ public class PostgresIntrospectionProvider implements IntrospectionProvider {
             LEFT JOIN information_schema.constraint_column_usage ccu
                 ON tc.constraint_name = ccu.constraint_name
                 AND tc.constraint_type = 'FOREIGN KEY'
-            WHERE tc.table_schema = 'public' AND tc.table_name = ?
+            WHERE tc.table_schema = ? AND tc.table_name = ?
             ORDER BY tc.constraint_name
             """;
 
+        String schemaName = DEFAULT_SCHEMA;
+        String bareTable = tableName;
+        if (tableName != null && tableName.contains(".")) {
+            int dot = tableName.indexOf('.');
+            schemaName = tableName.substring(0, dot);
+            bareTable = tableName.substring(dot + 1);
+        }
+
         try (PreparedStatement stmt = connection.prepareStatement(query)) {
-            stmt.setString(1, tableName);
+            stmt.setString(1, schemaName);
+            stmt.setString(2, bareTable);
             try (ResultSet rs = stmt.executeQuery()) {
                 while (rs.next()) {
                     String constraintName = rs.getString("constraint_name");
@@ -802,9 +862,9 @@ public class PostgresIntrospectionProvider implements IntrospectionProvider {
             JOIN pg_namespace n ON n.nspname = t.schemaname
             JOIN pg_class c ON c.relnamespace = n.oid AND c.relname = t.tablename
             LEFT JOIN pg_stat_all_tables s ON s.relid = c.oid
-            WHERE t.schemaname = 'public' AND c.relkind IN ('r', 'p')
-            ORDER BY t.tablename
-            """;
+            WHERE %s AND c.relkind IN ('r', 'p')
+            ORDER BY t.schemaname, t.tablename
+            """.formatted(nonSystemSchemaPredicate("t.schemaname"));
 
         try (Statement stmt = connection.createStatement();
              ResultSet rs = stmt.executeQuery(query)) {

--- a/backend/src/main/java/com/dbaagent/service/AgentBridgeService.java
+++ b/backend/src/main/java/com/dbaagent/service/AgentBridgeService.java
@@ -26,8 +26,10 @@ import java.util.Map;
  *
  * <p>The Java backend can't run the agent shell tooling itself (no agent runtime
  * in its image), so provisioning is delegated over the compose network to the
- * agent's internal, secret-gated provisioner endpoint. Failures never block the
- * tab — we still return the profile name.
+ * agent's internal, secret-gated provisioner endpoint. The browser Agent-tab
+ * boot path ({@link #ensureProfile}) is fail-loud — a configured-but-failing
+ * provisioner throws rather than returning a profile with a stale disk token.
+ * Headless channels ({@link #ensureProfileForUser}) stay best-effort.
  */
 @Service
 public class AgentBridgeService {
@@ -91,24 +93,60 @@ public class AgentBridgeService {
     @Value("${security.session.refresh-days:7}")
     private long sessionWindowDays;
 
+    /**
+     * Base URL for this same backend's own REST API, used only by
+     * {@link #probeMcpAuth} to verify a freshly minted token actually works
+     * before the Agent tab opens chat. Loopback by default — the probe never
+     * needs to leave the box, so no external base-URL config is required.
+     */
+    @Value("${agent.local-api-base-url:http://127.0.0.1:${server.port:8080}/api}")
+    private String localApiBaseUrl;
+
     public String profileFor(String username) {
         String safe = username.toLowerCase().replaceAll("[^a-z0-9]+", "-").replaceAll("(^-+|-+$)", "");
         return "u-" + safe;
     }
 
     /**
-     * Ensure the user's agent profile exists and is bound to their current token;
-     * returns the profile name. Best-effort — provisioning problems are logged but
-     * never thrown (the Agent tab still opens, just without fresh per-user scope).
+     * Thrown when provisioning is configured (enabled + secret set) but the
+     * provisioner call itself fails — non-2xx response or a connect/timeout
+     * error. Callers must surface this rather than silently returning a
+     * profile name that may point at a stale disk token (the W1 fix for
+     * "Agent tab opens, tool calls 401 six steps later").
      */
-    public String ensureProfile(String username, String authToken, String connectionId) {
+    public static class ProvisioningException extends RuntimeException {
+        public ProvisioningException(String message) {
+            super(message);
+        }
+        public ProvisioningException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    /** Result of {@link #ensureProfile}: the resolved profile plus the token actually provisioned with it. */
+    public record ProfileBootstrap(String profile, String token) {}
+
+    /**
+     * Ensure the user's agent profile exists and is bound to their current token;
+     * returns the profile name plus the token that was provisioned with it (so
+     * the caller can probe that exact credential — see
+     * {@link AgentBridgeService#probeMcpAuth}).
+     *
+     * <p>Fail-loud: when provisioning is configured (enabled + secret set), a
+     * non-2xx or unreachable provisioner throws {@link ProvisioningException}
+     * instead of returning a profile that may still carry a stale/expired disk
+     * token. When provisioning is disabled or unconfigured, the tab still opens
+     * against the shared default profile (documented, not silent) and the
+     * returned token is the caller-supplied session token, unprovisioned.
+     */
+    public ProfileBootstrap ensureProfile(String username, String authToken, String connectionId) {
         String profile = profileFor(username);
         if (!provisionEnabled) {
-            return profile;
+            return new ProfileBootstrap(profile, authToken);
         }
         if (provisionSecret == null || provisionSecret.isBlank()) {
             log.warn("agent.provision-secret is unset — skipping per-user provisioning for {}", username);
-            return profile;
+            return new ProfileBootstrap(profile, authToken);
         }
         // The agent profile must carry a credential that outlives a single chat
         // session. The user's session JWT lives only ~15 min and is coupled to a
@@ -122,16 +160,21 @@ public class AgentBridgeService {
             agentToken = authToken == null ? "" : authToken;
         }
         callProvisioner(username, profile, agentToken, connectionId);
-        return profile;
+        return new ProfileBootstrap(profile, agentToken);
     }
 
     /**
-     * Headless variant for non-browser channels (Slack, etc.): provision the
-     * user's profile with a dedicated CHANNEL token minted directly for the
-     * DeepSQL user — no inbound session/cookie needed. The channel token has its
-     * own name so the UI login/logout lifecycle (which extends/revokes the
-     * {@code (auto)} token) never touches it; a web logout won't kill the user's
-     * Slack agent access. Best-effort — never throws.
+     * Headless variant for non-browser channels (Slack, dashboard generation,
+     * the agent-chat turn API): provision the user's profile with a dedicated
+     * CHANNEL token minted directly for the DeepSQL user — no inbound
+     * session/cookie needed. The channel token has its own name so the UI
+     * login/logout lifecycle (which extends/revokes the {@code (auto)} token)
+     * never touches it; a web logout won't kill the user's Slack agent access.
+     *
+     * <p>Unlike {@link #ensureProfile} (the browser Agent-tab boot path, which
+     * is fail-loud), this stays best-effort: a provisioner hiccup here must not
+     * take down dashboard generation or a Slack turn over a transient network
+     * blip. Provisioning failures are logged, not propagated.
      */
     public String ensureProfileForUser(String username, String connectionId) {
         String profile = profileFor(username);
@@ -147,11 +190,24 @@ public class AgentBridgeService {
             log.warn("Could not mint channel token for {} — skipping headless provisioning", username);
             return profile;
         }
-        callProvisioner(username, profile, channelToken, connectionId);
+        try {
+            callProvisioner(username, profile, channelToken, connectionId);
+        } catch (ProvisioningException e) {
+            log.warn("Headless agent provisioning failed for {}: {}", username, e.getMessage());
+        }
         return profile;
     }
 
-    /** POST the provision request to the agent container's internal provisioner. */
+    /**
+     * POST the provision request to the agent container's internal provisioner.
+     *
+     * <p>Throws {@link ProvisioningException} on a non-2xx response or any
+     * connect/timeout/IO failure — the caller (both {@code ensureProfile}
+     * variants) has already confirmed provisioning is enabled and configured, so
+     * a failure here means the Agent tab is about to open against a profile the
+     * provisioner never actually refreshed. That must block the tab, not log a
+     * warning and proceed.
+     */
     private void callProvisioner(String username, String profile, String token, String connectionId) {
         try {
             String body = objectMapper.writeValueAsString(Map.of(
@@ -168,10 +224,91 @@ public class AgentBridgeService {
             if (resp.statusCode() / 100 == 2) {
                 log.info("Provisioned/refreshed agent profile {} for user {}", profile, username);
             } else {
-                log.warn("Agent provisioning HTTP {} for user {}: {}", resp.statusCode(), username, resp.body());
+                String message = "Agent provisioning HTTP " + resp.statusCode() + " for user " + username
+                    + ": " + resp.body();
+                log.warn(message);
+                throw new ProvisioningException(message);
             }
+        } catch (ProvisioningException e) {
+            throw e;
         } catch (Exception e) {
             log.warn("Agent provisioning call failed for user {}: {}", username, e.getMessage());
+            throw new ProvisioningException(
+                "Agent provisioning call failed for user " + username + ": " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Derive the provisioner's revoke endpoint from its configured provision
+     * URL ({@code .../provision} -> {@code .../revoke}). Returns null if the
+     * configured URL doesn't follow that convention (best-effort only).
+     */
+    private String revokeUrl() {
+        if (provisionerUrl == null || !provisionerUrl.contains("/provision")) {
+            return null;
+        }
+        return provisionerUrl.replace("/provision", "/revoke");
+    }
+
+    /**
+     * Best-effort POST to the provisioner's {@code /revoke} so the on-disk
+     * token file / env fallback are cleared alongside the DB-side revoke.
+     * Never throws — this runs after the DB token is already gone, so a
+     * provisioner hiccup here must not fail the logout request itself.
+     */
+    private void callProvisionerRevoke(String username) {
+        if (!provisionEnabled) {
+            return;
+        }
+        String url = revokeUrl();
+        if (url == null || provisionSecret == null || provisionSecret.isBlank()) {
+            return;
+        }
+        try {
+            String body = objectMapper.writeValueAsString(Map.of("user", username));
+            HttpRequest req = HttpRequest.newBuilder(URI.create(url))
+                .header("Content-Type", "application/json")
+                .header("X-Provision-Secret", provisionSecret)
+                .timeout(Duration.ofSeconds(10))
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+            HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+            if (resp.statusCode() / 100 == 2) {
+                log.info("Revoked on-disk agent token for user {}", username);
+            } else {
+                log.warn("Agent token revoke HTTP {} for user {}: {}", resp.statusCode(), username, resp.body());
+            }
+        } catch (Exception e) {
+            log.warn("Agent token revoke call failed for user {}: {}", username, e.getMessage());
+        }
+    }
+
+    /**
+     * Probe whether the just-minted/refreshed MCP token can actually reach the
+     * DeepSQL API — the health check the Agent tab boot depends on to decide
+     * whether to show the chat composer or a blocking "Agent cannot reach
+     * DeepSQL (auth)" banner. GETs {@code /connections} with the token as a
+     * bearer credential against the local backend (loopback — this call never
+     * leaves the box, so no external base-URL config is needed).
+     *
+     * @return true if the API accepted the token (2xx), false on any
+     *         non-2xx/auth failure or network error.
+     */
+    public boolean probeMcpAuth(String token) {
+        if (token == null || token.isBlank()) {
+            return false;
+        }
+        try {
+            HttpRequest req = HttpRequest.newBuilder(URI.create(localApiBaseUrl + "/connections"))
+                .header("Authorization", "Bearer " + token)
+                .timeout(Duration.ofSeconds(5))
+                .GET()
+                .build();
+            HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+            return resp.statusCode() / 100 == 2;
+        } catch (Exception e) {
+            log.warn("MCP auth probe failed: {}", e.getMessage());
+            return false;
         }
     }
 
@@ -258,5 +395,10 @@ public class AgentBridgeService {
         } catch (Exception e) {
             log.warn("Could not revoke agent token(s) for {}: {}", username, e.getMessage());
         }
+        // DB-side revoke only kills future auth checks — the plaintext token can
+        // still live on disk in the profile's .env / token file / MCP server env
+        // until the provisioner overwrites it. Clear that copy too so a revoked
+        // token can't keep the agent working. Best-effort: never blocks logout.
+        callProvisionerRevoke(username);
     }
 }

--- a/backend/src/main/java/com/dbaagent/service/CredentialService.java
+++ b/backend/src/main/java/com/dbaagent/service/CredentialService.java
@@ -2,6 +2,7 @@ package com.dbaagent.service;
 
 import com.dbaagent.model.ConnectionRequest;
 import com.dbaagent.model.DatabaseConnection;
+import com.dbaagent.provider.DatabaseProviderRegistry;
 import com.dbaagent.repository.CredentialRepository;
 import com.dbaagent.security.EncryptionService;
 import com.dbaagent.service.security.ConnectionAccessService;
@@ -26,13 +27,18 @@ public class CredentialService {
     private final EncryptionService encryptionService;
     private final ConnectionAccessService connectionAccessService;
     private final TelemetryClient telemetryClient;
+    private final DatabaseProviderRegistry providerRegistry;
 
     @Transactional
     public DatabaseConnection saveConnection(ConnectionRequest request, String ownerUsername) {
         DatabaseConnection connection = new DatabaseConnection();
         connection.setId(UUID.randomUUID().toString());
         connection.setConnectionName(request.getConnectionName());
-        connection.setDbType(request.getDbType());
+        // Canonicalize through the provider registry ("postgresql" -> "postgres", etc.) so
+        // every downstream consumer that switches on dbType (DatabaseProviderRegistry.getDialect,
+        // frontend badges, telemetry) sees one spelling per dialect regardless of which alias
+        // the caller (onboarding wizard, API client, import) happened to send.
+        connection.setDbType(providerRegistry.getCanonicalName(request.getDbType()));
         connection.setOwnerUsername(ownerUsername);
         connection.setCreatedAt(LocalDateTime.now());
         connection.setLastUsed(LocalDateTime.now());
@@ -377,7 +383,7 @@ public class CredentialService {
 
         // Update non-encrypted fields
         connection.setConnectionName(request.getConnectionName());
-        connection.setDbType(request.getDbType());
+        connection.setDbType(providerRegistry.getCanonicalName(request.getDbType()));
         connection.setLastUsed(LocalDateTime.now());
 
         // Update and re-encrypt sensitive fields

--- a/backend/src/main/java/com/dbaagent/service/QueryExecutorService.java
+++ b/backend/src/main/java/com/dbaagent/service/QueryExecutorService.java
@@ -394,42 +394,48 @@ public class QueryExecutorService {
 
     private List<DatabaseObject> getPostgreSQLObjects(Connection connection) throws SQLException {
         List<DatabaseObject> objects = new ArrayList<>();
+        // Keep in sync with PostgresIntrospectionProvider non-system schema filter (W2a).
+        String nonSystem = "NOT IN ('pg_catalog','information_schema','pg_toast') "
+            + "AND %1$s NOT LIKE 'pg_temp_%%' AND %1$s NOT LIKE 'pg_toast_temp_%%'";
 
         // Get tables and views
-        String tablesQuery = "SELECT t.tablename as name, 'table' as type, " +
-            "(SELECT reltuples::bigint FROM pg_class WHERE relname = t.tablename) as row_count " +
-            "FROM pg_tables t WHERE t.schemaname = 'public' " +
-            "UNION ALL " +
-            "SELECT v.viewname as name, 'view' as type, 0 as row_count " +
-            "FROM pg_views v WHERE v.schemaname = 'public' " +
-            "ORDER BY type, name";
+        String tablesQuery = "SELECT t.schemaname as schema_name, t.tablename as name, 'table' as type, "
+            + "(SELECT reltuples::bigint FROM pg_class c "
+            + " JOIN pg_namespace n ON c.relnamespace = n.oid "
+            + " WHERE n.nspname = t.schemaname AND c.relname = t.tablename) as row_count "
+            + "FROM pg_tables t WHERE t.schemaname " + String.format(nonSystem, "t.schemaname") + " "
+            + "UNION ALL "
+            + "SELECT v.schemaname as schema_name, v.viewname as name, 'view' as type, 0 as row_count "
+            + "FROM pg_views v WHERE v.schemaname " + String.format(nonSystem, "v.schemaname") + " "
+            + "ORDER BY schema_name, type, name";
 
         try (Statement stmt = connection.createStatement();
              ResultSet rs = stmt.executeQuery(tablesQuery)) {
             while (rs.next()) {
                 DatabaseObject obj = new DatabaseObject();
+                String schemaName = rs.getString("schema_name");
                 obj.setName(rs.getString("name"));
-                obj.setSchema("public");
+                obj.setSchema(schemaName);
                 obj.setType(rs.getString("type"));
                 obj.setRowCount(rs.getLong("row_count"));
-                obj.setColumns(getPostgreSQLColumns(connection, obj.getName()));
+                obj.setColumns(getPostgreSQLColumns(connection, schemaName, obj.getName()));
                 objects.add(obj);
             }
         }
 
         // Get functions
-        String functionsQuery = "SELECT p.proname as name, pg_get_functiondef(p.oid) as definition " +
-            "FROM pg_proc p " +
-            "JOIN pg_namespace n ON p.pronamespace = n.oid " +
-            "WHERE n.nspname = 'public' AND p.prokind = 'f' " +
-            "ORDER BY p.proname";
+        String functionsQuery = "SELECT n.nspname as schema_name, p.proname as name, pg_get_functiondef(p.oid) as definition "
+            + "FROM pg_proc p "
+            + "JOIN pg_namespace n ON p.pronamespace = n.oid "
+            + "WHERE n.nspname " + String.format(nonSystem, "n.nspname") + " AND p.prokind = 'f' "
+            + "ORDER BY n.nspname, p.proname";
 
         try (Statement stmt = connection.createStatement();
              ResultSet rs = stmt.executeQuery(functionsQuery)) {
             while (rs.next()) {
                 DatabaseObject obj = new DatabaseObject();
                 obj.setName(rs.getString("name"));
-                obj.setSchema("public");
+                obj.setSchema(rs.getString("schema_name"));
                 obj.setType("function");
                 obj.setDefinition(rs.getString("definition"));
                 objects.add(obj);
@@ -437,18 +443,18 @@ public class QueryExecutorService {
         }
 
         // Get procedures
-        String proceduresQuery = "SELECT p.proname as name, pg_get_functiondef(p.oid) as definition " +
-            "FROM pg_proc p " +
-            "JOIN pg_namespace n ON p.pronamespace = n.oid " +
-            "WHERE n.nspname = 'public' AND p.prokind = 'p' " +
-            "ORDER BY p.proname";
+        String proceduresQuery = "SELECT n.nspname as schema_name, p.proname as name, pg_get_functiondef(p.oid) as definition "
+            + "FROM pg_proc p "
+            + "JOIN pg_namespace n ON p.pronamespace = n.oid "
+            + "WHERE n.nspname " + String.format(nonSystem, "n.nspname") + " AND p.prokind = 'p' "
+            + "ORDER BY n.nspname, p.proname";
 
         try (Statement stmt = connection.createStatement();
              ResultSet rs = stmt.executeQuery(proceduresQuery)) {
             while (rs.next()) {
                 DatabaseObject obj = new DatabaseObject();
                 obj.setName(rs.getString("name"));
-                obj.setSchema("public");
+                obj.setSchema(rs.getString("schema_name"));
                 obj.setType("procedure");
                 obj.setDefinition(rs.getString("definition"));
                 objects.add(obj);
@@ -458,23 +464,26 @@ public class QueryExecutorService {
         return objects;
     }
 
-    private List<ColumnInfo> getPostgreSQLColumns(Connection connection, String tableName) throws SQLException {
+    private List<ColumnInfo> getPostgreSQLColumns(Connection connection, String schemaName, String tableName) throws SQLException {
         List<ColumnInfo> columns = new ArrayList<>();
-        String query = "SELECT c.column_name, c.data_type, c.is_nullable, c.column_default, " +
-            "CASE WHEN pk.column_name IS NOT NULL THEN true ELSE false END as is_primary_key " +
-            "FROM information_schema.columns c " +
-            "LEFT JOIN ( " +
-            "    SELECT ku.column_name " +
-            "    FROM information_schema.table_constraints tc " +
-            "    JOIN information_schema.key_column_usage ku ON tc.constraint_name = ku.constraint_name " +
-            "    WHERE tc.constraint_type = 'PRIMARY KEY' AND ku.table_name = ? " +
-            ") pk ON c.column_name = pk.column_name " +
-            "WHERE c.table_name = ? AND c.table_schema = 'public' " +
-            "ORDER BY c.ordinal_position";
+        String query = "SELECT c.column_name, c.data_type, c.is_nullable, c.column_default, "
+            + "CASE WHEN pk.column_name IS NOT NULL THEN true ELSE false END as is_primary_key "
+            + "FROM information_schema.columns c "
+            + "LEFT JOIN ( "
+            + "    SELECT ku.column_name "
+            + "    FROM information_schema.table_constraints tc "
+            + "    JOIN information_schema.key_column_usage ku ON tc.constraint_name = ku.constraint_name "
+            + "      AND tc.table_schema = ku.table_schema "
+            + "    WHERE tc.constraint_type = 'PRIMARY KEY' AND ku.table_schema = ? AND ku.table_name = ? "
+            + ") pk ON c.column_name = pk.column_name "
+            + "WHERE c.table_schema = ? AND c.table_name = ? "
+            + "ORDER BY c.ordinal_position";
 
         try (PreparedStatement stmt = connection.prepareStatement(query)) {
-            stmt.setString(1, tableName);
+            stmt.setString(1, schemaName);
             stmt.setString(2, tableName);
+            stmt.setString(3, schemaName);
+            stmt.setString(4, tableName);
             try (ResultSet rs = stmt.executeQuery()) {
                 while (rs.next()) {
                     ColumnInfo col = new ColumnInfo();

--- a/backend/src/main/java/com/dbaagent/service/SchemaIntrospectionService.java
+++ b/backend/src/main/java/com/dbaagent/service/SchemaIntrospectionService.java
@@ -41,9 +41,17 @@ public class SchemaIntrospectionService {
                 Long rowCount = provider.getTableRowCount(connection, database, tableName);
                 String tableSize = provider.getTableSize(connection, database, tableName);
 
+                String schemaName = provider.getDefaultSchema();
+                String bareName = tableName;
+                if (tableName != null && tableName.contains(".")) {
+                    int dot = tableName.indexOf('.');
+                    schemaName = tableName.substring(0, dot);
+                    bareName = tableName.substring(dot + 1);
+                }
+
                 return TableDetails.builder()
-                        .tableName(tableName)
-                        .tableSchema(provider.getDefaultSchema())
+                        .tableName(bareName != null ? bareName : tableName)
+                        .tableSchema(schemaName)
                         .columns(columns)
                         .indexes(indexes)
                         .constraints(constraints)

--- a/backend/src/main/java/com/dbaagent/service/brain/keycolumn/KeyColumnAnalysisService.java
+++ b/backend/src/main/java/com/dbaagent/service/brain/keycolumn/KeyColumnAnalysisService.java
@@ -1107,8 +1107,16 @@ public class KeyColumnAnalysisService {
         LocalDateTime now = LocalDateTime.now();
 
         for (KeyColumnAnalysis analysis : analyses) {
+            // A column that is already indexed (indexName set by enrichWithIndexStats)
+            // or is a known key (TRUE_KEY, or a PRIMARY/UNIQUE label from any future
+            // classifier) can never be flagged UNINDEXED_* — that combination is a
+            // contradiction, not a finding. This is what stops resolved primary keys
+            // from generating "unindexed join/filter" noise every single run.
+            boolean isKnownKeyOrIndexed = analysis.getIndexName() != null
+                || isKeyLikeType(analysis.getKeyType());
+
             // Rule 1: Unindexed filter columns (skip if already indexed)
-            if (analysis.getWhereCount() >= 5 && analysis.getIndexName() == null) {
+            if (analysis.getWhereCount() >= 5 && !isKnownKeyOrIndexed) {
                 ColumnAntiPattern pattern = ColumnAntiPattern.builder()
                     .connectionId(connectionId)
                     .tableName(analysis.getTableName())
@@ -1133,7 +1141,7 @@ public class KeyColumnAnalysisService {
             }
 
             // Rule 2: Unindexed JOIN columns (skip if already indexed)
-            if (analysis.getJoinCount() >= 5 && analysis.getIndexName() == null) {
+            if (analysis.getJoinCount() >= 5 && !isKnownKeyOrIndexed) {
                 ColumnAntiPattern pattern = ColumnAntiPattern.builder()
                     .connectionId(connectionId)
                     .tableName(analysis.getTableName())
@@ -1158,7 +1166,7 @@ public class KeyColumnAnalysisService {
             }
 
             // Rule 3: Unindexed ORDER BY (skip if already indexed)
-            if (analysis.getOrderByCount() >= 3 && analysis.getIndexName() == null) {
+            if (analysis.getOrderByCount() >= 3 && !isKnownKeyOrIndexed) {
                 ColumnAntiPattern pattern = ColumnAntiPattern.builder()
                     .connectionId(connectionId)
                     .tableName(analysis.getTableName())
@@ -1271,6 +1279,16 @@ public class KeyColumnAnalysisService {
         }
 
         return patterns;
+    }
+
+    /**
+     * True for any keyType label that means "this column is already a real key" —
+     * TRUE_KEY is what this classifier actually assigns (see classifyKeys), while
+     * PRIMARY/UNIQUE are accepted defensively in case a future classifier or an
+     * imported/legacy row uses those labels instead.
+     */
+    private boolean isKeyLikeType(String keyType) {
+        return "TRUE_KEY".equals(keyType) || "PRIMARY".equals(keyType) || "UNIQUE".equals(keyType);
     }
 
     /**
@@ -1939,32 +1957,74 @@ public class KeyColumnAnalysisService {
     }
 
     /**
-     * Fetch index usage statistics from database metadata
+     * Fetch index metadata via {@link QueryExecutorService#getTableIndexes} (dialect-agnostic —
+     * dispatches through {@code IntrospectionProvider}, not a Postgres-specific query) and set
+     * {@code indexName} on every analysis whose column is covered by an index. This is what
+     * {@link #detectAntiPatterns} gates UNINDEXED_* on — before this method actually populated
+     * indexName, every column (including primary keys) looked unindexed forever, so PK/UK
+     * columns kept generating UNINDEXED_JOIN/UNINDEXED_FILTER noise no matter how they were
+     * actually indexed.
      */
     private void enrichWithIndexStats(List<KeyColumnAnalysis> analyses, String connectionId) {
-        log.info("Fetching index usage statistics");
+        log.info("Fetching index metadata for {} key column analyses", analyses.size());
 
+        Map<String, List<TableIndex>> indexesByTable = new HashMap<>();
         for (KeyColumnAnalysis analysis : analyses) {
-            try {
-                // Query database for index info - PostgreSQL specific
-                String sql = String.format(
-                    "SELECT indexname, idx_scan FROM pg_stat_user_indexes " +
-                    "WHERE schemaname = 'public' AND tablename = '%s' " +
-                    "AND indexdef LIKE '%%%s%%'",
-                    analysis.getTableName(), analysis.getColumnName()
-                );
+            String tableName = analysis.getTableName();
+            if (tableName == null) {
+                continue;
+            }
+            List<TableIndex> indexes = indexesByTable.computeIfAbsent(tableName, t -> {
+                try {
+                    return queryExecutorService.getTableIndexes(connectionId, t);
+                } catch (Exception e) {
+                    log.debug("Could not fetch indexes for table {}: {}", t, e.getMessage());
+                    return Collections.emptyList();
+                }
+            });
+            if (indexes.isEmpty()) {
+                continue;
+            }
 
-                // Execute query using QueryExecutorService
-                // Note: This would need proper implementation based on database type
-                // For now, just mark as analyzed
-                analysis.setIndexUsageCount(0L);
-                analysis.setIndexScanCount(0L);
+            String columnName = analysis.getColumnName();
+            // Prefer the primary-key index, then any unique index, then any index
+            // that covers the column — matches how detectAntiPatterns treats
+            // PRIMARY/UNIQUE as strictly stronger signal than a plain index.
+            TableIndex best = null;
+            for (TableIndex index : indexes) {
+                if (index.getColumns() == null || !containsColumnIgnoreCase(index.getColumns(), columnName)) {
+                    continue;
+                }
+                if (index.isPrimary()) {
+                    best = index;
+                    break;
+                }
+                if (best == null || (index.isUnique() && !best.isUnique())) {
+                    best = index;
+                }
+            }
 
-            } catch (Exception e) {
-                log.debug("Could not fetch index stats for {}.{}: {}",
-                    analysis.getTableName(), analysis.getColumnName(), e.getMessage());
+            if (best != null) {
+                analysis.setIndexName(best.getName());
+                if ("NON_KEY".equals(analysis.getKeyType()) || analysis.getKeyType() == null) {
+                    if (best.isPrimary()) {
+                        analysis.setKeyType("TRUE_KEY");
+                    }
+                }
             }
         }
+    }
+
+    private boolean containsColumnIgnoreCase(List<String> columns, String columnName) {
+        if (columnName == null) {
+            return false;
+        }
+        for (String column : columns) {
+            if (columnName.equalsIgnoreCase(column)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/backend/src/main/java/com/dbaagent/service/scheduler/BrainInitSchedulerService.java
+++ b/backend/src/main/java/com/dbaagent/service/scheduler/BrainInitSchedulerService.java
@@ -549,7 +549,7 @@ public class BrainInitSchedulerService {
             case RAG_EMBEDDING -> 80;
             case BRAIN_ANALYSIS -> 92;
             case SEMANTIC_MODELING -> 96;
-            case COMPLETED, FAILED -> 100;
+            case COMPLETED, FAILED, NEEDS_ATTENTION -> 100;
         };
     }
 

--- a/backend/src/main/java/com/dbaagent/service/scheduler/BrainInitStageExecutor.java
+++ b/backend/src/main/java/com/dbaagent/service/scheduler/BrainInitStageExecutor.java
@@ -120,7 +120,7 @@ public class BrainInitStageExecutor {
                 case RAG_EMBEDDING -> executeRagEmbedding(connectionId, status, taskRunId);
                 case BRAIN_ANALYSIS -> executeBrainAnalysis(connectionId, status, taskRunId);
                 case SEMANTIC_MODELING -> executeSemanticModeling(connectionId, status, taskRunId);
-                case COMPLETED, FAILED -> null;
+                case COMPLETED, FAILED, NEEDS_ATTENTION -> null;
             };
         } catch (Exception e) {
             if (isStaleOrCancelled(connectionId, taskRunId)) {
@@ -143,26 +143,94 @@ public class BrainInitStageExecutor {
 
         var schema = schemaScannerService.scanSchema(connectionId);
         int tablesDiscovered = schema.getTables() != null ? schema.getTables().size() : 0;
+        int baseTablesDiscovered = schema.getTables() != null
+            ? (int) schema.getTables().stream()
+                .filter(t -> t.getType() == null || "table".equalsIgnoreCase(t.getType()))
+                .count()
+            : 0;
         int columnsDiscovered = schema.getTables() != null
             ? schema.getTables().stream().mapToInt(table ->
                 table.getColumns() != null ? table.getColumns().size() : 0).sum()
             : 0;
         var snapshot = schemaSnapshotService.captureSnapshot(connectionId, false);
 
+        int liveUserTableCount = countLiveUserBaseTables(connectionId);
+        java.util.Set<String> schemasScanned = new java.util.LinkedHashSet<>();
+        if (schema.getTables() != null) {
+            for (var table : schema.getTables()) {
+                if (table.getSchema() != null && !table.getSchema().isBlank()) {
+                    schemasScanned.add(table.getSchema());
+                }
+            }
+        }
+        int coveragePercent = liveUserTableCount <= 0
+            ? (baseTablesDiscovered > 0 ? 100 : 0)
+            : (int) Math.min(100, Math.round((baseTablesDiscovered * 100.0) / liveUserTableCount));
+
         Map<String, Object> details = new HashMap<>();
         details.put("tablesDiscovered", tablesDiscovered);
+        details.put("baseTablesDiscovered", baseTablesDiscovered);
         details.put("columnsDiscovered", columnsDiscovered);
+        details.put("liveUserTableCount", liveUserTableCount);
+        details.put("coveragePercent", coveragePercent);
+        details.put("schemasScanned", new java.util.ArrayList<>(schemasScanned));
         if (snapshot != null && snapshot.getCapturedAt() != null) {
             details.put("snapshotCapturedAt", snapshot.getCapturedAt());
         }
         if (snapshot != null && snapshot.getSchemaHash() != null) {
             details.put("schemaFingerprint", snapshot.getSchemaHash());
         }
-        details.put("method", "Evicts cached schema/object metadata, rescans the live schema, and stores a fresh snapshot");
+        details.put("method", "Evicts cached schema/object metadata, rescans non-system schemas, and stores a fresh snapshot");
         recordStageDetails(status, InitStage.SCHEMA_SCAN, details);
+
+        // Coverage gate (W2b): never claim a healthy Brain when we indexed nothing
+        // while live user tables exist, or when coverage is badly incomplete.
+        if (liveUserTableCount > 0 && baseTablesDiscovered == 0) {
+            markFailed(status,
+                "Brain found 0 user tables but the database has " + liveUserTableCount
+                    + " live base table(s). Check USAGE/SELECT grants on non-system schemas.",
+                taskRunId);
+            return null;
+        }
+        if (liveUserTableCount > 0 && coveragePercent < 80) {
+            markNeedsAttention(status, taskRunId, coveragePercent, baseTablesDiscovered, liveUserTableCount, schemasScanned);
+            return null;
+        }
+
         updateProgress(status, 18,
-            "Scanned " + tablesDiscovered + " tables and captured a fresh schema snapshot", taskRunId);
+            "Scanned " + tablesDiscovered + " objects (" + baseTablesDiscovered
+                + "/" + Math.max(liveUserTableCount, baseTablesDiscovered)
+                + " base tables across " + schemasScanned.size() + " schema(s))",
+            taskRunId);
         return InitStage.DATA_SAMPLING;
+    }
+
+    /**
+     * Count live non-system base tables visible to the JDBC user. Postgres uses
+     * the same exclusion pattern as introspection (W2a); other dialects fall
+     * back to discovered object counts so the gate stays a no-op.
+     */
+    private int countLiveUserBaseTables(String connectionId) {
+        try {
+            var jdbc = connectionService.getJdbcTemplateForBackgroundJob(connectionId);
+            String dbType = connectionService.getDbType(connectionId);
+            if (dbType != null && dbType.toLowerCase().contains("postgres")) {
+                Integer count = jdbc.queryForObject("""
+                    SELECT COUNT(*)::int
+                    FROM pg_tables t
+                    JOIN pg_namespace n ON n.nspname = t.schemaname
+                    JOIN pg_class c ON c.relnamespace = n.oid AND c.relname = t.tablename
+                    WHERE t.schemaname NOT IN ('pg_catalog','information_schema','pg_toast')
+                      AND t.schemaname NOT LIKE 'pg_temp_%'
+                      AND t.schemaname NOT LIKE 'pg_toast_temp_%'
+                      AND c.relkind IN ('r', 'p')
+                    """, Integer.class);
+                return count != null ? count : 0;
+            }
+        } catch (Exception e) {
+            log.warn("Could not count live user tables for {}: {}", connectionId, e.getMessage());
+        }
+        return 0;
     }
 
     private InitStage executeDataSampling(String connectionId, ConnectionInitStatus status, UUID taskRunId) {
@@ -549,6 +617,33 @@ public class BrainInitStageExecutor {
         saveHistory(fresh);
     }
 
+    private void markNeedsAttention(
+            ConnectionInitStatus status,
+            UUID taskRunId,
+            int coveragePercent,
+            int baseTablesDiscovered,
+            int liveUserTableCount,
+            java.util.Set<String> schemasScanned) {
+        var current = initStatusRepo.findById(status.getConnectionId());
+        if (current.isEmpty() || !taskRunId.equals(current.get().getActiveRunId())) {
+            return;
+        }
+        ConnectionInitStatus fresh = current.get();
+        closeActiveStage(fresh);
+        fresh.setCurrentStage(InitStage.NEEDS_ATTENTION);
+        fresh.setProgressPercent(Math.min(99, Math.max(coveragePercent, 1)));
+        fresh.setStageMessage(
+            "Indexed " + baseTablesDiscovered + "/" + liveUserTableCount
+                + " live base tables (" + coveragePercent + "% coverage across "
+                + schemasScanned.size() + " schema(s)). Fix grants or schema list, then re-initialize."
+        );
+        fresh.setErrorMessage(null);
+        fresh.setCompletedAt(LocalDateTime.now());
+        initStatusRepo.save(fresh);
+        broadcast(fresh.getConnectionId(), fresh);
+        saveHistory(fresh);
+    }
+
     private void markCompleted(ConnectionInitStatus status, UUID taskRunId) {
         var current = initStatusRepo.findById(status.getConnectionId());
         if (current.isEmpty() || !taskRunId.equals(current.get().getActiveRunId())) {
@@ -579,7 +674,7 @@ public class BrainInitStageExecutor {
             case RAG_EMBEDDING -> 80;
             case BRAIN_ANALYSIS -> 92;
             case SEMANTIC_MODELING -> 96;
-            case COMPLETED, FAILED -> 100;
+            case COMPLETED, FAILED, NEEDS_ATTENTION -> 100;
         };
     }
 

--- a/backend/src/main/java/com/dbaagent/service/scheduler/BrainInitStageExecutor.java
+++ b/backend/src/main/java/com/dbaagent/service/scheduler/BrainInitStageExecutor.java
@@ -729,7 +729,7 @@ public class BrainInitStageExecutor {
                 return;
             }
             ConnectionInitStatus fresh = current.get();
-            Map<String, Object> merged = fresh.getStageDetails() != null
+            Map<String, Map<String, Object>> merged = fresh.getStageDetails() != null
                 ? new HashMap<>(fresh.getStageDetails())
                 : new HashMap<>();
             merged.put(stage.name(), new HashMap<>(details));

--- a/backend/src/main/java/com/dbaagent/service/scheduler/BrainInitStageExecutor.java
+++ b/backend/src/main/java/com/dbaagent/service/scheduler/BrainInitStageExecutor.java
@@ -714,7 +714,33 @@ public class BrainInitStageExecutor {
     }
 
     private void recordStageDetails(ConnectionInitStatus status, InitStage stage, Map<String, Object> details) {
+        // Mutate the in-memory handle used by later markCompleted/history…
+        if (status.getStageDetails() == null) {
+            status.setStageDetails(new HashMap<>());
+        }
         status.getStageDetails().put(stage.name(), new HashMap<>(details));
+
+        // …and persist onto the live row. updateProgress/updateStage reload from
+        // the DB, so writing only the in-memory object used to leave stageDetails
+        // permanently empty — which hid the W2b coverage fields from the UI.
+        try {
+            var current = initStatusRepo.findById(status.getConnectionId());
+            if (current.isEmpty()) {
+                return;
+            }
+            ConnectionInitStatus fresh = current.get();
+            Map<String, Object> merged = fresh.getStageDetails() != null
+                ? new HashMap<>(fresh.getStageDetails())
+                : new HashMap<>();
+            merged.put(stage.name(), new HashMap<>(details));
+            fresh.setStageDetails(merged);
+            initStatusRepo.save(fresh);
+            // Keep the caller’s handle in sync with what we just wrote.
+            status.setStageDetails(merged);
+        } catch (Exception e) {
+            log.warn("Failed to persist stageDetails for {} / {}: {}",
+                status.getConnectionId(), stage, e.getMessage());
+        }
     }
 
     private void broadcast(String connectionId, ConnectionInitStatus status) {

--- a/backend/src/main/resources/db/migration/V110__brain_init_needs_attention.sql
+++ b/backend/src/main/resources/db/migration/V110__brain_init_needs_attention.sql
@@ -1,0 +1,34 @@
+-- Hand-maintained changelog (no Flyway runtime). BrainInitSchemaCompatibilityInitializer
+-- also realigns these CHECKs from InitStage.values() at boot.
+ALTER TABLE connection_init_status
+    DROP CONSTRAINT IF EXISTS connection_init_status_current_stage_check;
+
+ALTER TABLE connection_init_status
+    ADD CONSTRAINT connection_init_status_current_stage_check
+    CHECK (current_stage IN (
+        'SCHEMA_SCAN', 'DATA_SAMPLING', 'KEY_COLUMN_ANALYSIS',
+        'COLUMN_VALUE_COLLECTION', 'INFERRED_RELATIONSHIPS',
+        'SCHEMA_CLASSIFICATION', 'AI_DESCRIPTION', 'RAG_EMBEDDING',
+        'BRAIN_ANALYSIS', 'SEMANTIC_MODELING', 'NEEDS_ATTENTION',
+        'COMPLETED', 'FAILED'
+    ));
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'connection_init_history_final_stage_check'
+    ) THEN
+        ALTER TABLE connection_init_history
+            DROP CONSTRAINT connection_init_history_final_stage_check;
+        ALTER TABLE connection_init_history
+            ADD CONSTRAINT connection_init_history_final_stage_check
+            CHECK (final_stage IN (
+                'SCHEMA_SCAN', 'DATA_SAMPLING', 'KEY_COLUMN_ANALYSIS',
+                'COLUMN_VALUE_COLLECTION', 'INFERRED_RELATIONSHIPS',
+                'SCHEMA_CLASSIFICATION', 'AI_DESCRIPTION', 'RAG_EMBEDDING',
+                'BRAIN_ANALYSIS', 'SEMANTIC_MODELING', 'NEEDS_ATTENTION',
+                'COMPLETED', 'FAILED'
+            ));
+    END IF;
+END $$;

--- a/backend/src/test/java/com/dbaagent/service/CredentialServiceTelemetryTest.java
+++ b/backend/src/test/java/com/dbaagent/service/CredentialServiceTelemetryTest.java
@@ -2,6 +2,7 @@ package com.dbaagent.service;
 
 import com.dbaagent.model.ConnectionRequest;
 import com.dbaagent.model.DatabaseConnection;
+import com.dbaagent.provider.DatabaseProviderRegistry;
 import com.dbaagent.repository.CredentialRepository;
 import com.dbaagent.security.EncryptionService;
 import com.dbaagent.service.security.ConnectionAccessService;
@@ -33,16 +34,21 @@ class CredentialServiceTelemetryTest {
     @Mock private EncryptionService encryptionService;
     @Mock private ConnectionAccessService connectionAccessService;
     @Mock private TelemetryClient telemetryClient;
+    @Mock private DatabaseProviderRegistry providerRegistry;
 
     private CredentialService service;
 
     @BeforeEach
     void setup() {
         service = new CredentialService(credentialRepository, encryptionService,
-                connectionAccessService, telemetryClient);
+                connectionAccessService, telemetryClient, providerRegistry);
         when(encryptionService.encrypt(any(), anyString())).thenReturn(new byte[]{1, 2, 3});
         when(credentialRepository.save(any(DatabaseConnection.class)))
                 .thenAnswer(inv -> inv.getArgument(0));
+        // Telemetry dialect labels (postgres/mysql/unknown) come from normalizeDialect,
+        // not the canonicalizer under test elsewhere — echo the input back so these
+        // assertions stay about telemetry, not canonicalization.
+        when(providerRegistry.getCanonicalName(anyString())).thenAnswer(inv -> inv.getArgument(0));
     }
 
     @Test

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="AI-powered Database Performance Assistant" />
-    <title>DBA Agent</title>
+    <title>DeepSQL</title>
   </head>
   <body>
     <div id="root"></div>

--- a/scripts/local-agent-provisioner.py
+++ b/scripts/local-agent-provisioner.py
@@ -7,13 +7,21 @@ this OSS checkout. For Cursor Cloud / native local dev, this script provides the
 same contract so /api/agent/session can create `u-<user>` agent profiles with
 MCP credentials before the Agent tab opens.
 
-Contract (matches AgentBridgeService.callProvisioner):
+Contract (matches AgentBridgeService.callProvisioner / revokeAgentTokens):
   POST /provision
   Header: X-Provision-Secret: <AGENT_PROVISION_SECRET>
   Body:   { "user": "<username>", "token": "<mcp-or-jwt>", "connectionId": "<uuid>" }
 
+  POST /revoke
+  Header: X-Provision-Secret: <AGENT_PROVISION_SECRET>
+  Body:   { "user": "<username>" }
+  Clears the on-disk token file and blanks DEEPSQL_AUTH_TOKEN in both the MCP
+  server env and the profile .env — called after a DB-side token revoke so no
+  stale plaintext credential keeps the agent working post-logout.
+
 Idempotent: creates the profile on first call (cloning default), then refreshes
-DEEPSQL_AUTH_TOKEN / DEEPSQL_API_BASE_URL / DEEPSQL_MCP_USER_ID in the profile .env.
+DEEPSQL_TOKEN_FILE / DEEPSQL_AUTH_TOKEN / DEEPSQL_API_BASE_URL /
+DEEPSQL_MCP_USER_ID in the profile .env and MCP server env.
 """
 from __future__ import annotations
 
@@ -39,6 +47,23 @@ def profile_for(username: str) -> str:
     return f"u-{safe or 'user'}"
 
 
+def token_file_for(home: Path) -> Path:
+    return home / "deepsql.token"
+
+
+def write_token_file(home: Path, token: str) -> Path:
+    """Write the MCP token atomically (temp file + rename) so the long-lived
+    MCP subprocess (which re-reads this file on every request, see
+    deepsql-phase1-lib.js readTokenFile) never observes a partially-written
+    token mid-rotation. 0600 — same secrecy bar as the profile .env."""
+    path = token_file_for(home)
+    tmp = path.with_suffix(f".tmp-{os.getpid()}")
+    tmp.write_text((token or "") + "\n")
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, path)
+    return path
+
+
 def ensure_profile(name: str) -> Path:
     home = HERMES_HOME / "profiles" / name
     if home.exists():
@@ -49,7 +74,7 @@ def ensure_profile(name: str) -> Path:
     return home
 
 
-def write_profile_env(home: Path, *, user: str, token: str) -> None:
+def write_profile_env(home: Path, *, user: str, token: str, token_file: Path) -> None:
     env_path = home / ".env"
     keys: dict[str, str] = {}
     if env_path.exists():
@@ -67,6 +92,10 @@ def write_profile_env(home: Path, *, user: str, token: str) -> None:
                     keys["AZURE_OPENAI_KEY"] = line.split("=", 1)[1]
                     keys["OPENAI_API_KEY"] = keys["AZURE_OPENAI_KEY"]
     keys["DEEPSQL_API_BASE_URL"] = API_BASE
+    # DEEPSQL_TOKEN_FILE is read live (mtime-checked) by the MCP subprocess, so
+    # a rotated token takes effect without restarting Hermes. DEEPSQL_AUTH_TOKEN
+    # stays as a fallback for any consumer that only reads the env snapshot.
+    keys["DEEPSQL_TOKEN_FILE"] = str(token_file)
     keys["DEEPSQL_AUTH_TOKEN"] = token or ""
     keys["DEEPSQL_MCP_USER_ID"] = user
     keys["DEEPSQL_MCP_PROJECT_ID"] = "deepsql-agent"
@@ -100,13 +129,16 @@ def _load_profile_config(home: Path):
     return cfg if isinstance(cfg, dict) else {}
 
 
-def write_profile_mcp(home: Path, *, user: str, token: str) -> None:
+def write_profile_mcp(home: Path, *, user: str, token: str, token_file: Path) -> None:
     import yaml  # agent venv / system PyYAML
 
     cfg_path = home / "config.yaml"
     cfg = _load_profile_config(home)
     # Token must live on the MCP subprocess env — the agent runtime does not auto-forward
-    # the profile .env into mcp_servers.*.env.
+    # the profile .env into mcp_servers.*.env. DEEPSQL_TOKEN_FILE lets the MCP
+    # process pick up a rotated token live (mtime-checked re-read) without
+    # Hermes respawning the subprocess; DEEPSQL_AUTH_TOKEN is kept as a
+    # fallback for the env-snapshot path.
     cfg.setdefault("mcp_servers", {})["deepsql"] = {
         "command": "node",
         "args": [str(REPO_ROOT / "mcp" / "deepsql-phase1-server.js")],
@@ -114,6 +146,7 @@ def write_profile_mcp(home: Path, *, user: str, token: str) -> None:
             "DEEPSQL_API_BASE_URL": API_BASE,
             "DEEPSQL_MCP_USER_ID": user,
             "DEEPSQL_MCP_PROJECT_ID": "deepsql-agent",
+            "DEEPSQL_TOKEN_FILE": str(token_file),
             "DEEPSQL_AUTH_TOKEN": token or "",
         },
     }
@@ -151,8 +184,14 @@ class Handler(BaseHTTPRequestHandler):
         return self._send(404, {"error": "not found"})
 
     def do_POST(self):
-        if self.path.rstrip("/") != "/provision":
-            return self._send(404, {"error": "not found"})
+        path = self.path.rstrip("/")
+        if path == "/provision":
+            return self._handle_provision()
+        if path == "/revoke":
+            return self._handle_revoke()
+        return self._send(404, {"error": "not found"})
+
+    def _handle_provision(self):
         if not SECRET:
             return self._send(500, {"error": "AGENT_PROVISION_SECRET unset"})
         if self.headers.get("X-Provision-Secret") != SECRET:
@@ -168,8 +207,37 @@ class Handler(BaseHTTPRequestHandler):
         profile = profile_for(user)
         try:
             home = ensure_profile(profile)
-            write_profile_mcp(home, user=user, token=token)
-            write_profile_env(home, user=user, token=token)
+            token_file = write_token_file(home, token)
+            write_profile_mcp(home, user=user, token=token, token_file=token_file)
+            write_profile_env(home, user=user, token=token, token_file=token_file)
+        except Exception as e:
+            return self._send(500, {"error": str(e)})
+        return self._send(200, {"ok": True, "profile": profile, "home": str(home)})
+
+    def _handle_revoke(self):
+        """Best-effort disk cleanup on logout: blank the token file and the
+        DEEPSQL_AUTH_TOKEN fallback in both the MCP env and the profile .env
+        so a revoked DB token doesn't keep working via a stale plaintext copy
+        on disk. Does not delete the profile itself — just its credential."""
+        if not SECRET:
+            return self._send(500, {"error": "AGENT_PROVISION_SECRET unset"})
+        if self.headers.get("X-Provision-Secret") != SECRET:
+            return self._send(401, {"error": "unauthorized"})
+        try:
+            body = self._read_json()
+        except Exception:
+            return self._send(400, {"error": "invalid json"})
+        user = str(body.get("user") or "").strip()
+        if not user:
+            return self._send(400, {"error": "user required"})
+        profile = profile_for(user)
+        home = HERMES_HOME / "profiles" / profile
+        if not home.exists():
+            return self._send(200, {"ok": True, "profile": profile, "note": "no profile on disk"})
+        try:
+            write_token_file(home, "")
+            write_profile_mcp(home, user=user, token="", token_file=token_file_for(home))
+            write_profile_env(home, user=user, token="", token_file=token_file_for(home))
         except Exception as e:
             return self._send(500, {"error": str(e)})
         return self._send(200, {"ok": True, "profile": profile, "home": str(home)})

--- a/scripts/self-host/setup-agent.sh
+++ b/scripts/self-host/setup-agent.sh
@@ -244,11 +244,23 @@ cfg = cfg or {}
 repo = os.environ["REPO_ROOT"]
 port = os.environ["BACKEND_PORT"]
 token = os.environ["TOKEN"]
+
+# Token file: written atomically (temp + rename) so the long-lived MCP
+# subprocess (mtime-checked re-read, see deepsql-phase1-lib.js readTokenFile)
+# never observes a partial write mid-rotation. DEEPSQL_AUTH_TOKEN stays as a
+# fallback for any consumer that only reads the env snapshot.
+token_file = home / "deepsql.token"
+tmp = token_file.with_suffix(f".tmp-{os.getpid()}")
+tmp.write_text(token + "\n")
+tmp.chmod(0o600)
+os.replace(tmp, token_file)
+
 cfg.setdefault("mcp_servers", {})["deepsql"] = {
     "command": "node",
     "args": [f"{repo}/mcp/deepsql-phase1-server.js"],
     "env": {
         "DEEPSQL_API_BASE_URL": f"http://localhost:{port}/api/",
+        "DEEPSQL_TOKEN_FILE": str(token_file),
         "DEEPSQL_AUTH_TOKEN": token,
         "DEEPSQL_MCP_USER_ID": os.environ["PROFILE"],
         "DEEPSQL_MCP_PROJECT_ID": os.environ["PROFILE"],
@@ -260,6 +272,7 @@ cfg_path.write_text(yaml.safe_dump(cfg, sort_keys=False))
 env_path = home / ".env"
 env_path.write_text(
     f"DEEPSQL_API_BASE_URL=http://localhost:{port}/api/\n"
+    f"DEEPSQL_TOKEN_FILE={token_file}\n"
     f"DEEPSQL_AUTH_TOKEN={token}\n"
     f"DEEPSQL_MCP_USER_ID={os.environ['PROFILE']}\n"
     f"DEEPSQL_MCP_PROJECT_ID={os.environ['PROFILE']}\n"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import Login from './pages/Login'
 import Signup from './pages/Signup'
 import ActivateInvite from './pages/ActivateInvite'
 import CliAuthorize from './pages/CliAuthorize'
+import Onboarding from './pages/Onboarding'
 import PublicDashboardPage from './pages/PublicDashboardPage'
 import SharedDashboardPage from './pages/SharedDashboardPage'
 import { Component } from 'react'
@@ -123,6 +124,15 @@ function App() {
               </ProtectedRoute>
             }
           />
+          {/* First-run setup wizard — add a connection, configure the LLM, kick Brain init. */}
+          <Route
+            path="/onboarding"
+            element={
+              <ProtectedRoute>
+                <Onboarding />
+              </ProtectedRoute>
+            }
+          />
           {/* Public shared dashboard — no login; the token is the authorization. */}
           <Route path="/share/dashboard/:token" element={<PublicDashboardPage />} />
           {/* Internal deep link to one dashboard (login + access required). */}
@@ -134,8 +144,8 @@ function App() {
               </ProtectedRoute>
             }
           />
-          {/* Legacy /setup route — redirect to dashboard */}
-          <Route path="/setup" element={<Navigate to="/dashboard" replace />} />
+          {/* Legacy /setup route — now the real onboarding wizard, not a dead end. */}
+          <Route path="/setup" element={<Navigate to="/onboarding" replace />} />
           <Route path="/cli-authorize" element={<CliAuthorize />} />
           <Route path="/cli-authorize/device" element={<CliAuthorize />} />
         </Routes>

--- a/src/components/AgentChat/AgentChatPanel.jsx
+++ b/src/components/AgentChat/AgentChatPanel.jsx
@@ -30,16 +30,25 @@ function deriveTitle(messages) {
   return firstUser.content.replace(/\s+/g, ' ').trim().slice(0, 80)
 }
 
+// Generic, schema-agnostic prompts — must work for any connection (booking
+// systems, SaaS multi-tenant DBs, analytics warehouses, ...). Never hardcode
+// a domain-specific table/column name here (see the chat guardrail in
+// AGENTS.md); AgentChatPanel has no idea what tables the active connection has.
 const SUGGESTIONS = [
-  'How many bookings are in this database?',
-  'What does this database track, and the 5 largest tables?',
-  'What indexes should I add or drop to speed things up?',
+  'How many tables are there?',
+  'Show the largest tables',
+  'What are the top slow queries?',
 ]
 
 export default function AgentChatPanel({ connectionId, connectionName }) {
   const [sessionId, setSessionId] = useState(null)
   const [booting, setBooting] = useState(true)
   const [bootError, setBootError] = useState(null)
+  // True once /api/agent/session comes back with mcpAuthOk===false — the
+  // freshly provisioned MCP token can't reach DeepSQL's API. Chat must stay
+  // blocked until a retry goes green (W1: fail loud before the first message,
+  // not six tool-call failures in).
+  const [authBlocked, setAuthBlocked] = useState(false)
   const [messages, setMessages] = useState([])
   const [input, setInput] = useState('')
   const [sending, setSending] = useState(false)
@@ -52,12 +61,18 @@ export default function AgentChatPanel({ connectionId, connectionName }) {
   const restoredRef = useRef(false) // guards the persist effect until boot finishes
 
   const boot = useCallback(async ({ fresh = false } = {}) => {
-    setBooting(true); setBootError(null)
+    setBooting(true); setBootError(null); setAuthBlocked(false)
     restoredRef.current = false
     convIdRef.current = null
     esRef.current?.close(); esRef.current = null
     try {
-      const { profile } = await agentChatAPI.bootstrap(connectionId)
+      const { profile, mcpAuthOk, mcpAuthError } = await agentChatAPI.bootstrap(connectionId)
+      if (mcpAuthOk === false) {
+        setAuthBlocked(true)
+        setBootError(mcpAuthError || 'Agent cannot reach DeepSQL (auth). Reconnect / check Agent runtime.')
+        setBooting(false)
+        return
+      }
       profileRef.current = profile
       // Hermes requires the hermes_profile cookie before session/chat calls;
       // without it, chat/start 404s and the UI loader never resolves.
@@ -116,7 +131,7 @@ export default function AgentChatPanel({ connectionId, connectionName }) {
 
   const send = async (preset) => {
     const text = (preset ?? input).trim()
-    if (!text || sending || !sessionId) return
+    if (!text || sending || !sessionId || authBlocked) return
     setInput('')
     setMessages((m) => [...m, { role: 'user', content: text }, { role: 'assistant', content: '', tools: [], streaming: true }])
     setSending(true)
@@ -221,17 +236,17 @@ export default function AgentChatPanel({ connectionId, connectionName }) {
       <div className={styles.composer}>
         <textarea
           className={styles.textarea}
-          placeholder={sessionId ? 'Message the DeepSQL Agent…' : 'Starting…'}
+          placeholder={authBlocked ? 'Agent unavailable — reconnect above' : sessionId ? 'Message the DeepSQL Agent…' : 'Starting…'}
           value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={onKeyDown}
           rows={1}
-          disabled={!sessionId || booting}
+          disabled={!sessionId || booting || authBlocked}
         />
         {sending ? (
           <button className={styles.stopBtn} onClick={stop} title="Stop"><Square size={15} /></button>
         ) : (
-          <button className={styles.sendBtn} onClick={() => send()} disabled={!input.trim() || !sessionId} title="Send"><ArrowUp size={16} /></button>
+          <button className={styles.sendBtn} onClick={() => send()} disabled={!input.trim() || !sessionId || authBlocked} title="Send"><ArrowUp size={16} /></button>
         )}
       </div>
     </div>

--- a/src/components/BrainInitModal.jsx
+++ b/src/components/BrainInitModal.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { X, CheckCircle, Loader2, XCircle, RotateCcw, ArrowRight } from 'lucide-react'
 import { connectionAPI } from '@/lib/api/client'
+import { isInitRunning, isInitTerminal } from '@/lib/initStage'
 
 const STAGES = [
   { key: 'SCHEMA_SCAN',    label: 'Scanning schema',       desc: 'Reading tables, columns, and relationships' },
@@ -70,7 +71,7 @@ export default function BrainInitModal({
 
     setHasExistingRun(hasRun)
 
-    if (currentStage && !['NONE', 'COMPLETED', 'FAILED', 'ERROR'].includes(currentStage)) {
+    if (currentStage && isInitRunning(currentStage)) {
       setStatus('running')
       setActiveStage(currentStage)
       setDoneStages(completedStages.filter((stage) => stage !== currentStage))
@@ -123,7 +124,7 @@ export default function BrainInitModal({
       try {
         const nextStatus = await loadExistingStatus()
         const stage = nextStatus?.currentStage || nextStatus?.stage || ''
-        if (!stage || ['COMPLETED', 'FAILED', 'ERROR', 'NONE'].includes(stage)) {
+        if (!stage || (stage === 'NONE' || isInitTerminal(stage))) {
           stopPolling()
         }
       } catch {
@@ -163,7 +164,7 @@ export default function BrainInitModal({
     } else {
       void loadExistingStatus().then((nextStatus) => {
         const stage = nextStatus?.currentStage || nextStatus?.stage || ''
-        if (stage && !['NONE', 'COMPLETED', 'FAILED', 'ERROR'].includes(stage)) {
+        if (stage && isInitRunning(stage)) {
           startPolling()
         }
       })

--- a/src/components/InitProgressIndicator.js
+++ b/src/components/InitProgressIndicator.js
@@ -16,6 +16,7 @@ import useInitProgressStore, {
 } from "../lib/stores/useInitProgressStore";
 import { connectionAPI } from "../lib/api/client";
 import InitHistoryModal from "./InitHistoryModal";
+import { isInitTerminal } from "../lib/initStage";
 
 const STAGE_LABELS = {
   SCHEMA_SCAN: "Scanning schema",
@@ -30,6 +31,7 @@ const STAGE_LABELS = {
   SEMANTIC_MODELING: "Modeling semantics",
   COMPLETED: "All set!",
   FAILED: "Initialization failed",
+  NEEDS_ATTENTION: "Needs attention",
 };
 
 const STAGE_DESCRIPTIONS = {
@@ -246,7 +248,7 @@ export function InitProgressIndicator({ connectionId }) {
         errorCountRef.current = 0;
         if (data) {
           setInitProgress(data);
-          if (["COMPLETED", "FAILED"].includes(data.currentStage)) {
+          if (isInitTerminal(data.currentStage)) {
             clearInterval(pollingRef.current);
             pollingRef.current = null;
           }
@@ -350,7 +352,7 @@ export function InitProgressIndicator({ connectionId }) {
         errorCountRef.current = 0;
         if (data) {
           setInitProgress(data);
-          if (["COMPLETED", "FAILED"].includes(data.currentStage)) {
+          if (isInitTerminal(data.currentStage)) {
             clearInterval(pollingRef.current);
             pollingRef.current = null;
           }
@@ -403,8 +405,8 @@ export function InitProgressIndicator({ connectionId }) {
   useEffect(() => {
     if (
       prevStageRef.current &&
-      !["COMPLETED", "FAILED"].includes(prevStageRef.current) &&
-      ["COMPLETED", "FAILED"].includes(stage)
+      !isInitTerminal(prevStageRef.current) &&
+      isInitTerminal(stage)
     ) {
       fetchHistory();
     }
@@ -433,6 +435,11 @@ export function InitProgressIndicator({ connectionId }) {
     chipLabel = "Brain ready";
     chipBg = "#f0fdf4";
     chipColor = "#15803d";
+  } else if (stage === "NEEDS_ATTENTION") {
+    chipIcon = <AlertCircle size={14} style={{ color: "#d97706" }} />;
+    chipLabel = "Needs attention";
+    chipBg = "#fffbeb";
+    chipColor = "#b45309";
   } else if (stage === "FAILED") {
     chipIcon = <AlertCircle size={14} style={{ color: "#dc2626" }} />;
     chipLabel = "Init failed";
@@ -723,7 +730,7 @@ export function InitProgressIndicator({ connectionId }) {
           )}
 
           {/* Action buttons — re-init + view history */}
-          {(stage === "COMPLETED" || stage === "FAILED" || !stage) && (
+          {(stage === "COMPLETED" || stage === "FAILED" || stage === "NEEDS_ATTENTION" || !stage) && (
             <div
               style={{
                 display: "flex",

--- a/src/components/company-knowledge/BackgroundJobsTab.jsx
+++ b/src/components/company-knowledge/BackgroundJobsTab.jsx
@@ -33,12 +33,16 @@ function formatTimestamp(value) {
  */
 const STAGE_LABELS = {
   SCHEMA_SCAN: 'Schema scan',
+  DATA_SAMPLING: 'Data sampling',
   KEY_COLUMN_ANALYSIS: 'Key column analysis',
-  TABLE_RELATIONSHIPS: 'Table relationships',
-  WORKLOAD_FINGERPRINT: 'Workload fingerprint',
-  BUSINESS_RULE_DRAFT: 'Business rule draft',
-  EMBEDDINGS: 'Embeddings',
-  READINESS_CALCULATION: 'Readiness calculation',
+  COLUMN_VALUE_COLLECTION: 'Column value collection',
+  INFERRED_RELATIONSHIPS: 'Inferred relationships',
+  SCHEMA_CLASSIFICATION: 'Schema classification',
+  AI_DESCRIPTION: 'AI description',
+  RAG_EMBEDDING: 'RAG embedding',
+  BRAIN_ANALYSIS: 'Brain analysis',
+  SEMANTIC_MODELING: 'Semantic modeling',
+  NEEDS_ATTENTION: 'Needs attention',
   COMPLETED: 'Complete',
   FAILED: 'Failed',
 }
@@ -48,20 +52,23 @@ function stageLabel(stage) {
 }
 
 /**
- * Canonical stage order — matches the backend InitStage enum's progression
- * order. Used to render the stages timeline in the order they actually run,
- * not insertion order of the stage_timings JSON map.
+ * Canonical stage order — matches the backend InitStage enum exactly
+ * (com.dbaagent.model.InitStage), excluding the terminal COMPLETED/FAILED
+ * states which aren't pipeline steps. Any drift here is how "Complete 100%"
+ * used to render with grey/pending dots for stages the frontend didn't know
+ * existed.
  */
 const STAGE_ORDER = [
   'SCHEMA_SCAN',
+  'DATA_SAMPLING',
   'KEY_COLUMN_ANALYSIS',
+  'COLUMN_VALUE_COLLECTION',
+  'INFERRED_RELATIONSHIPS',
   'SCHEMA_CLASSIFICATION',
-  'TABLE_RELATIONSHIPS',
   'AI_DESCRIPTION',
-  'WORKLOAD_FINGERPRINT',
-  'BUSINESS_RULE_DRAFT',
-  'EMBEDDINGS',
-  'READINESS_CALCULATION',
+  'RAG_EMBEDDING',
+  'BRAIN_ANALYSIS',
+  'SEMANTIC_MODELING',
 ]
 
 function formatDuration(ms) {
@@ -86,6 +93,10 @@ export default function BackgroundJobsTab({ connectionId }) {
   const [initStatusLoading, setInitStatusLoading] = useState(false)
   // Stages-timeline collapse + action-button busy/notice state.
   const [stagesExpanded, setStagesExpanded] = useState(false)
+  // Scheduled maintenance jobs are power-user content — ten job cards
+  // shouldn't dominate the first paint of "teach your business". Collapsed
+  // by default; the count in the toggle label is enough for most visits.
+  const [jobsExpanded, setJobsExpanded] = useState(false)
   const [initActionBusy, setInitActionBusy] = useState(null)  // 'reinit' | 'cancel' | 'refresh' | null
   const [initActionNotice, setInitActionNotice] = useState(null)
 
@@ -282,8 +293,24 @@ export default function BackgroundJobsTab({ connectionId }) {
     ? Math.max(0, Math.min(100, initStatus.progressPercent))
     : 0
   const isComplete = stage === 'COMPLETED'
-  const isFailed = stage === 'FAILED' || !!initStatus?.errorMessage
-  const isRunning = !!initStatus && !isComplete && !isFailed
+  const isNeedsAttention = stage === 'NEEDS_ATTENTION'
+  const isFailed = (stage === 'FAILED' || !!initStatus?.errorMessage) && !isNeedsAttention
+  const isRunning = !!initStatus && !isComplete && !isFailed && !isNeedsAttention
+  const schemaScanDetails = initStatus?.stageDetails?.SCHEMA_SCAN || {}
+  const coverageLine = (() => {
+    const live = schemaScanDetails.liveUserTableCount
+    const discovered = schemaScanDetails.baseTablesDiscovered ?? schemaScanDetails.tablesDiscovered
+    const coverage = schemaScanDetails.coveragePercent
+    const schemas = Array.isArray(schemaScanDetails.schemasScanned)
+      ? schemaScanDetails.schemasScanned.length
+      : null
+    if (typeof live === 'number' && typeof discovered === 'number') {
+      const schemaBit = schemas != null ? ` across ${schemas} schema${schemas === 1 ? '' : 's'}` : ''
+      const covBit = typeof coverage === 'number' ? ` (${coverage}%)` : ''
+      return `Indexed ${discovered}/${live} base tables${covBit}${schemaBit}`
+    }
+    return null
+  })()
   const initStartedText = formatTimestamp(initStatus?.startedAt)
   const initCompletedText = formatTimestamp(initStatus?.completedAt)
 
@@ -294,6 +321,8 @@ export default function BackgroundJobsTab({ connectionId }) {
           <div className={styles.brainInitHeading}>
             {isComplete ? (
               <CheckCircle2 size={16} className={styles.brainInitIconOk} />
+            ) : isNeedsAttention ? (
+              <AlertTriangle size={16} className={styles.brainInitIconFail} />
             ) : isFailed ? (
               <AlertTriangle size={16} className={styles.brainInitIconFail} />
             ) : isRunning ? (
@@ -342,7 +371,7 @@ export default function BackgroundJobsTab({ connectionId }) {
               if the previous run completed cleanly. Disabled mid-run to
               avoid stomping on an in-progress pipeline.
             */}
-            {(!isRunning || isFailed) && (
+            {(!isRunning || isFailed || isNeedsAttention) && (
               <button
                 type="button"
                 className={styles.brainInitBtn}
@@ -372,13 +401,18 @@ export default function BackgroundJobsTab({ connectionId }) {
           />
         </div>
 
-        {(initStatus?.stageMessage || initStatus?.errorMessage || initStartedText || initCompletedText) && (
+        {(initStatus?.stageMessage || initStatus?.errorMessage || coverageLine || initStartedText || initCompletedText) && (
           <div className={styles.brainInitMeta}>
             {initStatus?.errorMessage ? (
               <span className={styles.brainInitError}>{initStatus.errorMessage}</span>
             ) : initStatus?.stageMessage ? (
               <span>{initStatus.stageMessage}</span>
             ) : null}
+            {coverageLine && (
+              <span className={isNeedsAttention ? styles.brainInitError : undefined}>
+                {coverageLine}
+              </span>
+            )}
             <span className={styles.brainInitTimings}>
               {initStartedText && <>Started {initStartedText}</>}
               {initStartedText && initCompletedText && <> · </>}
@@ -419,7 +453,13 @@ export default function BackgroundJobsTab({ connectionId }) {
                 {STAGE_ORDER.map(stageKey => {
                   const timing = initStatus.stageTimings?.[stageKey]
                   const isCurrent = stage === stageKey
-                  const isDone = !!timing?.endedAt
+                  // Once the pipeline reports COMPLETED, every stage is done —
+                  // regardless of whether its individual timing entry made it
+                  // into stage_timings (e.g. an older init run predating a
+                  // stage, or a timing write that raced completion). Without
+                  // this, a fully-finished Brain could still show grey/pending
+                  // dots for stages the backend has already finished.
+                  const isDone = isComplete || !!timing?.endedAt
                   const dotClass = isDone
                     ? styles.brainInitStageDotDone
                     : isCurrent
@@ -445,130 +485,148 @@ export default function BackgroundJobsTab({ connectionId }) {
         )}
       </section>
 
-      <div className={styles.bgJobsStatsRow}>
-        <button
-          type="button"
-          className={`${styles.bgJobsStat} ${selectedJobsFilter === 'all' ? styles.bgJobsStatActive : ''}`}
-          onClick={() => setSelectedJobsFilter('all')}
-        >
-          <span className={styles.bgJobsStatLabel}>Scheduled</span>
-          <strong className={styles.bgJobsStatValue}>{stats.totalCount}</strong>
-        </button>
-        <button
-          type="button"
-          className={`${styles.bgJobsStat} ${selectedJobsFilter === 'active' ? styles.bgJobsStatActive : ''}`}
-          onClick={() => setSelectedJobsFilter('active')}
-        >
-          <span className={styles.bgJobsStatLabel}>Active</span>
-          <strong className={styles.bgJobsStatValue}>{stats.activeCount}</strong>
-        </button>
-        <button
-          type="button"
-          className={`${styles.bgJobsStat} ${selectedJobsFilter === 'running' ? styles.bgJobsStatActive : ''}`}
-          onClick={() => setSelectedJobsFilter('running')}
-        >
-          <span className={styles.bgJobsStatLabel}>Running</span>
-          <strong className={styles.bgJobsStatValue}>{stats.runningCount}</strong>
-        </button>
-        <button
-          type="button"
-          className={`${styles.bgJobsStat} ${selectedJobsFilter === 'next' ? styles.bgJobsStatActive : ''}`}
-          onClick={() => setSelectedJobsFilter('next')}
-        >
-          <span className={styles.bgJobsStatLabel}>By next run</span>
-          <strong className={styles.bgJobsStatValue}>Sort</strong>
-        </button>
-        {jobsLoading && (
-          <span className={styles.bgJobsLoading}>
-            <Loader2 size={14} className={styles.spinner} /> Refreshing
-          </span>
-        )}
-      </div>
+      {/* Scheduled maintenance — collapsed by default. This is power-user
+          content (recurring jobs like re-scans and re-embeddings); the
+          "teach your business" flow above is what most visits are for. */}
+      <button
+        type="button"
+        className={styles.brainInitStagesToggle}
+        onClick={() => setJobsExpanded(v => !v)}
+        aria-expanded={jobsExpanded}
+      >
+        {jobsExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+        {jobsExpanded ? 'Hide' : 'Show'} scheduled maintenance ({stats.totalCount})
+        {jobsLoading && <Loader2 size={12} className={styles.spinner} />}
+      </button>
 
-      {jobNotice && (
-        <div className={`${styles.diagnosticsPanel} ${jobNotice.tone === 'error' ? styles.danger : styles.muted}`}>
-          <div className={styles.diagnosticsHeader}>{jobNotice.message}</div>
-        </div>
-      )}
+      {jobsExpanded && (
+        <>
+          <div className={styles.bgJobsStatsRow}>
+            <button
+              type="button"
+              className={`${styles.bgJobsStat} ${selectedJobsFilter === 'all' ? styles.bgJobsStatActive : ''}`}
+              onClick={() => setSelectedJobsFilter('all')}
+            >
+              <span className={styles.bgJobsStatLabel}>Scheduled</span>
+              <strong className={styles.bgJobsStatValue}>{stats.totalCount}</strong>
+            </button>
+            <button
+              type="button"
+              className={`${styles.bgJobsStat} ${selectedJobsFilter === 'active' ? styles.bgJobsStatActive : ''}`}
+              onClick={() => setSelectedJobsFilter('active')}
+            >
+              <span className={styles.bgJobsStatLabel}>Active</span>
+              <strong className={styles.bgJobsStatValue}>{stats.activeCount}</strong>
+            </button>
+            <button
+              type="button"
+              className={`${styles.bgJobsStat} ${selectedJobsFilter === 'running' ? styles.bgJobsStatActive : ''}`}
+              onClick={() => setSelectedJobsFilter('running')}
+            >
+              <span className={styles.bgJobsStatLabel}>Running</span>
+              <strong className={styles.bgJobsStatValue}>{stats.runningCount}</strong>
+            </button>
+            <button
+              type="button"
+              className={`${styles.bgJobsStat} ${selectedJobsFilter === 'next' ? styles.bgJobsStatActive : ''}`}
+              onClick={() => setSelectedJobsFilter('next')}
+            >
+              <span className={styles.bgJobsStatLabel}>By next run</span>
+              <strong className={styles.bgJobsStatValue}>Sort</strong>
+            </button>
+            {jobsLoading && (
+              <span className={styles.bgJobsLoading}>
+                <Loader2 size={14} className={styles.spinner} /> Refreshing
+              </span>
+            )}
+          </div>
 
-      {jobsError && (
-        <div className={`${styles.diagnosticsPanel} ${styles.danger}`}>
-          <div className={styles.diagnosticsHeader}>{jobsError}</div>
-        </div>
-      )}
+          {jobNotice && (
+            <div className={`${styles.diagnosticsPanel} ${jobNotice.tone === 'error' ? styles.danger : styles.muted}`}>
+              <div className={styles.diagnosticsHeader}>{jobNotice.message}</div>
+            </div>
+          )}
 
-      {filteredJobs.length === 0 ? (
-        <div className={styles.emptyState}>
-          {jobs.length === 0
-            ? 'No scheduled Brain jobs are registered for this connection yet.'
-            : 'No jobs match this filter right now.'}
-        </div>
-      ) : (
-        <div className={styles.bgJobsList}>
-          {filteredJobs.map((job) => {
-            const nextRunText = formatTimestamp(job.nextRunAt)
-            const lastSuccessText = formatTimestamp(job.lastSuccessAt)
-            const lastFailureText = formatTimestamp(job.lastFailureAt)
-            const running = job.status === 'running'
-            return (
-              <article key={job.key} className={styles.bgJobCard}>
-                <div className={styles.bgJobTopRow}>
-                  <div className={styles.bgJobTitleBlock}>
-                    <div className={styles.bgJobTitleRow}>
-                      <h3 className={styles.bgJobTitle}>{job.title}</h3>
-                      <span className={styles.bgJobScope}>
-                        {job.scope === 'global' ? 'All connections' : 'This connection'}
+          {jobsError && (
+            <div className={`${styles.diagnosticsPanel} ${styles.danger}`}>
+              <div className={styles.diagnosticsHeader}>{jobsError}</div>
+            </div>
+          )}
+
+          {filteredJobs.length === 0 ? (
+            <div className={styles.emptyState}>
+              {jobs.length === 0
+                ? 'No scheduled Brain jobs are registered for this connection yet.'
+                : 'No jobs match this filter right now.'}
+            </div>
+          ) : (
+            <div className={styles.bgJobsList}>
+              {filteredJobs.map((job) => {
+                const nextRunText = formatTimestamp(job.nextRunAt)
+                const lastSuccessText = formatTimestamp(job.lastSuccessAt)
+                const lastFailureText = formatTimestamp(job.lastFailureAt)
+                const running = job.status === 'running'
+                return (
+                  <article key={job.key} className={styles.bgJobCard}>
+                    <div className={styles.bgJobTopRow}>
+                      <div className={styles.bgJobTitleBlock}>
+                        <div className={styles.bgJobTitleRow}>
+                          <h3 className={styles.bgJobTitle}>{job.title}</h3>
+                          <span className={styles.bgJobScope}>
+                            {job.scope === 'global' ? 'All connections' : 'This connection'}
+                          </span>
+                        </div>
+                        <p className={styles.bgJobDescription}>{job.description}</p>
+                      </div>
+                      <span
+                        className={`${styles.bgJobStatusBadge} ${
+                          running
+                            ? styles.bgJobStatusRunning
+                            : job.status === 'active'
+                              ? styles.bgJobStatusActive
+                              : styles.bgJobStatusInactive
+                        }`}
+                      >
+                        {job.status}
                       </span>
                     </div>
-                    <p className={styles.bgJobDescription}>{job.description}</p>
-                  </div>
-                  <span
-                    className={`${styles.bgJobStatusBadge} ${
-                      running
-                        ? styles.bgJobStatusRunning
-                        : job.status === 'active'
-                          ? styles.bgJobStatusActive
-                          : styles.bgJobStatusInactive
-                    }`}
-                  >
-                    {job.status}
-                  </span>
-                </div>
 
-                <div className={styles.bgJobMeta}>
-                  <span>
-                    <Clock3 size={13} />
-                    {nextRunText ? ` Next run ${nextRunText}` : ' No next run scheduled'}
-                  </span>
-                  {lastSuccessText && <span>Last success {lastSuccessText}</span>}
-                  {lastFailureText && <span>Last failure {lastFailureText}</span>}
-                  {job.consecutiveFailures > 0 && (
-                    <span>{job.consecutiveFailures} consecutive failure{job.consecutiveFailures > 1 ? 's' : ''}</span>
-                  )}
-                </div>
+                    <div className={styles.bgJobMeta}>
+                      <span>
+                        <Clock3 size={13} />
+                        {nextRunText ? ` Next run ${nextRunText}` : ' No next run scheduled'}
+                      </span>
+                      {lastSuccessText && <span>Last success {lastSuccessText}</span>}
+                      {lastFailureText && <span>Last failure {lastFailureText}</span>}
+                      {job.consecutiveFailures > 0 && (
+                        <span>{job.consecutiveFailures} consecutive failure{job.consecutiveFailures > 1 ? 's' : ''}</span>
+                      )}
+                    </div>
 
-                {job.statusReason && (
-                  <p className={styles.bgJobReason}>{job.statusReason}</p>
-                )}
-
-                <div className={styles.bgJobActions}>
-                  <button
-                    type="button"
-                    className={styles.secondaryButton}
-                    onClick={() => handleRunJob(job.key)}
-                    disabled={jobActionKey === job.key || running}
-                  >
-                    {jobActionKey === job.key ? (
-                      <><Loader2 size={14} className={styles.spinner} /> Starting…</>
-                    ) : (
-                      <><Play size={14} /> Run now</>
+                    {job.statusReason && (
+                      <p className={styles.bgJobReason}>{job.statusReason}</p>
                     )}
-                  </button>
-                </div>
-              </article>
-            )
-          })}
-        </div>
+
+                    <div className={styles.bgJobActions}>
+                      <button
+                        type="button"
+                        className={styles.secondaryButton}
+                        onClick={() => handleRunJob(job.key)}
+                        disabled={jobActionKey === job.key || running}
+                      >
+                        {jobActionKey === job.key ? (
+                          <><Loader2 size={14} className={styles.spinner} /> Starting…</>
+                        ) : (
+                          <><Play size={14} /> Run now</>
+                        )}
+                      </button>
+                    </div>
+                  </article>
+                )
+              })}
+            </div>
+          )}
+        </>
       )}
     </div>
   )

--- a/src/components/company-knowledge/BackgroundJobsTab.jsx
+++ b/src/components/company-knowledge/BackgroundJobsTab.jsx
@@ -146,6 +146,8 @@ export default function BackgroundJobsTab({ connectionId }) {
     const initActive = initStatus
       && initStatus.currentStage !== 'COMPLETED'
       && initStatus.currentStage !== 'FAILED'
+      && initStatus.currentStage !== 'NEEDS_ATTENTION'
+      && initStatus.currentStage !== 'ERROR'
       && !initStatus.completedAt
     const intervalMs = (anyRunning || initActive) ? 4000 : 15000
     const intervalId = window.setInterval(() => {

--- a/src/components/company-knowledge/CompanyKnowledgePanel.jsx
+++ b/src/components/company-knowledge/CompanyKnowledgePanel.jsx
@@ -244,7 +244,13 @@ export default function CompanyKnowledgePanel({ connectionId }) {
     retry: false,
     refetchInterval: (query) => {
       const stage = query.state.data?.currentStage
-      return stage && stage !== 'COMPLETED' && stage !== 'FAILED' ? 4000 : false
+      // Keep polling only while a non-terminal stage is running
+      // (COMPLETED / FAILED / NEEDS_ATTENTION / NONE stop).
+      if (!stage || stage === 'NONE' || stage === 'COMPLETED'
+          || stage === 'FAILED' || stage === 'NEEDS_ATTENTION' || stage === 'ERROR') {
+        return false
+      }
+      return 4000
     },
   })
 
@@ -252,6 +258,8 @@ export default function CompanyKnowledgePanel({ connectionId }) {
     if (userChoseTab || activeTab !== 'background-jobs') {
       return
     }
+    // Only auto-advance on full COMPLETED — NEEDS_ATTENTION stays on Initialize
+    // so the user sees coverage messaging and can re-init.
     if (initStatusQuery.data?.currentStage === 'COMPLETED') {
       setDefaultTab('schema-context')
     }

--- a/src/components/company-knowledge/CompanyKnowledgePanel.jsx
+++ b/src/components/company-knowledge/CompanyKnowledgePanel.jsx
@@ -1,7 +1,8 @@
-import { useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { ArrowRight, Cog, FileCode, Inbox, Loader2, Map as MapIcon, NotebookText, Plus, Save, Trash2, X } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
-import { schemaAPI } from '@/lib/api/client'
+import { connectionAPI, schemaAPI } from '@/lib/api/client'
+import { queryKeys } from '@/lib/queryKeys'
 import { useCompanyKnowledgeStore } from '@/lib/stores/useCompanyKnowledgeStore'
 import {
   useCodeScanSuggestions,
@@ -10,7 +11,6 @@ import {
   useDeleteCompanyKnowledge,
   useUpdateCompanyKnowledge,
 } from '@/lib/hooks/queries'
-import { queryKeys } from '@/lib/queryKeys'
 import sectionStyles from '@/components/sections/TopLevelSection.module.css'
 import styles from './CompanyKnowledgePanel.module.css'
 import BackgroundJobsTab from './BackgroundJobsTab'
@@ -213,6 +213,8 @@ export default function CompanyKnowledgePanel({ connectionId }) {
   const clearLinkedFilters = useCompanyKnowledgeStore((state) => state.clearLinkedFilters)
   const activeTab = useCompanyKnowledgeStore((state) => state.activeTab)
   const setActiveTab = useCompanyKnowledgeStore((state) => state.setActiveTab)
+  const userChoseTab = useCompanyKnowledgeStore((state) => state.userChoseTab)
+  const setDefaultTab = useCompanyKnowledgeStore((state) => state.setDefaultTab)
 
   const pendingSuggestionsQuery = useCodeScanSuggestions({
     connectionId,
@@ -231,6 +233,29 @@ export default function CompanyKnowledgePanel({ connectionId }) {
     queryFn: () => schemaAPI.getSchema(connectionId),
     enabled: Boolean(connectionId),
   })
+
+  // Drives the one-time auto-advance off the default 'background-jobs' tab
+  // once the Brain finishes initializing (see setDefaultTab in the store).
+  // 404 (no init record yet) is normalized to null, same as BackgroundJobsTab.
+  const initStatusQuery = useQuery({
+    queryKey: queryKeys.brain.initStatus(connectionId),
+    queryFn: () => connectionAPI.getInitStatus(connectionId),
+    enabled: Boolean(connectionId),
+    retry: false,
+    refetchInterval: (query) => {
+      const stage = query.state.data?.currentStage
+      return stage && stage !== 'COMPLETED' && stage !== 'FAILED' ? 4000 : false
+    },
+  })
+
+  useEffect(() => {
+    if (userChoseTab || activeTab !== 'background-jobs') {
+      return
+    }
+    if (initStatusQuery.data?.currentStage === 'COMPLETED') {
+      setDefaultTab('schema-context')
+    }
+  }, [activeTab, initStatusQuery.data, setDefaultTab, userChoseTab])
 
   const tableOptions = useMemo(
     () => (schemaQuery.data?.schema?.tables || schemaQuery.data?.tables || [])

--- a/src/components/onboarding/StepBrainInit.jsx
+++ b/src/components/onboarding/StepBrainInit.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef, useCallback } from 'react'
 import { CheckCircle, Loader2, XCircle, AlertCircle, RotateCcw, ArrowRight } from 'lucide-react'
 import { connectionAPI } from '@/lib/api/client'
+import { isInitComplete, isInitFailed, isInitNeedsAttention } from '@/lib/initStage'
 
 const STAGES = [
   { key: 'SCHEMA_SCAN',   label: 'Scanning schema',         desc: 'Reading tables, columns, and relationships' },
@@ -31,11 +32,11 @@ export default function StepBrainInit({ connectionId, onComplete }) {
 
         const stage       = s.currentStage || s.stage || ''
         const prog        = s.progressPercent ?? s.progress ?? 0
-        const isCompleted = stage === 'COMPLETED' || prog >= 100
-        const isFailed    = stage === 'FAILED' || stage === 'ERROR'
         const timings     = s.stageTimings || {}
 
-        if (isCompleted) {
+        // Do NOT treat progress>=100 alone as complete — coverage can stop at
+        // NEEDS_ATTENTION with a high percent while still incomplete.
+        if (isInitComplete(stage)) {
           clearInterval(pollRef.current)
           setDoneStages(STAGES.map(st => st.key))
           setActiveStage(null)
@@ -45,7 +46,7 @@ export default function StepBrainInit({ connectionId, onComplete }) {
           return
         }
 
-        if (isFailed) {
+        if (isInitNeedsAttention(stage) || isInitFailed(stage)) {
           clearInterval(pollRef.current)
           const lastAttempted = [...STAGES].reverse().find(st => timings[st.key]?.startedAt)
           const failedKey = lastAttempted?.key
@@ -55,7 +56,12 @@ export default function StepBrainInit({ connectionId, onComplete }) {
           setActiveStage(null)
           setProgress(prog)
           setStatus('error')
-          setErrorMsg(s.errorMessage || 'Initialization failed')
+          setErrorMsg(
+            s.errorMessage
+              || (isInitNeedsAttention(stage)
+                ? 'Brain indexed only part of the schema. Fix grants or schema access, then retry.'
+                : 'Initialization failed'),
+          )
           return
         }
 

--- a/src/components/onboarding/StepDatabase.jsx
+++ b/src/components/onboarding/StepDatabase.jsx
@@ -11,7 +11,7 @@ const DEFAULT_PORTS = { postgres: '5432', mysql: '3306' }
 
 export default function StepDatabase({ data, onUpdate }) {
   const [form, setForm] = useState({
-    dbType:   data.dbType   || 'postgresql',
+    dbType:   data.dbType   || 'postgres',
     host:     data.host     || '',
     port:     data.port     || '5432',
     database: data.database || '',
@@ -37,13 +37,13 @@ export default function StepDatabase({ data, onUpdate }) {
     setTestError('')
     try {
       await connectionAPI.testConnection({
-        databaseType: form.dbType,
-        host:         form.host,
-        port:         parseInt(form.port) || 5432,
-        databaseName: form.database,
-        username:     form.username,
-        password:     form.password,
-        sslMode:      form.sslMode,
+        dbType:   form.dbType,
+        host:     form.host,
+        port:     parseInt(form.port) || 5432,
+        database: form.database,
+        username: form.username,
+        password: form.password,
+        sslMode:  form.sslMode,
       })
       setTestState('ok')
       onUpdate({ ...form, tested: true })

--- a/src/components/tabs/Brain/BrainWorkspace.jsx
+++ b/src/components/tabs/Brain/BrainWorkspace.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Clock3, Database, Loader2, Network, Play, RefreshCw, Sparkles } from 'lucide-react'
 import BrainInitModal from '@/components/BrainInitModal'
 import { connectionAPI } from '@/lib/api/client'
+import { isInitRunning, isInitFailed, isInitNeedsAttention } from '@/lib/initStage'
 import { DEFAULT_ROLE_FILTERS, ERD3DErrorBoundary, SchemaDiagramFilter, SchemaERD3D } from './SchemaERD3D'
 import styles from './BrainWorkspace.module.css'
 
@@ -23,6 +24,7 @@ const STAGE_LABELS = {
   ...Object.fromEntries(STAGES.map((stage) => [stage.key, stage.label])),
   COMPLETED: 'Brain ready',
   FAILED: 'Initialization failed',
+  NEEDS_ATTENTION: 'Needs attention',
 }
 
 function stageLabel(stage) {
@@ -97,7 +99,7 @@ export default function BrainWorkspace({ connectionId }) {
       return undefined
     }
     const currentStage = status?.currentStage || status?.stage || 'NONE'
-    const isRunning = currentStage && !['NONE', 'COMPLETED', 'FAILED'].includes(currentStage)
+    const isRunning = isInitRunning(currentStage)
     const intervalMs = isRunning ? 4000 : 15000
     const intervalId = window.setInterval(() => {
       void loadWorkspace({ silent: true })
@@ -111,11 +113,11 @@ export default function BrainWorkspace({ connectionId }) {
   )
 
   const currentStage = status?.currentStage || status?.stage || 'NONE'
-  const isRunning = currentStage && !['NONE', 'COMPLETED', 'FAILED'].includes(currentStage)
+  const isRunning = isInitRunning(currentStage)
   const isReady = currentStage === 'COMPLETED' || hasCompletedInit
   const progress = Math.max(0, Math.min(100, Number(status?.progressPercent ?? status?.progress ?? (isReady ? 100 : 0))))
-  const ctaLabel = isRunning ? 'View current status' : isReady ? 'View completed stages' : currentStage === 'FAILED' ? 'View failure details' : 'Initialize Brain'
-  const primaryAutoStart = !isRunning && !isReady && currentStage !== 'FAILED'
+  const ctaLabel = isRunning ? 'View current status' : isReady ? 'View completed stages' : (isInitFailed(currentStage) || isInitNeedsAttention(currentStage)) ? 'View details' : 'Initialize Brain'
+  const primaryAutoStart = !isRunning && !isReady && !isInitFailed(currentStage) && !isInitNeedsAttention(currentStage)
   const statusText = isRunning
     ? `${stageLabel(currentStage)} · ${progress}%`
     : currentStage === 'FAILED'
@@ -308,14 +310,14 @@ export default function BrainWorkspace({ connectionId }) {
               {isRunning ? <Loader2 size={15} className={styles.spinningIcon} /> : <Sparkles size={15} />}
               {ctaLabel}
             </button>
-            {(!isRunning && (isReady || currentStage === 'FAILED' || currentStage === 'NONE')) && (
+            {(!isRunning && (isReady || isInitFailed(currentStage) || isInitNeedsAttention(currentStage) || currentStage === 'NONE')) && (
               <button
                 className={styles.secondaryButton}
                 onClick={() => openStatusModal(true)}
                 disabled={loading}
               >
                 <RefreshCw size={15} />
-                {isReady ? 'Refresh Brain' : currentStage === 'FAILED' ? 'Retry Brain init' : 'Start Brain init'}
+                {isReady ? 'Refresh Brain' : (isInitFailed(currentStage) || isInitNeedsAttention(currentStage)) ? 'Retry Brain init' : 'Start Brain init'}
               </button>
             )}
             {(!isRunning && !forceRebuilding) && (

--- a/src/hooks/useAuth.jsx
+++ b/src/hooks/useAuth.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, createContext, useContext, useMemo, useCallback } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { getActionPermission, getActionConfig } from '@/lib/actions'
-import { authAPI, AUTH_CHANGE_EVENT } from '@/lib/api/client'
+import { authAPI, setupAPI, AUTH_CHANGE_EVENT } from '@/lib/api/client'
 import { queryClient } from '@/lib/queryClient'
 import { useChatStore } from '@/lib/stores/useChatStore'
 import { useConnectionStore } from '@/lib/stores/useConnectionStore'
@@ -170,10 +170,26 @@ export function AuthProvider({ children }) {
     }
   }, [applyAuthPayload, handleLoggedOut, navigate, refreshCurrentUser])
 
+  // Product-ready ≠ "an admin exists" — a fresh install has no connections
+  // yet, so send a just-logged-in user into the setup wizard instead of a
+  // dashboard with nothing to show. Best-effort: if the status check itself
+  // fails, don't block login on it — fall through to the dashboard.
+  const postLoginDestination = useCallback(async () => {
+    try {
+      const status = await setupAPI.getStatus()
+      if (status && status.hasConnections === false) {
+        return '/onboarding'
+      }
+    } catch {
+      /* status check failed — don't block login on it */
+    }
+    return '/dashboard'
+  }, [])
+
   const login = useCallback((payload) => {
     applyAuthPayload(payload)
-    navigate('/dashboard', { replace: true })
-  }, [applyAuthPayload, navigate])
+    postLoginDestination().then((destination) => navigate(destination, { replace: true }))
+  }, [applyAuthPayload, navigate, postLoginDestination])
 
   const logout = useCallback(async () => {
     try {

--- a/src/lib/api/agentClient.js
+++ b/src/lib/api/agentClient.js
@@ -63,7 +63,12 @@ async function postJson(url, body, _retried = false) {
     await ensureAgentCsrf();
     return postJson(url, body, true);
   }
-  if (!res.ok) throw new Error(`${url} → ${res.status}`);
+  if (!res.ok) {
+    // Surface the backend's clear-error JSON (e.g. agent_provisioning_failed)
+    // instead of a bare status code — the caller shows this text verbatim.
+    const errBody = await res.json().catch(() => null);
+    throw new Error(errBody?.message || errBody?.error || `${url} → ${res.status}`);
+  }
   return res.json();
 }
 

--- a/src/lib/initStage.js
+++ b/src/lib/initStage.js
@@ -1,0 +1,33 @@
+/**
+ * Brain init stage helpers — keep in sync with
+ * com.dbaagent.model.InitStage#isTerminal().
+ */
+
+const TERMINAL_STAGES = new Set([
+  'COMPLETED',
+  'FAILED',
+  'ERROR',
+  'NEEDS_ATTENTION',
+])
+
+/** Pipeline finished (success, failure, or incomplete coverage). Stop polling. */
+export function isInitTerminal(stage) {
+  return !stage || TERMINAL_STAGES.has(stage)
+}
+
+/** Still running a non-terminal stage (includes NONE? no — NONE is idle). */
+export function isInitRunning(stage) {
+  return Boolean(stage) && stage !== 'NONE' && !TERMINAL_STAGES.has(stage)
+}
+
+export function isInitComplete(stage) {
+  return stage === 'COMPLETED'
+}
+
+export function isInitNeedsAttention(stage) {
+  return stage === 'NEEDS_ATTENTION'
+}
+
+export function isInitFailed(stage) {
+  return stage === 'FAILED' || stage === 'ERROR'
+}

--- a/src/lib/queryKeys.js
+++ b/src/lib/queryKeys.js
@@ -47,6 +47,7 @@ export const queryKeys = {
   brain: {
     all: (connectionId) => ["brain", connectionId],
     understanding: (connectionId) => ["brain", connectionId, "understanding"],
+    initStatus: (connectionId) => ["brain", connectionId, "initStatus"],
 
     // Tasks
     tasks: (connectionId, status) => [

--- a/src/lib/stores/useCompanyKnowledgeStore.js
+++ b/src/lib/stores/useCompanyKnowledgeStore.js
@@ -9,12 +9,21 @@ export const useCompanyKnowledgeStore = create((set, get) => ({
 
   // Active tab inside the Brain surface (formerly Company Knowledge).
   // Valid: 'business-rules' | 'schema-context' | 'sources' | 'suggestions' | 'background-jobs'
-  // Default 'background-jobs' (rendered as "Brain Init") so users land on
-  // the enrichment progress + scheduled-jobs view first — it's the natural
-  // "is my brain ready?" entry point. Key kept as 'background-jobs' for
-  // backwards compatibility with any persisted state.
+  // Default 'background-jobs' (rendered as "Initialize") so users land on the
+  // enrichment progress view while the Brain is still running. Once init
+  // reports COMPLETED, CompanyKnowledgePanel auto-advances to 'schema-context'
+  // via setDefaultTab (see userChoseTab below) — there's nothing left to watch
+  // on the init tab, and "add context" is the next real step.
   activeTab: 'background-jobs',
-  setActiveTab: (tab) => set({ activeTab: tab }),
+  // True once the user has explicitly clicked a tab. Gates the COMPLETED
+  // auto-advance so it only fires while the user is still sitting on the
+  // untouched default — it must never yank someone back to 'schema-context'
+  // after they've deliberately navigated elsewhere (e.g. to review suggestions).
+  userChoseTab: false,
+  setActiveTab: (tab) => set({ activeTab: tab, userChoseTab: true }),
+  // Used only by the one-time COMPLETED auto-advance — does not count as the
+  // user "choosing" a tab, so it can only fire once per session.
+  setDefaultTab: (tab) => set({ activeTab: tab }),
 
   // Suggestion-tab status filter.
   suggestionStatusFilter: 'PENDING',

--- a/src/lib/stores/useInitProgressStore.js
+++ b/src/lib/stores/useInitProgressStore.js
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { shallow } from "zustand/shallow";
+import { isInitRunning } from "@/lib/initStage";
 
 const useInitProgressStore = create((set) => ({
   connectionId: null,
@@ -66,6 +67,6 @@ export const useIsInitActive = (connectionId) =>
     (s) =>
       !!s.stage &&
       s.connectionId === connectionId &&
-      !["COMPLETED", "FAILED"].includes(s.stage),
+      isInitRunning(s.stage),
   );
 export default useInitProgressStore;

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import { useAuth } from '@/hooks/useAuth'
-import { authAPI } from '@/lib/api/client'
+import { authAPI, setupAPI } from '@/lib/api/client'
 import { ArrowLeft, Database, KeyRound, Mail, ShieldCheck, Sparkles, Zap, Activity, LineChart } from 'lucide-react'
 
 const STEP_LOGIN = 'login'
@@ -27,12 +27,20 @@ export default function Login() {
   const [error, setError] = useState(initialError)
   const [info, setInfo] = useState('')
   const [loading, setLoading] = useState(false)
+  const [setupStatus, setSetupStatus] = useState(null)
 
   useEffect(() => {
     if (initialError) {
       setError(initialError)
     }
   }, [initialError])
+
+  // Public endpoint — no auth required. Lets a returning admin who never
+  // finished the wizard jump straight back into it instead of guessing why
+  // the dashboard looks empty after login.
+  useEffect(() => {
+    setupAPI.getStatus().then(setSetupStatus).catch(() => {})
+  }, [])
 
   const handleAuthenticated = (payload) => {
     setError('')
@@ -94,7 +102,7 @@ export default function Login() {
     <form onSubmit={handlePasswordLogin} className="space-y-5">
       <div>
         <label htmlFor="email" className="text-xs font-semibold text-gray-500 uppercase tracking-wider block mb-1.5">
-          Work Email
+          Email
         </label>
         <div className="relative group">
           <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-gray-400 group-focus-within:text-gray-600 transition-colors" />
@@ -203,7 +211,7 @@ export default function Login() {
   const stepTitle = step === STEP_OTP ? 'Verify your sign-in' : 'Secure sign-in'
   const stepSubtitle = step === STEP_OTP
     ? 'Complete the extra email verification step for this workspace.'
-    : 'Use your work email and password to access DeepSQL.'
+    : 'Sign in with your email and password to access DeepSQL.'
 
   return (
     <div className="flex min-h-screen w-full bg-white text-gray-900 overflow-x-hidden">
@@ -281,6 +289,15 @@ export default function Login() {
           )}
 
           {step === STEP_OTP ? renderOtpStep() : renderLoginStep()}
+
+          {step === STEP_LOGIN && setupStatus && setupStatus.hasConnections === false && (
+            <p className="mt-5 text-center text-sm text-gray-500">
+              No database connected yet.{' '}
+              <Link to="/onboarding" className="text-gray-900 hover:text-gray-700 font-medium underline underline-offset-2">
+                Finish setup
+              </Link>
+            </p>
+          )}
         </div>
 
         <div className="absolute bottom-6 left-0 right-0 text-center text-gray-500 text-sm px-6">

--- a/src/pages/Onboarding.jsx
+++ b/src/pages/Onboarding.jsx
@@ -94,17 +94,20 @@ export default function Onboarding() {
           setSaveError('Please test your database connection before continuing.')
           return
         }
-        // Create the connection so Brain init has a connectionId
+        // Create the connection so Brain init has a connectionId. Field names
+        // must match ConnectionRequest exactly (connectionName / dbType /
+        // database) — the wizard previously sent name/databaseType/databaseName,
+        // which ConnectionRequest silently ignored (they deserialize to null).
         try {
           const created = await connectionAPI.saveConnection({
-            name:         dbData.database || dbData.host,
-            databaseType: dbData.dbType,
-            host:         dbData.host,
-            port:         parseInt(dbData.port) || 5432,
-            databaseName: dbData.database,
-            username:     dbData.username,
-            password:     dbData.password,
-            sslMode:      dbData.sslMode,
+            connectionName: dbData.database || dbData.host,
+            dbType:         dbData.dbType,
+            host:           dbData.host,
+            port:           parseInt(dbData.port) || 5432,
+            database:       dbData.database,
+            username:       dbData.username,
+            password:       dbData.password,
+            sslMode:        dbData.sslMode,
           })
           setConnectionId(created.id ?? created.connectionId)
         } catch (err) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements the **minimum viable Sunday cut** from [`docs/oss-ux/E2E_FIX_PROPOSAL.md`](docs/oss-ux/E2E_FIX_PROPOSAL.md) (PR #47 handoff), on top of latest `main` (#44 agent container, #47 oss-ux docs).

| Workstream | What shipped |
|------------|--------------|
| **W2a/b** | Postgres Brain scans all non-system schemas; qualified keys; coverage gate + persisted `stageDetails` (`liveUserTableCount`, `coveragePercent`, `schemasScanned`); `NEEDS_ATTENTION` stage |
| **W1** | Provisioner writes `deepsql.token` + `DEEPSQL_TOKEN_FILE`; fail-loud provision; session MCP auth probe (`mcpAuthOk`); Agent boot banner; revoke clears disk token |
| **W4** | Brain `STAGE_ORDER` synced to `InitStage`; stepper → Add context on complete; jobs collapsed; coverage line in UI |
| **W5** | Index enrichment + skip `UNINDEXED_*` on PK/UK/`TRUE_KEY` |
| **W3 thin** | `/onboarding` routed; login redirect when no connections; wizard payload matches `ConnectionRequest` |
| **W6** | Title DeepSQL; generic Agent suggestions; canonicalize `dbType` |

Deferred: schema allow-list UI (W2c), fuller W7 smoke matrix, security S1–S5.

## E2E results (Compose redeploy of this branch)

- [x] Backend compile
- [x] Rebuild + redeploy `backend` / `frontend` / `deepsql-agent`
- [x] `e2e-agent-check.py` on `demo_shop` — **AGENT_OK + DASH_OK**
- [x] Multi-schema fixture `crm`+`sales`: objects API returns 3 tables across both schemas; Brain `SCHEMA_SCAN` reports `liveUserTableCount=3`, `coveragePercent=100`, `schemasScanned=['crm','sales']`
- [x] `/onboarding` → HTTP 200
- [x] `POST /api/agent/session` returns `mcpAuthOk: true` after login and after logout→login; `deepsql.token` present on agent profile
- [x] Self-host smoke (agent paths) PASS

PR tip: `c1b7504`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe687-99b1-76fd-80fa-dd213aecc497?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe687-99b1-76fd-80fa-dd213aecc497&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

