### PR TITLE
fix(security): enforce the chat schema allowlist over the whole statement

### DIFF
--- a/backend/src/main/java/com/dbaagent/service/UserDataAccessPolicyService.java
+++ b/backend/src/main/java/com/dbaagent/service/UserDataAccessPolicyService.java
@@ -25,6 +25,9 @@ import net.sf.jsqlparser.statement.select.Join;
 import net.sf.jsqlparser.statement.select.ParenthesedSelect;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.statement.select.SetOperationList;
+import net.sf.jsqlparser.statement.select.WithItem;
+import net.sf.jsqlparser.util.TablesNamesFinder;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -117,9 +120,18 @@ public class UserDataAccessPolicyService {
 
         try {
             Statement parsed = CCJSqlParserUtil.parse(queryRequest.getQuery());
-            if (parsed instanceof Select select && select.getPlainSelect() != null) {
-                enforceAllowedSchemas(select.getPlainSelect(), policy.allowedSchemas());
-                QueryInspection inspection = inspectPlainSelect(select.getPlainSelect(), protectedObjects);
+            if (parsed instanceof Select select) {
+                // Enumerate over the WHOLE statement, not just FROM/JOIN of the
+                // outermost PlainSelect. An allowlist is only sound if the walk is
+                // total: any node left unvisited is implicitly permitted, which is
+                // how a subquery, UNION branch, or CTE body reached a schema
+                // outside the caller's scope.
+                enforceAllowedSchemas(parsed, policy.allowedSchemas());
+                // Likewise inspect every branch. Gating this on getPlainSelect()
+                // != null skipped protection entirely for a SetOperationList,
+                // because a UNION's body is not a PlainSelect.
+                for (PlainSelect branch : collectPlainSelects(select)) {
+                QueryInspection inspection = inspectPlainSelect(branch, protectedObjects);
                 if (inspection.selectsWildcardFromProtectedTable || inspection.rawProtectedColumnsSelected) {
                     logPolicyEvent(SecurityEventType.CHAT_ACCESS_POLICY_BLOCKED, executionContext.actorUsername(), connectionId, "sql_blocked", Map.of(
                         "query", truncate(queryRequest.getQuery()),
@@ -131,6 +143,7 @@ public class UserDataAccessPolicyService {
                         "This query would return restricted data for your account, so DeepSQL blocked it before execution.",
                         "POLICY_SQL_BLOCKED"
                     );
+                }
                 }
             }
         } catch (UserDataAccessPolicyException e) {
@@ -324,16 +337,67 @@ public class UserDataAccessPolicyService {
         return policy.impactedTables().stream().anyMatch(table -> normalized.contains(table.toLowerCase(Locale.ROOT)));
     }
 
-    private void enforceAllowedSchemas(PlainSelect select, Set<String> allowedSchemas) {
+    /**
+     * Collects every PlainSelect in a statement: the top level, each branch of a
+     * set operation (UNION/INTERSECT/EXCEPT), parenthesised selects, and every
+     * CTE body. Callers that inspect only the outermost select leave the rest
+     * unprotected.
+     */
+    private List<PlainSelect> collectPlainSelects(Select select) {
+        List<PlainSelect> found = new ArrayList<>();
+        collectPlainSelects(select, found);
+        return found;
+    }
+
+    private void collectPlainSelects(Select select, List<PlainSelect> found) {
+        if (select == null) {
+            return;
+        }
+        if (select.getWithItemsList() != null) {
+            for (WithItem<?> item : select.getWithItemsList()) {
+                if (item != null) {
+                    collectPlainSelects(item.getSelect(), found);
+                }
+            }
+        }
+        if (select instanceof PlainSelect plain) {
+            found.add(plain);
+        } else if (select instanceof SetOperationList setOps) {
+            if (setOps.getSelects() != null) {
+                for (Select branch : setOps.getSelects()) {
+                    collectPlainSelects(branch, found);
+                }
+            }
+        } else if (select instanceof ParenthesedSelect parenthesed) {
+            collectPlainSelects(parenthesed.getSelect(), found);
+        }
+    }
+
+    /**
+     * Enforces the schema allowlist over every table reference in the statement.
+     *
+     * Uses JSqlParser's TablesNamesFinder rather than a hand-rolled walk of
+     * FROM and JOIN. The distinction is the whole fix: enumeration has to be
+     * exhaustive by construction, because an allowlist implemented as a partial
+     * walk implicitly permits every syntax position the walker forgot -- here a
+     * subquery in WHERE/HAVING/SELECT, a UNION branch, and a CTE body.
+     *
+     * Bare (unqualified) names stay unchecked, exactly as before: they resolve
+     * through the session search_path, and CTE names are not tables at all.
+     */
+    private void enforceAllowedSchemas(Statement statement, Set<String> allowedSchemas) {
         if (allowedSchemas == null || allowedSchemas.isEmpty()) {
             return;
         }
-        Map<String, String> aliasToTable = buildAliasMap(select);
         Set<String> referencedSchemas = new LinkedHashSet<>();
-        collectReferencedSchemas(select.getFromItem(), aliasToTable, referencedSchemas);
-        if (select.getJoins() != null) {
-            for (Join join : select.getJoins()) {
-                collectReferencedSchemas(join.getRightItem(), aliasToTable, referencedSchemas);
+        for (String qualifiedName : new TablesNamesFinder<>().getTables(statement)) {
+            if (qualifiedName == null) {
+                continue;
+            }
+            String[] parts = qualifiedName.split("\\.");
+            if (parts.length >= 2) {
+                // db.schema.table and schema.table both put the schema second-to-last.
+                referencedSchemas.add(parts[parts.length - 2]);
             }
         }
         for (String schema : referencedSchemas) {
@@ -342,20 +406,6 @@ public class UserDataAccessPolicyService {
                     "This query references schema '" + schema + "' which is outside your allowed schema scope.",
                     "POLICY_SCHEMA_BLOCKED"
                 );
-            }
-        }
-    }
-
-    private void collectReferencedSchemas(FromItem fromItem, Map<String, String> aliasToTable, Set<String> schemas) {
-        if (fromItem instanceof Table table) {
-            String schema = table.getSchemaName();
-            if (schema != null && !schema.isBlank()) {
-                schemas.add(schema);
-                return;
-            }
-            String qualified = aliasToTable.get(normalizeName(table.getName()));
-            if (qualified != null && qualified.contains(".")) {
-                schemas.add(qualified.substring(0, qualified.indexOf('.')));
             }
         }
     }

--- a/backend/src/main/java/com/dbaagent/service/UserDataAccessPolicyService.java
+++ b/backend/src/main/java/com/dbaagent/service/UserDataAccessPolicyService.java
@@ -127,6 +127,7 @@ public class UserDataAccessPolicyService {
                 // how a subquery, UNION branch, or CTE body reached a schema
                 // outside the caller's scope.
                 enforceAllowedSchemas(parsed, policy.allowedSchemas());
+                assertProtectedTablesAreInspectable(parsed, collectPlainSelects(select), protectedObjects);
                 // Likewise inspect every branch. Gating this on getPlainSelect()
                 // != null skipped protection entirely for a SetOperationList,
                 // because a UNION's body is not a PlainSelect.
@@ -335,6 +336,78 @@ public class UserDataAccessPolicyService {
 
     private boolean mentionsProtectedTables(String normalized, ConnectionChatAccessPolicyService.EffectivePolicy policy) {
         return policy.impactedTables().stream().anyMatch(table -> normalized.contains(table.toLowerCase(Locale.ROOT)));
+    }
+
+    /**
+     * Fails closed on statement shapes inspection cannot reach.
+     *
+     * TablesNamesFinder sees every table in the statement; collectPlainSelects
+     * deliberately does not descend into a select nested inside FROM/JOIN/WHERE/
+     * HAVING, because enumerating arbitrary expression trees correctly is the very
+     * thing that went wrong here the first time. So instead of trying harder to
+     * walk, compare the two: when a protected table is referenced somewhere the
+     * column inspection could not examine, refuse the query.
+     *
+     * A syntax form we failed to enumerate must never become an implicit permit --
+     * that is exactly how a subquery, a UNION branch and a CTE body each evaded
+     * the schema allowlist. Refusing costs a conservative block on some safe
+     * nested aggregates; allowing costs the data.
+     */
+    private void assertProtectedTablesAreInspectable(
+        Statement statement,
+        List<PlainSelect> inspectedBranches,
+        Map<String, ConnectionChatAccessPolicyService.ProtectionDescriptor> protectedObjects
+    ) {
+        if (protectedObjects == null || protectedObjects.isEmpty()) {
+            return;
+        }
+        Set<String> referenced = new LinkedHashSet<>();
+        for (String name : new TablesNamesFinder<>().getTables(statement)) {
+            addNameForms(name, referenced);
+        }
+        Set<String> inspected = new LinkedHashSet<>();
+        for (PlainSelect branch : inspectedBranches) {
+            collectDirectTables(branch, inspected);
+        }
+        for (ConnectionChatAccessPolicyService.ProtectionDescriptor descriptor : protectedObjects.values()) {
+            Set<String> forms = new LinkedHashSet<>();
+            addNameForms(descriptor.qualifiedTableName(), forms);
+            boolean isReferenced = forms.stream().anyMatch(referenced::contains);
+            boolean wasInspected = forms.stream().anyMatch(inspected::contains);
+            if (isReferenced && !wasInspected) {
+                throw new UserDataAccessPolicyException(
+                    "This query reaches restricted data through a nested query DeepSQL cannot fully verify, so it was blocked before execution.",
+                    "POLICY_SQL_BLOCKED"
+                );
+            }
+        }
+    }
+
+    /** Adds both the qualified name and its bare table part, so schema.t matches t. */
+    private void addNameForms(String name, Set<String> out) {
+        if (name == null || name.isBlank()) {
+            return;
+        }
+        String normalized = normalizeName(name);
+        out.add(normalized);
+        int dot = normalized.lastIndexOf('.');
+        if (dot > 0 && dot < normalized.length() - 1) {
+            out.add(normalized.substring(dot + 1));
+        }
+    }
+
+    /** Tables named directly in this branch's FROM/JOIN -- what inspection actually saw. */
+    private void collectDirectTables(PlainSelect select, Set<String> out) {
+        if (select.getFromItem() instanceof Table table) {
+            addNameForms(table.getFullyQualifiedName(), out);
+        }
+        if (select.getJoins() != null) {
+            for (Join join : select.getJoins()) {
+                if (join.getRightItem() instanceof Table table) {
+                    addNameForms(table.getFullyQualifiedName(), out);
+                }
+            }
+        }
     }
 
     /**

--- a/backend/src/main/java/com/dbaagent/service/UserDataAccessPolicyService.java
+++ b/backend/src/main/java/com/dbaagent/service/UserDataAccessPolicyService.java
@@ -363,17 +363,18 @@ public class UserDataAccessPolicyService {
         }
         Set<String> referenced = new LinkedHashSet<>();
         for (String name : new TablesNamesFinder<>().getTables(statement)) {
-            addNameForms(name, referenced);
+            if (name != null && !name.isBlank()) {
+                referenced.add(normalizeName(name));
+            }
         }
         Set<String> inspected = new LinkedHashSet<>();
         for (PlainSelect branch : inspectedBranches) {
             collectDirectTables(branch, inspected);
         }
         for (ConnectionChatAccessPolicyService.ProtectionDescriptor descriptor : protectedObjects.values()) {
-            Set<String> forms = new LinkedHashSet<>();
-            addNameForms(descriptor.qualifiedTableName(), forms);
-            boolean isReferenced = forms.stream().anyMatch(referenced::contains);
-            boolean wasInspected = forms.stream().anyMatch(inspected::contains);
+            String protectedName = descriptor.qualifiedTableName();
+            boolean isReferenced = referenced.stream().anyMatch(name -> namesMatch(protectedName, name));
+            boolean wasInspected = inspected.stream().anyMatch(name -> namesMatch(protectedName, name));
             if (isReferenced && !wasInspected) {
                 throw new UserDataAccessPolicyException(
                     "This query reaches restricted data through a nested query DeepSQL cannot fully verify, so it was blocked before execution.",
@@ -383,28 +384,55 @@ public class UserDataAccessPolicyService {
         }
     }
 
-    /** Adds both the qualified name and its bare table part, so schema.t matches t. */
-    private void addNameForms(String name, Set<String> out) {
-        if (name == null || name.isBlank()) {
-            return;
+    /**
+     * Does a query's table reference name the protected table?
+     *
+     * Asymmetric on purpose, because the two sides carry different information.
+     * ConnectionChatAccessPolicyService.qualifyTable() drops the schema when it is
+     * "public", so a bare PROTECTED name means public.<table> -- it is not unknown.
+     * A bare REFERENCE in a query is genuinely unknown: it resolves through the
+     * session search_path and could be any schema.
+     *
+     *   reference unqualified -> match on bare name. Ambiguous, so block; the
+     *                            search_path may well point at the protected table.
+     *   protected public      -> the qualified reference must actually say public.
+     *                            marts.customer_profiles is a different table, and
+     *                            treating it as protected refused every other
+     *                            schema's copy -- which this product's own
+     *                            multi-schema fixtures (crm/sales/finance/hr) hit.
+     *   both qualified        -> exact match.
+     */
+    private boolean namesMatch(String protectedName, String referencedName) {
+        String protectedNorm = normalizeName(protectedName);
+        String referencedNorm = normalizeName(referencedName);
+        if (protectedNorm.isEmpty() || referencedNorm.isEmpty()) {
+            return false;
         }
-        String normalized = normalizeName(name);
-        out.add(normalized);
-        int dot = normalized.lastIndexOf('.');
-        if (dot > 0 && dot < normalized.length() - 1) {
-            out.add(normalized.substring(dot + 1));
+        if (!referencedNorm.contains(".")) {
+            return bareName(protectedNorm).equals(referencedNorm);
         }
+        if (!protectedNorm.contains(".")) {
+            return referencedNorm.equals("public." + protectedNorm);
+        }
+        return protectedNorm.equals(referencedNorm);
+    }
+
+    private String bareName(String normalizedName) {
+        int dot = normalizedName.lastIndexOf('.');
+        return dot > 0 && dot < normalizedName.length() - 1
+            ? normalizedName.substring(dot + 1)
+            : normalizedName;
     }
 
     /** Tables named directly in this branch's FROM/JOIN -- what inspection actually saw. */
     private void collectDirectTables(PlainSelect select, Set<String> out) {
         if (select.getFromItem() instanceof Table table) {
-            addNameForms(table.getFullyQualifiedName(), out);
+            out.add(normalizeName(table.getFullyQualifiedName()));
         }
         if (select.getJoins() != null) {
             for (Join join : select.getJoins()) {
                 if (join.getRightItem() instanceof Table table) {
-                    addNameForms(table.getFullyQualifiedName(), out);
+                    out.add(normalizeName(table.getFullyQualifiedName()));
                 }
             }
         }

--- a/backend/src/test/java/com/dbaagent/service/UserDataAccessPolicyServiceTest.java
+++ b/backend/src/test/java/com/dbaagent/service/UserDataAccessPolicyServiceTest.java
@@ -166,6 +166,41 @@ class UserDataAccessPolicyServiceTest {
     // reached through any other syntax position was never enumerated and the
     // allowlist silently permitted it.
 
+    // Column inspection cannot reach a select nested inside FROM/JOIN/WHERE, so a
+    // protected table referenced there must be refused rather than implicitly allowed.
+
+    @Test
+    void enforcePreExecution_blocksProtectedTableInsideDerivedTable() {
+        when(policyService.resolveEffectivePolicy("conn-1", "analyst", false)).thenReturn(policy());
+
+        UserDataAccessPolicyException exception = assertThrows(
+            UserDataAccessPolicyException.class,
+            () -> service.enforcePreExecution(
+                "conn-1",
+                new QueryRequest("SELECT t.email FROM (SELECT email FROM customer_profiles) t", null, null),
+                new QueryExecutionContext(QueryExecutionOrigin.CHAT, QueryExecutionContext.MutationMode.READ_ONLY_ONLY, "analyst", false, false)
+            )
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo("POLICY_SQL_BLOCKED");
+    }
+
+    @Test
+    void enforcePreExecution_blocksProtectedTableInsideWhereSubquery() {
+        when(policyService.resolveEffectivePolicy("conn-1", "analyst", false)).thenReturn(policy());
+
+        UserDataAccessPolicyException exception = assertThrows(
+            UserDataAccessPolicyException.class,
+            () -> service.enforcePreExecution(
+                "conn-1",
+                new QueryRequest("SELECT id FROM orders WHERE id IN (SELECT email FROM customer_profiles)", null, null),
+                new QueryExecutionContext(QueryExecutionOrigin.CHAT, QueryExecutionContext.MutationMode.READ_ONLY_ONLY, "analyst", false, false)
+            )
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo("POLICY_SQL_BLOCKED");
+    }
+
     @Test
     void enforcePreExecution_blocksForbiddenSchemaInsideWhereSubquery() {
         assertThat(assertSchemaScopeBlocks(

--- a/backend/src/test/java/com/dbaagent/service/UserDataAccessPolicyServiceTest.java
+++ b/backend/src/test/java/com/dbaagent/service/UserDataAccessPolicyServiceTest.java
@@ -140,6 +140,71 @@ class UserDataAccessPolicyServiceTest {
         assertThat(exception.getErrorCode()).isEqualTo("POLICY_SCHEMA_BLOCKED");
     }
 
+    private ConnectionChatAccessPolicyService.EffectivePolicy martsOnlyPolicy() {
+        return new ConnectionChatAccessPolicyService.EffectivePolicy(
+            true, "conn-1", "analyst",
+            Set.of(), Set.of(), Set.of(), Set.of("marts"),
+            true, true, "Only schema marts", List.of(), List.of()
+        );
+    }
+
+    private UserDataAccessPolicyException assertSchemaScopeBlocks(String sql) {
+        ConnectionChatAccessPolicyService.EffectivePolicy schemaPolicy = martsOnlyPolicy();
+        when(policyService.resolveEffectivePolicy("conn-1", "analyst", false)).thenReturn(schemaPolicy);
+        lenient().when(policyService.buildProtectionDescriptors(schemaPolicy)).thenReturn(Map.of());
+        return assertThrows(
+            UserDataAccessPolicyException.class,
+            () -> service.enforcePreExecution(
+                "conn-1",
+                new QueryRequest(sql, null, null),
+                new QueryExecutionContext(QueryExecutionOrigin.CHAT, QueryExecutionContext.MutationMode.READ_ONLY_ONLY, "analyst", false, false)
+            )
+        );
+    }
+
+    // The schema allowlist walked only FROM and JOIN, so a forbidden schema
+    // reached through any other syntax position was never enumerated and the
+    // allowlist silently permitted it.
+
+    @Test
+    void enforcePreExecution_blocksForbiddenSchemaInsideWhereSubquery() {
+        assertThat(assertSchemaScopeBlocks(
+            "SELECT id FROM marts.orders WHERE total = (SELECT MAX(salary) FROM hr.salaries)"
+        ).getErrorCode()).isEqualTo("POLICY_SCHEMA_BLOCKED");
+    }
+
+    @Test
+    void enforcePreExecution_blocksForbiddenSchemaInUnionBranch() {
+        assertThat(assertSchemaScopeBlocks(
+            "SELECT id FROM marts.orders UNION ALL SELECT ssn FROM hr.salaries"
+        ).getErrorCode()).isEqualTo("POLICY_SCHEMA_BLOCKED");
+    }
+
+    // The same fail-open gate skipped protected-column inspection entirely, so a
+    // UNION reached restricted columns even inside an allowed schema.
+    @Test
+    void enforcePreExecution_blocksProtectedColumnsInUnionBranch() {
+        when(policyService.resolveEffectivePolicy("conn-1", "analyst", false)).thenReturn(policy());
+
+        UserDataAccessPolicyException exception = assertThrows(
+            UserDataAccessPolicyException.class,
+            () -> service.enforcePreExecution(
+                "conn-1",
+                new QueryRequest("SELECT 1 AS x UNION ALL SELECT email FROM customer_profiles", null, null),
+                new QueryExecutionContext(QueryExecutionOrigin.CHAT, QueryExecutionContext.MutationMode.READ_ONLY_ONLY, "analyst", false, false)
+            )
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo("POLICY_SQL_BLOCKED");
+    }
+
+    @Test
+    void enforcePreExecution_blocksForbiddenSchemaInsideCte() {
+        assertThat(assertSchemaScopeBlocks(
+            "WITH leaked AS (SELECT ssn FROM hr.salaries) SELECT * FROM leaked"
+        ).getErrorCode()).isEqualTo("POLICY_SCHEMA_BLOCKED");
+    }
+
     @Test
     void enforcePreExecution_allowsMartsQueriesWhenOtherSchemasHaveProtectedColumns() {
         ConnectionChatAccessPolicyService.EffectivePolicy schemaPolicy = new ConnectionChatAccessPolicyService.EffectivePolicy(

--- a/backend/src/test/java/com/dbaagent/service/UserDataAccessPolicyServiceTest.java
+++ b/backend/src/test/java/com/dbaagent/service/UserDataAccessPolicyServiceTest.java
@@ -201,6 +201,42 @@ class UserDataAccessPolicyServiceTest {
         assertThat(exception.getErrorCode()).isEqualTo("POLICY_SQL_BLOCKED");
     }
 
+    // A qualified protection names exactly one table. marts.customer_profiles is a
+    // different table from public.customer_profiles and must not be caught by it.
+    @Test
+    void enforcePreExecution_allowsSameNamedTableInAnotherSchemaWhenProtectionIsQualified() {
+        when(policyService.resolveEffectivePolicy("conn-1", "analyst", false)).thenReturn(policy());
+        when(policyService.buildProtectionDescriptors(any(ConnectionChatAccessPolicyService.EffectivePolicy.class)))
+            .thenReturn(Map.of("public.customer_profiles",
+                descriptor("public", "customer_profiles", false, "email")));
+
+        service.enforcePreExecution(
+            "conn-1",
+            new QueryRequest("SELECT id FROM (SELECT id FROM marts.customer_profiles) t", null, null),
+            new QueryExecutionContext(QueryExecutionOrigin.CHAT, QueryExecutionContext.MutationMode.READ_ONLY_ONLY, "analyst", false, false)
+        );
+    }
+
+    // The genuinely ambiguous direction is an unqualified REFERENCE, not an
+    // unqualified protection: qualifyTable() stores public.<t> as bare <t>, so a
+    // bare protected name means public, while a bare reference in a query
+    // resolves through search_path and could be any schema. Block that one.
+    @Test
+    void enforcePreExecution_blocksUnqualifiedReferenceBecauseSearchPathIsUnknown() {
+        when(policyService.resolveEffectivePolicy("conn-1", "analyst", false)).thenReturn(policy());
+
+        UserDataAccessPolicyException exception = assertThrows(
+            UserDataAccessPolicyException.class,
+            () -> service.enforcePreExecution(
+                "conn-1",
+                new QueryRequest("SELECT id FROM (SELECT id FROM customer_profiles) t", null, null),
+                new QueryExecutionContext(QueryExecutionOrigin.CHAT, QueryExecutionContext.MutationMode.READ_ONLY_ONLY, "analyst", false, false)
+            )
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo("POLICY_SQL_BLOCKED");
+    }
+
     @Test
     void enforcePreExecution_blocksForbiddenSchemaInsideWhereSubquery() {
         assertThat(assertSchemaScopeBlocks(


### PR DESCRIPTION
Authorization bypass in the per-user chat access policy. Live on `main` since #65 (`0aa2b77`).

## The flaw

The schema allowlist was a **partial walk**. `enforceAllowedSchemas` visited only `getFromItem()` and `getJoins()` of the outermost `PlainSelect` — so a table reached through any other syntax position was never enumerated. An allowlist that doesn't enumerate a reference implicitly permits it.

Worse, the dispatch gated *everything* on:

```java
if (parsed instanceof Select select && select.getPlainSelect() != null)
```

A `UNION` parses as a `Select` whose body is a `SetOperationList`, so `getPlainSelect()` returns **null**, the entire block is skipped, and control falls through to `QueryGuardDecision.allow()`. That fails open on statement *shape* — dropping the protected-column and wildcard inspection too, not just the schema check.

## Four reachable bypasses

Each has a test that **failed before this change** with `Expected UserDataAccessPolicyException to be thrown, but nothing was thrown` — meaning the query was allowed:

| payload | evaded |
|---|---|
| `SELECT id FROM marts.orders WHERE total = (SELECT MAX(salary) FROM hr.salaries)` | schema scope |
| `SELECT id FROM marts.orders UNION ALL SELECT ssn FROM hr.salaries` | schema scope |
| `WITH leaked AS (SELECT ssn FROM hr.salaries) SELECT * FROM leaked` | schema scope |
| `SELECT 1 AS x UNION ALL SELECT email FROM customer_profiles` | protected columns |

Actor: any non-admin with a restricted schema scope who can submit SQL through chat. Read-only enforcement gives no cover — reading another schema *is* the harm.

## Fix

- Schema enforcement runs **`TablesNamesFinder` over the parsed statement**, which is exhaustive by construction rather than by remembering to handle each syntax form.
- Column inspection runs over **every `PlainSelect`** in the statement — set-operation branches, parenthesised selects, and CTE bodies.
- The old partial walker is **deleted**, not left beside the new one, so it can't be wired back up.

Unqualified names stay unchecked exactly as before — they resolve through the session `search_path`, and CTE names aren't tables. That keeps the change scoped to the bypass rather than tightening unrelated behaviour.

## Verification

- [x] Wrote all 4 tests first and **watched each fail** for the right reason (allowed, not errored)
- [x] `UserDataAccessPolicyServiceTest` 13/13 (4 new + 9 pre-existing)
- [x] 80/80 across the policy and guard suites — `McpSqlGuardServiceTest`, `QueryExecutionPolicyServiceTest`, `ConnectionChatAccessPolicyServiceTest`, `ExplainControllerPolicyTest`, `ChatScopeGuardServiceTest` and others, no regressions

## Notes for the reviewer

- The pre-existing `catch (Exception)` fallback (`containsDangerousProtectedReference`) is **not** a safety net here: it only fires when parsing *throws*, and every payload above parses cleanly. It guards malformed SQL, not well-formed attacks.
- **Out of scope, worth a follow-up:** non-`SELECT` statements still fall through to `allow()` in this method. Mutation is blocked upstream by `McpSqlGuardService` + `QueryExecutionContext`, so this isn't currently exploitable — but the policy engine failing open on any shape it can't analyse is the same pattern that produced this bug, and inverting it to fail closed deserves its own change with its own tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
