### PR TITLE
chore(release): v1.1.0 + weekly Saturday 9 AM PT cadence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 for product tags (`vMAJOR.MINOR.PATCH`).
 
+Product releases follow a **weekly cadence** (Saturday 09:00 America/Los_Angeles). See `docs/oss-ux/RELEASE.md`.
+
+## [1.1.0] — 2026-08-15
+
+### Added
+
+- Progressive dashboard builds (`dashboard-shell` / `dashboard-widget` SSE chunks) with live Preview mounting.
+- Dashboard organization: clone, folders, favorites, search.
+- Dashboard version history (`dashboard_versions`, restore) and AI-evaluated alerts (`dashboard_alerts`).
+- Dashboard refresh / auto-refresh and public TV kiosk mode.
+- Centered dashboard intro and editable breadcrumb title.
+- Server-owned dashboard generation persistence (`generation_status`, optimistic locking).
+
+### Changed
+
+- Multi-schema awareness across Editor, Brain, and Advisor UI (#55).
+- Slow Queries and Workload Analysis merged into a single Performance area (#52).
+
+### Fixed
+
+- CI: remove CodeQL visibility guard that blocked merges (#56).
+- Cloud agent ops notes for Hermes MCP restart and multi-schema fixtures (#53).
+
+### Notes
+
+- `@deepsql/mcp` remains `0.27.0` for this cut (no MCP API changes required).
+- Hand-apply SQL changelog `V111`–`V114` when not using `ddl-auto=update`.
+
 ## [1.0.0] — 2026-08-13
 
 First public OSS release.
@@ -31,4 +59,5 @@ First public OSS release.
 - Residual high-severity items tracked in `docs/oss-ux/OSS_SECURITY_REVIEW.md` (IDOR sweep, SET preamble allowlist, SSRF hardening, share-password defaults) are deferred past this cut.
 - Primary distribution path remains `docker compose up --build` (no pre-built container registry in this release).
 
+[1.1.0]: https://github.com/DeepSQLAI/deepsql/releases/tag/v1.1.0
 [1.0.0]: https://github.com/DeepSQLAI/deepsql/releases/tag/v1.0.0

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.dbaagent</groupId>
     <artifactId>dba-agent-backend</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <name>DBA Agent Backend</name>
     <description>Backend service for DBA Agent with secure credential storage and schema analysis</description>
 

--- a/docs/oss-ux/DAILY_RELEASE_AUTOMATION.md
+++ b/docs/oss-ux/DAILY_RELEASE_AUTOMATION.md
@@ -1,4 +1,6 @@
-# Daily release-manager automation (9 AM)
+# Daily release-manager automation (9 AM) — optional PR triage
+
+Product **releases** are weekly (Saturday 09:00 PT) — see [`WEEKLY_RELEASE_AUTOMATION.md`](./WEEKLY_RELEASE_AUTOMATION.md) and [`RELEASE.md`](./RELEASE.md). This daily automation is optional **PR triage only**; it does not cut tags.
 
 Cursor Automations cannot be created via MCP/API from a Cloud Agent — create this once in the UI.
 

--- a/docs/oss-ux/README.md
+++ b/docs/oss-ux/README.md
@@ -8,9 +8,10 @@ These docs are the durable home for OSS go-live planning. **Do not rely on `/opt
 | [`E2E_FIX_PROPOSAL.md`](./E2E_FIX_PROPOSAL.md) | Product fix workstreams W1–W7 + PR order |
 | [`OSS_SECURITY_REVIEW.md`](./OSS_SECURITY_REVIEW.md) | Security Criticals/Highs + S1–S10 track |
 | [`E2E_RELEASE_VERIFICATION.md`](./E2E_RELEASE_VERIFICATION.md) | Pre-`v1.0.0` stack redeploy + smoke matrix results |
-| [`RELEASE.md`](./RELEASE.md) | How to cut GitHub Releases (artifacts, tags, checksums) |
-| [`DAILY_RELEASE_AUTOMATION.md`](./DAILY_RELEASE_AUTOMATION.md) | Morning PR triage automation prompt |
+| [`RELEASE.md`](./RELEASE.md) | Cadence + how to cut GitHub Releases (artifacts, tags, checksums) |
+| [`WEEKLY_RELEASE_AUTOMATION.md`](./WEEKLY_RELEASE_AUTOMATION.md) | Saturday 09:00 PT weekly release automation prompt |
+| [`DAILY_RELEASE_AUTOMATION.md`](./DAILY_RELEASE_AUTOMATION.md) | Optional daily PR triage automation prompt |
 
-Product release notes live under [`docs/releases/`](../releases/). Build locally with `./scripts/release/build-artifacts.sh v1.0.0` (output: `release-artifacts/v1.0.0/`).
+Product release notes live under [`docs/releases/`](../releases/). Build locally with `./scripts/release/build-artifacts.sh v1.1.0` (output: `release-artifacts/v1.1.0/`).
 
 Other Cloud Agents: read these paths from the repo (this branch or after merge to `main`).

--- a/docs/oss-ux/RELEASE.md
+++ b/docs/oss-ux/RELEASE.md
@@ -2,16 +2,31 @@
 
 How we cut an official GitHub release with builds, source archives, checksums, and SBOMs.
 
+## Cadence
+
+**Weekly product releases — Saturday 09:00 America/Los_Angeles** (Pacific; PST/PDT).
+
+| Activity | When | Doc |
+|----------|------|-----|
+| Cut GitHub Release from `main` | Sat 09:00 PT | This file + [`WEEKLY_RELEASE_AUTOMATION.md`](./WEEKLY_RELEASE_AUTOMATION.md) |
+| Optional daily PR triage | Daily 09:00 (timezone of choice) | [`DAILY_RELEASE_AUTOMATION.md`](./DAILY_RELEASE_AUTOMATION.md) |
+
+Skip the weekly cut only when `main` has no commits since the latest `v*.*.*` tag, or when tip CI is red.
+
+Cron for the weekly automation: `CRON_TZ=America/Los_Angeles 0 9 * * 6`.
+
 ## Versioning
 
 | Surface | Where | Current |
 |---------|-------|---------|
-| Product / Git tag | `vMAJOR.MINOR.PATCH` | `v1.0.0` |
-| Backend JAR | `backend/pom.xml` `<version>` | `1.0.0` |
+| Product / Git tag | `vMAJOR.MINOR.PATCH` | `v1.1.0` |
+| Backend JAR | `backend/pom.xml` `<version>` | `1.1.0` |
 | Frontend package | root `package.json` | `0.1.0` (internal) |
 | MCP / CLI npm | `mcp/package.json` | `0.27.0` |
 
-Tag the **product** version (`v1.0.0`). Keep backend `pom.xml` in lockstep with the tag for the JAR filename. MCP may continue its own semver when publishing `@deepsql/mcp` to npm.
+Tag the **product** version (`v1.1.0`). Keep backend `pom.xml` in lockstep with the tag for the JAR filename. MCP may continue its own semver when publishing `@deepsql/mcp` to npm.
+
+Default bump for a weekly cut: **MINOR** when user-visible features landed since the last tag; **PATCH** for fixes/docs only; **MAJOR** only for breaking install/API changes.
 
 ## Pre-flight (release manager)
 
@@ -27,20 +42,20 @@ Tag the **product** version (`v1.0.0`). Keep backend `pom.xml` in lockstep with 
 ## Local artifact build
 
 ```bash
-./scripts/release/build-artifacts.sh v1.0.0
-# → release-artifacts/v1.0.0/
+./scripts/release/build-artifacts.sh v1.1.0
+# → release-artifacts/v1.1.0/
 ```
 
 Skip expensive rebuilds when iterating:
 
 ```bash
-SKIP_BACKEND=1 SKIP_FRONTEND=1 ./scripts/release/build-artifacts.sh v1.0.0
+SKIP_BACKEND=1 SKIP_FRONTEND=1 ./scripts/release/build-artifacts.sh v1.1.0
 ```
 
 Verify checksums:
 
 ```bash
-cd release-artifacts/v1.0.0
+cd release-artifacts/v1.1.0
 sha256sum -c SHA256SUMS
 ```
 
@@ -50,8 +65,9 @@ Preferred path (CI):
 
 ```bash
 git checkout main && git pull
-git tag -a v1.0.0 -m "DeepSQL v1.0.0"
-git push origin v1.0.0
+# ensure pom + RELEASE_NOTES-vX.Y.Z.md are already on main
+git tag -a v1.1.0 -m "DeepSQL v1.1.0"
+git push origin v1.1.0
 ```
 
 Pushing the tag runs `.github/workflows/release.yml`, which:
@@ -59,16 +75,16 @@ Pushing the tag runs `.github/workflows/release.yml`, which:
 1. Builds source archives, backend JAR, frontend tarball, MCP pack
 2. Generates CycloneDX SBOMs (best-effort)
 3. Writes `SHA256SUMS` / `SHA512SUMS` + `manifest.json`
-4. Creates a GitHub Release (non-draft) attaching every file under `release-artifacts/v1.0.0/`
+4. Creates a GitHub Release (non-draft) attaching every file under `release-artifacts/v1.1.0/`
 
 Manual fallback (if Actions cannot publish):
 
 ```bash
-./scripts/release/build-artifacts.sh v1.0.0
-gh release create v1.0.0 \
-  --title "DeepSQL v1.0.0" \
-  --notes-file docs/releases/RELEASE_NOTES-v1.0.0.md \
-  release-artifacts/v1.0.0/*
+./scripts/release/build-artifacts.sh v1.1.0
+gh release create v1.1.0 \
+  --title "DeepSQL v1.1.0" \
+  --notes-file docs/releases/RELEASE_NOTES-v1.1.0.md \
+  release-artifacts/v1.1.0/*
 ```
 
 ## Artifact set (what “industry standard” means here)

--- a/docs/oss-ux/WEEKLY_RELEASE_AUTOMATION.md
+++ b/docs/oss-ux/WEEKLY_RELEASE_AUTOMATION.md
@@ -1,0 +1,74 @@
+# Weekly release automation (Saturday 9 AM PT)
+
+Product releases are a **weekly** activity. Cursor Automations cannot be created via MCP/API from a Cloud Agent — create this once in the UI.
+
+## Cadence
+
+| Intent | Cron |
+|--------|------|
+| **Canonical** — Saturday 09:00 America/Los_Angeles | `CRON_TZ=America/Los_Angeles 0 9 * * 6` |
+
+America/Los_Angeles observes PST/PDT; “9 AM PST” in planning means **09:00 Pacific** (this cron).
+
+Related (optional): daily PR triage remains in [`DAILY_RELEASE_AUTOMATION.md`](./DAILY_RELEASE_AUTOMATION.md). The Saturday run owns **cutting the release**.
+
+## Create
+
+1. Open https://cursor.com/automations/new (or Agents Window → Create automation).
+2. **Name:** DeepSQL weekly release (Sat 9 AM PT)
+3. **Trigger:** Scheduled → cron → `CRON_TZ=America/Los_Angeles 0 9 * * 6`
+4. **Repository:** DeepSQLAI/deepsql (required — scheduled automations default to no repo).
+5. **Tools:** enable repo git tools, **Comment on Pull Request**, and whatever is needed to open PRs / push tags in your plan. Prefer the Cloud Agent path that can push to the repo.
+6. Paste the prompt below.
+7. Activate; run once manually the first Saturday (or trigger manually) to verify.
+
+## Identity note
+
+Built-in GitHub comments from automations post as the **`cursor`** GitHub app identity. Write release notes and PR text as a human release manager — never say “bot / automation / Cursor” in GitHub comment bodies.
+
+## Prompt (paste as-is)
+
+```text
+You are the release manager for DeepSQL OSS (DeepSQLAI/deepsql). This is the WEEKLY release run (Saturday 09:00 America/Los_Angeles).
+
+## Goal
+Cut the next product GitHub Release from `main` if there is anything to ship since the latest `v*.*.*` tag. Follow docs/oss-ux/RELEASE.md.
+
+## Scope
+- Work only in this repository.
+- Durable process docs: docs/oss-ux/RELEASE.md, docs/oss-ux/WEEKLY_RELEASE_AUTOMATION.md, docs/oss-ux/OSS_SECURITY_REVIEW.md.
+
+## Steps
+1. `git fetch --tags origin` and identify the latest product tag (vMAJOR.MINOR.PATCH) and `origin/main` tip.
+2. If `main` has no commits since that tag: stop. Comment nothing on GitHub; summarize “no release this week” in the run summary.
+3. If `main` CI is red on the tip commit: stop. Leave a short release-manager note on the most relevant open PR or as a run summary listing the failing checks. Do not tag.
+4. Decide the next version:
+   - PATCH if only fixes/docs/chores
+   - MINOR if user-visible features landed (default when unsure and features exist)
+   - MAJOR only for breaking install/API changes called out explicitly
+5. Create a short-lived branch `cursor/weekly-release-vX.Y.Z-…` from `origin/main`:
+   - Bump `backend/pom.xml` project `<version>` to X.Y.Z (must match the tag for the JAR name).
+   - Append CHANGELOG.md Keep-a-Changelog section for [X.Y.Z].
+   - Add docs/releases/RELEASE_NOTES-vX.Y.Z.md (highlights, upgrade notes, artifact table).
+   - Update the Versioning table in docs/oss-ux/RELEASE.md “Current” column.
+6. Pre-flight on a running stack when available (docs/oss-ux/RELEASE.md): login, e2e-agent-check.py → AGENT_OK + DASH_OK, quick security smoke. If the stack cannot be brought up, say so and still prepare the docs/version PR but do not push the tag until smoke is green.
+7. Open a PR into `main`, get CI green, merge (or ask @venkateshsakamuri-lab to merge if you lack rights).
+8. On the merged `main` commit: annotated tag `vX.Y.Z` and `git push origin vX.Y.Z`. Tag push runs `.github/workflows/release.yml` which builds artifacts and creates the GitHub Release.
+9. Confirm the Release page exists and assets uploaded. If Actions fails, fall back to `./scripts/release/build-artifacts.sh vX.Y.Z` + `gh release create` per RELEASE.md.
+10. Optionally triage leftover open PRs (same standards as the daily triage prompt) after the release is published.
+
+## Versioning reminders
+- Product tag and backend pom stay in lockstep.
+- MCP npm (`mcp/package.json`) has its own semver — only bump/publish when MCP/CLI changed.
+- Do not put release artifacts under Vite `dist/`.
+
+## Comment style
+- Write as a normal release manager. Never mention bot / AI / Cursor / automation in GitHub text.
+- One clear summary when useful (version, commit range, Release URL).
+
+## Output (run summary)
+- Previous tag → new tag (or “skipped: no changes / CI red”)
+- PR URL and Release URL
+- Smoke results
+- Follow-ups for Venkat
+```

--- a/docs/releases/RELEASE_NOTES-v1.1.0.md
+++ b/docs/releases/RELEASE_NOTES-v1.1.0.md
@@ -1,0 +1,60 @@
+# DeepSQL v1.1.0
+
+**Weekly product cut** — dashboards, multi-schema UX, and Performance consolidation on top of `v1.0.0`.
+
+## Highlights
+
+- **Progressive dashboards** — builds stream a shell, then widgets; clone, folders/favorites, version history, refresh/TV kiosk, and AI-evaluated alerts.
+- **Server-owned dashboard chat** — generation turns persist even if the SSE client disconnects; concurrent turns are rejected safely.
+- **Multi-schema UI** — Editor, Brain, and Advisor surfaces treat non-`public` Postgres schemas as first-class.
+- **Performance hub** — Slow Queries and Workload Analysis live in one Performance area.
+- **CI unblock** — CodeQL visibility guard that blocked merges is removed.
+
+## Install / upgrade
+
+```bash
+git clone https://github.com/DeepSQLAI/deepsql.git
+cd deepsql
+git checkout v1.1.0
+cp .env.example .env
+# set SECURITY_JWT_SECRET, ENCRYPTION_KEY (or ENCRYPTION_KEYS), and DEEPSQL_CHAT_* in .env
+docker compose up --build -d
+```
+
+From `v1.0.0`: pull/checkout `v1.1.0`, rebuild Compose (or swap JAR + frontend tarball from this Release), and apply hand SQL for dashboard tables if you are not relying on `ddl-auto=update`:
+
+- `V111` / `V112` — `generation_status`, optimistic `version` on `saved_dashboards`
+- `V113` — `dashboard_versions`
+- `V114` — `dashboard_alerts`
+
+(No Flyway runtime — see `CLAUDE.md`.)
+
+Air-gapped: download artifacts below, verify `SHA256SUMS`, follow `docs/oss-ux/RELEASE.md`.
+
+## Artifacts in this release
+
+| File | Contents |
+|------|----------|
+| `deepsql-1.1.0-source.tar.gz` / `.zip` | Source tree at this tag |
+| `dba-agent-backend-1.1.0.jar` | Spring Boot executable |
+| `deepsql-frontend-1.1.0.tar.gz` | Production static UI |
+| `deepsql-mcp-0.27.0.tgz` | CLI + MCP server package (unchanged npm line) |
+| `sbom-*.cdx.json` | CycloneDX SBOMs |
+| `SHA256SUMS` / `SHA512SUMS` | Integrity hashes |
+| `manifest.json` | Machine-readable inventory |
+
+```bash
+sha256sum -c SHA256SUMS
+```
+
+## Verify
+
+```bash
+python3 scripts/self-host/e2e-agent-check.py
+```
+
+Expect `AGENT_OK True` and `DASH_OK True`.
+
+## Cadence
+
+Product releases are cut **weekly, Saturday 09:00 America/Los_Angeles**. See `docs/oss-ux/RELEASE.md` and `docs/oss-ux/WEEKLY_RELEASE_AUTOMATION.md`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prepares and documents the **v1.1.0** product cut from `main` since `v1.0.0`, and locks in a **weekly release cadence: Saturday 09:00 America/Los_Angeles**.

### Since v1.0.0
- Progressive dashboards (#57), dashboard improvements (#51)
- Multi-schema UI (#55), Performance hub (#52)
- CI CodeQL unblock (#56), cloud env caveats (#53)

### This PR
- Bump `backend/pom.xml` → `1.1.0`
- `CHANGELOG.md` + `docs/releases/RELEASE_NOTES-v1.1.0.md`
- Cadence in `docs/oss-ux/RELEASE.md`
- New `docs/oss-ux/WEEKLY_RELEASE_AUTOMATION.md` (cron + paste-ready prompt)
- Daily triage doc clarified as optional (not the release cut)

### After merge
1. Tag `v1.1.0` on the merge commit and push → `.github/workflows/release.yml` publishes the GitHub Release.
2. Create the Cursor Automation once from `WEEKLY_RELEASE_AUTOMATION.md` (cannot be created via API).

### Pre-flight
`scripts/self-host/e2e-agent-check.py` → `AGENT_OK True`, `DASH_OK True` on the current stack before this bump.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ce91e70-c67b-48c6-84b3-05bb9d06231a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ce91e70-c67b-48c6-84b3-05bb9d06231a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

