### PR TITLE
fix(ci): drop the CodeQL visibility guard that blocked every merge

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,13 +18,19 @@ jobs:
   analyze:
     name: analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
-    # Code scanning is free on public repositories; on a private one it requires
-    # GitHub Advanced Security, which this organisation's free plan does not
-    # include. Without this guard every run fails with a 403 until the repository
-    # is public, and a permanently red workflow trains people to stop reading CI.
-    # DELETE THIS LINE once the repository is public — from then on a failure
-    # here is a real finding rather than a billing state.
-    if: github.event.repository.visibility == 'public'
+    # No visibility guard here, deliberately. A job-level `if:` is evaluated
+    # before the matrix expands, so a skipped run reports a single check under
+    # the raw template name — `analyze (${{ matrix.language }})` — rather than
+    # the two expanded names. That phantom name reached the `Protect main branch`
+    # ruleset as a required check (GitHub's suggestion list offers whatever was
+    # last reported), and once this repository went public and the job began
+    # reporting the real names instead, nothing was left to satisfy the phantom:
+    # every pull request stalled on "Expected — waiting for status to be
+    # reported", unmergeable, with no failing job to point at.
+    #
+    # Code scanning is free while this repository is public. If it ever goes
+    # private without GitHub Advanced Security, drop these contexts from the
+    # ruleset — do not reintroduce an `if:` here.
     permissions:
       # Required to upload results to the code-scanning API.
       security-events: write


### PR DESCRIPTION
## Problem

Pull requests were sitting on a required check that could never arrive:

```
analyze (${{ matrix.language }})   Expected — Waiting for status to be reported   [Required]
```

Note the name: the **raw, un-interpolated template**. That is not a check that failed — it is a check nothing will ever report.

## Root cause

`codeql.yml` guarded the `analyze` job with:

```yaml
if: github.event.repository.visibility == 'public'
```

A job-level `if:` is evaluated **before the matrix expands**. So when the job is skipped, GitHub emits a *single* check run under the literal `name:` template rather than the two expanded names. While this repository was private, every PR reported exactly one CodeQL check, named `analyze (${{ matrix.language }})`, conclusion `skipped` — still visible on the older open PRs (#40, #36).

That phantom name was the only CodeQL check anyone had seen, so it was pinned as a required status check in the `Protect main branch` ruleset — GitHub's suggestion list offers whatever was last reported.

When the repository went public, the job started running for real and reporting `analyze (java-kotlin)` and `analyze (javascript-typescript)`. The required phantom was left with nothing to satisfy it, and every PR became unmergeable with no failing job to point at.

## Fix

Remove the guard. Its own comment named the condition for deleting it — *"DELETE THIS LINE once the repository is public"* — and that condition is now met: the repository is public and code scanning is free.

The replacement comment records the failure mode so the `if:` is not reintroduced, and directs a future private-repository scenario to the ruleset instead of a job condition.

## Test plan

- [ ] CodeQL runs on this PR and reports **`analyze (java-kotlin)`** and **`analyze (javascript-typescript)`** — not the template name
- [ ] Both legs pass, satisfying the two required contexts already configured in the ruleset
- [ ] No new `if:` remains on the job (the two matches in the file are inside comments)
- [ ] Watch the Monday `27 4 * * 1` cron: scheduled runs on Aug 3 and Aug 10 both reported `skipped`, correctly, since the repository was private then. Whether `github.event.repository.visibility` is even populated on `schedule` events was never tested — removing the guard makes it moot, and the next cron should now produce a real scan.

## Notes

- The `Protect main branch` ruleset has already been corrected separately; it now lists only the two expanded contexts. This PR removes the thing that generated the bad name in the first place.
- Older PRs created while the repository was private still carry the stale skipped check and report `UNKNOWN` mergeability. A rebase or any push forces GitHub to recompute them against the corrected ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
