### PR TITLE
fix: View as Agent must enforce the target user's data policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,7 +210,13 @@ returns a number).
 5. **Design**: Minimal black/white/grey palette, Inter font, subtle transitions. See UX guidelines in full CLAUDE.md.
 
 ### Admin profile switch
-Admins can **View as** a sub-user from the top-right of the home layout (`ProfileSwitch`) to verify connection ACLs, chat/editor policies, and role-gated nav. The admin JWT stays on the session; `ImpersonationService` sets an httpOnly `impersonate_user` cookie and `JwtAuthenticationFilter` overlays the target principal. `POST|DELETE|GET /api/admin/impersonate` are excluded from the overlay so stop/list still run as the real admin. Cannot target another ADMIN, self, or a non-ACTIVE account. `/auth/me` returns the **effective** user plus `impersonating` / `impersonatorUsername`.
+Admins can **View as** a sub-user from the top-right of the home layout (`ProfileSwitch`) to verify connection ACLs, chat/editor policies, and role-gated nav.
+
+The admin JWT **subject** stays the administrator so logout, refresh, and `/admin/impersonate` still own the real session. Policy identity is the target: an httpOnly `impersonate_user` cookie plus an `impUid` claim on the access token. `JwtAuthenticationFilter` overlays that principal onto the SecurityContext for every request except the impersonation control plane, logout, and session refresh. Chat, Editor, schema listing, and Agent MCP calls then run `AccessControlService` / `ConnectionChatAccessPolicyService` as the target (`actorIsAdmin` is false, so policies apply).
+
+The Agent tab must not inherit the admin MCP token. `/api/agent/session` mints an MCP token for the effective user and never falls back to the admin session JWT while View as is active. nginx `auth_request` on `/agent-api` forwards `/api/auth/me`'s `X-Remote-User` (the overlaid username) instead of hardcoding `admin`.
+
+`POST|DELETE|GET /api/admin/impersonate` are excluded from the overlay so stop/list still run as the real admin. Cannot target another ADMIN, self, or a non-ACTIVE account. `/auth/me` returns the **effective** user plus `impersonating` / `impersonatorUsername`.
 
 ### Git Rules
 - Do NOT commit automatically — wait for explicit user instruction.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,8 +199,9 @@ returns a number).
 2. **LLM Provider Registry**: Use `LlmProviderRegistry` for all provider-specific LLM behavior. Do NOT add if/else or switch on provider type. Chat and embedding providers are registered and resolved independently — some providers offer only one. Providers are *factories* over credentials, not `ChatModel`s, so credentials stay resolvable per call and key rotation needs no restart.
 3. **SSH-Aware Access**: Always use `ConnectionService.getJdbcTemplate(connectionId, request)` — handles SSH tunneling transparently.
 4. **SQL Rule**: All generated SQL MUST use table-qualified column names (`table.column_name`).
-5. **RAG Caching**: Three-tier cache (memory → Redis → Azure Search). Redis failure is graceful (app continues without caching).
-6. **Virtual Threads**: Enabled for concurrency (JDK 25).
+5. **Chat access policy**: Fail closed. Walk the whole SQL tree (CTEs, set ops, subqueries). Deny unparseable or unhandled statements. Require an actor except `INTERNAL`/`SCHEDULED`. MCP/Editor identity comes from `SecurityContext`, not `QueryActorContextHolder`. Persist `allowed_schemas`. Do not let "how many" override a protected-column mention. Public share is refused when the connection has an active policy.
+6. **RAG Caching**: Three-tier cache (memory → Redis → Azure Search). Redis failure is graceful (app continues without caching).
+7. **Virtual Threads**: Enabled for concurrency (JDK 25).
 
 ### Frontend Rules
 1. **API Centralization**: ALL API calls through `src/lib/api/client.js`. Never create direct axios instances.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,7 +245,16 @@ The Agent tab must not inherit the admin MCP token. `/api/agent/session` mints a
    `hermes_requires <0.20.0` on a "verified" 401 that came from a hand-rolled
    `hermes serve` run rather than `hermes webui`. 0.20.0 works. Verify against the
    real start path before writing a version constraint.
-5. **The agent image build clones two third-party repos over the public internet,
+5. **Hermes MCP is process-global.** One `deepsql-phase1-server.js` stdio server
+   is started from the first loaded profile (usually `u-admin`) and lives until
+   the Agent API process dies. `POST /api/profile/switch` is `process_wide=False`
+   on purpose (per-browser cookie), so a View as / new-thread Agent chat tagged
+   `profile: u-marts-editor` still sends the admin MCP bearer. Chat-access policy
+   then `resolveEffectivePolicy(..., actorIsAdmin=true)` → `none()`. The
+   provisioner mirrors the target user's token onto every `deepsql.token` the
+   live process might re-read (`DEEPSQL_TOKEN_FILE` mtime cache in
+   `mcp/deepsql-phase1-lib.js`).
+6. **The agent image build clones two third-party repos over the public internet,
    unauthenticated.** `agent/Dockerfile` fetches `NousResearch/hermes-agent` and
    `nesquena/hermes-webui` at build time. GitHub rate-limits unauthenticated
    requests *per source IP*, and Actions runners share pooled egress addresses, so
@@ -283,6 +292,16 @@ broken. Assert the *outcome*, never the attempt:
 - **`set -e` + `read` at EOF aborts silently.** Prompts in `install.sh` use
   `read … || true` so the explicit emptiness checks report the problem. Without it the
   installer exited 1 with no message, after writing generated secrets to `.env`.
+- **Minting an Agent MCP token ≠ Hermes using it.** `/api/agent/session` can mint
+  `u-marts-editor`'s token and `POST /api/profile/switch` can 200 while
+  `execute_sql` still authenticates as admin. Hermes keeps one DeepSQL MCP
+  stdio process (started from the first profile that loaded `mcp_servers`) and
+  `profile/switch` is `process_wide=False`. A new chat thread does not respawn
+  MCP. `probeMcpAuth` only proves the *minted* token works against Spring, not
+  that the live MCP process will send it. The provisioner must mirror the
+  token onto every `deepsql.token` the live process might be watching
+  (`scripts/local-agent-provisioner.py`). Audit: `security_event.user_id` on
+  `EDITOR_QUERY_EXECUTED` with `clientType=mcp`.
 - **Silent-failure rule, concretely:** the CLI rendered an unreachable server as
   `No databases connected yet` because one `catch` covered both the connection fetch
   and decorative extras. An unreachable host must never look like an empty account.

--- a/backend/src/main/java/com/dbaagent/controller/AuthController.java
+++ b/backend/src/main/java/com/dbaagent/controller/AuthController.java
@@ -207,11 +207,21 @@ public class AuthController {
         User effectiveUser = impersonationService.resolveFromCookie(httpRequest, user)
             .map(ImpersonationContext.State::target)
             .orElse(user);
-        // Keep the user's agent token alive for as long as the UI session lives.
-        // The SPA refreshes on access-token expiry (~every 15 min of activity), so
-        // this slides the agent token forward on each active interval — a logged-in
-        // UI never ends up with a dead agent.
+        if (effectiveUser != user && effectiveUser.getId() != null) {
+            authSessionService.reissueAccessToken(
+                httpResponse,
+                session.getId(),
+                user,
+                effectiveUser.getId()
+            );
+        }
+        // Keep agent tokens alive for as long as the UI session lives.
+        // During View as the SPA still refreshes the *admin* session; also
+        // slide the target user's minted MCP token or their Agent tab dies.
         agentBridgeService.extendAgentTokens(user.getUsername());
+        if (!effectiveUser.getUsername().equals(user.getUsername())) {
+            agentBridgeService.extendAgentTokens(effectiveUser.getUsername());
+        }
         Map<String, Object> payload = toAuthPayload(
             effectiveUser,
             effectiveUser.getRoleEnum(),

--- a/backend/src/main/java/com/dbaagent/controller/BrainController.java
+++ b/backend/src/main/java/com/dbaagent/controller/BrainController.java
@@ -65,6 +65,7 @@ import com.dbaagent.service.brain.query.AdaptivePlanScoringService;
 import com.dbaagent.service.brain.query.PlanPatternLibraryService;
 import com.dbaagent.service.brain.BrainInsightEmbeddingService;
 import com.dbaagent.service.SlowQueryHistoryService;
+import com.dbaagent.service.UserDataAccessPolicyService;
 import com.dbaagent.service.security.AccessControlService;
 import com.dbaagent.model.SlowQueryAnalysis;
 import lombok.RequiredArgsConstructor;
@@ -138,6 +139,7 @@ public class BrainController {
     private final SlowQueryHistoryService slowQueryHistoryService;
     private final BrainInsightEmbeddingService brainInsightEmbeddingService;
     private final AccessControlService accessControlService;
+    private final UserDataAccessPolicyService userDataAccessPolicyService;
 
     @GetMapping("/understanding/{connectionId}")
     public ResponseEntity<BrainUnderstandingResponse> getUnderstanding(
@@ -523,7 +525,12 @@ public class BrainController {
     ) {
         try {
             accessControlService.assertCanReadConnectionContent(connectionId);
-            return ResponseEntity.ok(joinRelationshipInferenceService.getRelationships(connectionId));
+            return ResponseEntity.ok(userDataAccessPolicyService.filterInferredRelationships(
+                connectionId,
+                accessControlService.getCurrentUsername(),
+                accessControlService.isCurrentUserAdmin(),
+                joinRelationshipInferenceService.getRelationships(connectionId)
+            ));
         } catch (ResponseStatusException e) {
             throw e;
         } catch (Exception e) {

--- a/backend/src/main/java/com/dbaagent/controller/DashboardQueryController.java
+++ b/backend/src/main/java/com/dbaagent/controller/DashboardQueryController.java
@@ -77,7 +77,10 @@ public class DashboardQueryController {
             qr.setExecutionOrigin(QueryExecutionOrigin.API);
             QueryResult result = queryExecutorService.executeQuery(
                 request.connectionId(), qr,
-                QueryExecutionContext.api(accessControlService.getCurrentUsername()));
+                QueryExecutionContext.api(
+                    accessControlService.getCurrentUsername(),
+                    accessControlService.isCurrentUserAdmin()
+                ));
             return ResponseEntity.ok(Map.of(
                 "success", true,
                 "columns", result.getColumns() == null ? java.util.List.of() : result.getColumns(),

--- a/backend/src/main/java/com/dbaagent/controller/McpController.java
+++ b/backend/src/main/java/com/dbaagent/controller/McpController.java
@@ -8,7 +8,6 @@ import com.dbaagent.model.QueryRequest;
 import com.dbaagent.model.QueryResult;
 import com.dbaagent.service.ExplainPlanService;
 import com.dbaagent.service.McpSqlGuardService;
-import com.dbaagent.service.QueryActorContextHolder;
 import com.dbaagent.service.QueryExecutionContext;
 import com.dbaagent.service.QueryExecutionPolicyException;
 import com.dbaagent.service.QueryExecutorService;
@@ -77,7 +76,10 @@ public class McpController {
             QueryResult result = queryExecutorService.executeQuery(
                 request.getConnectionId(),
                 queryRequest,
-                QueryExecutionContext.mcp(QueryActorContextHolder.currentUsername())
+                QueryExecutionContext.mcp(
+                    accessControlService.getCurrentUsername(),
+                    accessControlService.isCurrentUserAdmin()
+                )
             );
             return ResponseEntity.ok(Map.of(
                 "success", true,

--- a/backend/src/main/java/com/dbaagent/controller/SavedDashboardController.java
+++ b/backend/src/main/java/com/dbaagent/controller/SavedDashboardController.java
@@ -2,6 +2,7 @@ package com.dbaagent.controller;
 
 import com.dbaagent.model.DashboardVersion;
 import com.dbaagent.model.SavedDashboard;
+import com.dbaagent.service.ConnectionChatAccessPolicyService;
 import com.dbaagent.service.SavedDashboardService;
 import com.dbaagent.service.security.AccessControlService;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +28,9 @@ public class SavedDashboardController {
     @Autowired
     private AccessControlService accessControlService;
 
+    @Autowired
+    private ConnectionChatAccessPolicyService connectionChatAccessPolicyService;
+
     // Every write method below is load-then-save on a row a background generation
     // turn (SavedDashboardService.beginGenerationTurn etc.) may be writing at the
     // same time. Without this helper, the loser's raw Hibernate message
@@ -47,6 +51,13 @@ public class SavedDashboardController {
             SavedDashboard existing = savedDashboardService.getDashboardById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Dashboard not found"));
             accessControlService.assertCanReadConnectionContent(existing.getConnectionId());
+            if (connectionChatAccessPolicyService.hasActivePolicy(existing.getConnectionId())) {
+                return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of(
+                    "success", false,
+                    "errorCode", "POLICY_PUBLIC_SHARE_FORBIDDEN",
+                    "message", "This connection has an active chat access policy, so the dashboard cannot be shared publicly."
+                ));
+            }
             SavedDashboard d = savedDashboardService.enablePublicShare(id);
             return ResponseEntity.ok(Map.of("success", true,
                 "shareToken", d.getShareToken(), "isPublic", true));

--- a/backend/src/main/java/com/dbaagent/controller/SchemaController.java
+++ b/backend/src/main/java/com/dbaagent/controller/SchemaController.java
@@ -7,6 +7,7 @@ import com.dbaagent.service.CredentialService;
 import com.dbaagent.service.QueryExecutionContext;
 import com.dbaagent.service.QueryExecutionPolicyException;
 import com.dbaagent.service.ActiveQueryService;
+import com.dbaagent.service.McpTokenService;
 import com.dbaagent.service.QueryExecutorService;
 import com.dbaagent.service.RunningQueryRegistry;
 import com.dbaagent.service.SqlExecutionAuditService;
@@ -15,6 +16,7 @@ import com.dbaagent.service.UserDataAccessPolicyService;
 import com.dbaagent.service.SchemaScannerService;
 import com.dbaagent.service.VisualizationService;
 import com.dbaagent.service.security.AccessControlService;
+import org.springframework.http.HttpHeaders;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -195,11 +197,7 @@ public class SchemaController {
             QueryResult result = queryExecutorService.executeQuery(
                 connectionId,
                 queryRequest,
-                QueryExecutionContext.editor(
-                    accessControlService.getCurrentUsername(),
-                    accessControlService.isCurrentUserAdmin(),
-                    Boolean.TRUE.equals(queryRequest.getMutationConfirmed())
-                )
+                queryExecutionContext(queryRequest, httpRequest)
             );
             sqlExecutionAuditService.record(SqlExecutionAuditService.AuditRecord.executed()
                 .connectionId(connectionId)
@@ -411,6 +409,26 @@ public class SchemaController {
             response.put("message", "Failed to fetch table stats: " + e.getMessage());
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
         }
+    }
+
+    private QueryExecutionContext queryExecutionContext(QueryRequest queryRequest, HttpServletRequest httpRequest) {
+        String username = accessControlService.getCurrentUsername();
+        boolean admin = accessControlService.isCurrentUserAdmin();
+        if (isMcpBearer(httpRequest)) {
+            return QueryExecutionContext.mcp(username, admin);
+        }
+        return QueryExecutionContext.editor(
+            username,
+            admin,
+            Boolean.TRUE.equals(queryRequest.getMutationConfirmed())
+        );
+    }
+
+    private boolean isMcpBearer(HttpServletRequest httpRequest) {
+        String authorization = httpRequest.getHeader(HttpHeaders.AUTHORIZATION);
+        return authorization != null
+            && authorization.startsWith("Bearer ")
+            && authorization.substring(7).startsWith(McpTokenService.TOKEN_PREFIX);
     }
 
     private SchemaMetadata scopedSchema(String connectionId, SchemaMetadata schema) {

--- a/backend/src/main/java/com/dbaagent/controller/TrainingController.java
+++ b/backend/src/main/java/com/dbaagent/controller/TrainingController.java
@@ -10,6 +10,7 @@ import com.dbaagent.service.RetrievedContextResult;
 import com.dbaagent.service.SemanticModelService;
 import com.dbaagent.service.TrainingJobService;
 import com.dbaagent.service.TrainingService;
+import com.dbaagent.service.UserDataAccessPolicyService;
 import com.dbaagent.service.security.AccessControlService;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +38,7 @@ public class TrainingController {
     private final CredentialRepository credentialRepository;
     private final SemanticModelService semanticModelService;
     private final AccessControlService accessControlService;
+    private final UserDataAccessPolicyService userDataAccessPolicyService;
 
     /**
      * Train with schema DDL
@@ -186,7 +188,9 @@ public class TrainingController {
             if (question == null || question.isBlank()) {
                 return ResponseEntity.badRequest().body(Map.of("error", "Query parameter 'q' is required"));
             }
-            return ResponseEntity.ok(trainingService.debugRetrieve(connectionId, question, topK));
+            Map<String, Object> payload = trainingService.debugRetrieve(connectionId, question, topK);
+            filterDebugRetrieval(connectionId, payload);
+            return ResponseEntity.ok(payload);
         } catch (org.springframework.web.server.ResponseStatusException e) {
             throw e;
         } catch (Exception e) {
@@ -344,6 +348,34 @@ public class TrainingController {
     private void rebuildAndReindexConnection(String connectionId) {
         semanticModelService.rebuildSemanticModel(connectionId);
         trainingService.reindexConnection(connectionId);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void filterDebugRetrieval(String connectionId, Map<String, Object> payload) {
+        if (payload == null) {
+            return;
+        }
+        Object results = payload.get("results");
+        if (!(results instanceof List<?> rows)) {
+            return;
+        }
+        List<Map<String, Object>> filtered = new java.util.ArrayList<>();
+        for (Object row : rows) {
+            if (!(row instanceof Map<?, ?> map)) {
+                continue;
+            }
+            Object metadata = map.get("metadata");
+            if (userDataAccessPolicyService.isRagMetadataInScope(
+                connectionId,
+                accessControlService.getCurrentUsername(),
+                accessControlService.isCurrentUserAdmin(),
+                metadata == null ? null : String.valueOf(metadata)
+            )) {
+                filtered.add((Map<String, Object>) map);
+            }
+        }
+        payload.put("results", filtered);
+        payload.put("resultCount", filtered.size());
     }
 
     @Data

--- a/backend/src/main/java/com/dbaagent/dto/ConnectionChatAccessPolicyResponse.java
+++ b/backend/src/main/java/com/dbaagent/dto/ConnectionChatAccessPolicyResponse.java
@@ -16,6 +16,8 @@ public class ConnectionChatAccessPolicyResponse {
     List<String> blockedSensitivityCategories;
     List<String> deniedTables;
     List<String> deniedColumns;
+    List<String> allowedSchemas;
+    boolean allowAggregates;
     boolean blockMode;
     boolean redactMode;
     boolean active;

--- a/backend/src/main/java/com/dbaagent/dto/PolicyPreviewResponse.java
+++ b/backend/src/main/java/com/dbaagent/dto/PolicyPreviewResponse.java
@@ -11,6 +11,8 @@ public class PolicyPreviewResponse {
     List<String> blockedSensitivityCategories;
     List<String> deniedTables;
     List<String> deniedColumns;
+    List<String> allowedSchemas;
+    boolean allowAggregates;
     List<String> impactedTables;
     List<String> impactedColumns;
     boolean blockMode;

--- a/backend/src/main/java/com/dbaagent/model/ConnectionChatAccessPolicy.java
+++ b/backend/src/main/java/com/dbaagent/model/ConnectionChatAccessPolicy.java
@@ -40,6 +40,13 @@ public class ConnectionChatAccessPolicy {
     @Column(name = "denied_columns", columnDefinition = "jsonb")
     private List<String> deniedColumns;
 
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "allowed_schemas", columnDefinition = "jsonb")
+    private List<String> allowedSchemas;
+
+    @Column(name = "allow_aggregates", nullable = false)
+    private boolean allowAggregates = false;
+
     @Column(name = "block_mode", nullable = false)
     private boolean blockMode = true;
 

--- a/backend/src/main/java/com/dbaagent/repository/ConnectionChatAccessPolicyRepository.java
+++ b/backend/src/main/java/com/dbaagent/repository/ConnectionChatAccessPolicyRepository.java
@@ -9,5 +9,6 @@ import java.util.Optional;
 public interface ConnectionChatAccessPolicyRepository extends JpaRepository<ConnectionChatAccessPolicy, Long> {
     Optional<ConnectionChatAccessPolicy> findByConnectionIdAndUsernameIgnoreCase(String connectionId, String username);
     List<ConnectionChatAccessPolicy> findAllByUsernameIgnoreCaseOrderByUpdatedAtDesc(String username);
+    boolean existsByConnectionIdAndActiveTrue(String connectionId);
     void deleteByConnectionId(String connectionId);
 }

--- a/backend/src/main/java/com/dbaagent/security/ImpersonationContext.java
+++ b/backend/src/main/java/com/dbaagent/security/ImpersonationContext.java
@@ -5,11 +5,12 @@ import com.dbaagent.model.User;
 import java.util.Optional;
 
 /**
- * Request-scoped impersonation overlay. The admin JWT stays on the session;
+ * Request-scoped impersonation overlay. The admin JWT subject stays on the
+ * session so logout/refresh/control-plane still own the real administrator;
  * {@link JwtAuthenticationFilter} swaps the SecurityContext principal to the
- * target user and records both identities here so {@code /auth/me} can show a
- * banner and {@code AccessControlService} can honour the target even when
- * {@code security.auth.enabled} is false.
+ * target user (from {@code impersonate_user} cookie or {@code impUid} claim)
+ * so policy evaluation, {@code /auth/me}, and {@code AccessControlService}
+ * honour the viewed-as user — including when {@code security.auth.enabled} is false.
  */
 public final class ImpersonationContext {
 

--- a/backend/src/main/java/com/dbaagent/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/dbaagent/security/JwtAuthenticationFilter.java
@@ -143,10 +143,28 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
         try {
             impersonationService.applyToRequest(request);
+            stampEffectiveUser(response);
             chain.doFilter(request, response);
         } finally {
             ImpersonationContext.clear();
         }
+    }
+
+    /**
+     * nginx {@code auth_request} on {@code /agent-api} forwards this as
+     * {@code X-Remote-User}. It must be the <em>effective</em> principal so
+     * View as (and non-admin Agent users) do not run the shared admin profile.
+     */
+    private void stampEffectiveUser(HttpServletResponse response) {
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return;
+        }
+        String name = authentication.getName();
+        if (name == null || name.isBlank() || "anonymousUser".equals(name)) {
+            return;
+        }
+        response.setHeader("X-Remote-User", name);
     }
 
     private String extractUsernameSafely(String token) {

--- a/backend/src/main/java/com/dbaagent/security/JwtUtil.java
+++ b/backend/src/main/java/com/dbaagent/security/JwtUtil.java
@@ -135,6 +135,17 @@ public class JwtUtil {
         Set<Permission> permissions,
         Duration ttl
     ) {
+        return generateAccessToken(username, sessionId, role, permissions, ttl, null);
+    }
+
+    public String generateAccessToken(
+        String username,
+        String sessionId,
+        Role role,
+        Set<Permission> permissions,
+        Duration ttl,
+        Long impersonateUserId
+    ) {
         Map<String, Object> claims = new HashMap<>();
         claims.put("role", role.name());
 
@@ -145,8 +156,34 @@ public class JwtUtil {
         if (sessionId != null && !sessionId.isBlank()) {
             claims.put("sid", sessionId);
         }
+        if (impersonateUserId != null && impersonateUserId > 0) {
+            claims.put("impUid", impersonateUserId);
+        }
 
         return createToken(claims, username, ttl);
+    }
+
+    /**
+     * Target user id stamped onto an admin access token during View as.
+     * The JWT subject stays the administrator so logout/refresh/control-plane
+     * still own the real session; policy evaluation overlays this user.
+     */
+    public Long extractImpersonateUserId(String token) {
+        Claims claims = extractAllClaims(token);
+        Object raw = claims.get("impUid");
+        if (raw instanceof Number number) {
+            long value = number.longValue();
+            return value > 0 ? value : null;
+        }
+        if (raw instanceof String text && !text.isBlank()) {
+            try {
+                long value = Long.parseLong(text.trim());
+                return value > 0 ? value : null;
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
     }
 
     /**

--- a/backend/src/main/java/com/dbaagent/service/AgentBridgeService.java
+++ b/backend/src/main/java/com/dbaagent/service/AgentBridgeService.java
@@ -1,5 +1,6 @@
 package com.dbaagent.service;
 
+import com.dbaagent.security.ImpersonationContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -142,9 +143,19 @@ public class AgentBridgeService {
     public ProfileBootstrap ensureProfile(String username, String authToken, String connectionId) {
         String profile = profileFor(username);
         if (!provisionEnabled) {
+            if (ImpersonationContext.isActive()) {
+                throw new ProvisioningException(
+                    "Agent provisioning is disabled; View as cannot bind a user-scoped Agent token"
+                );
+            }
             return new ProfileBootstrap(profile, authToken);
         }
         if (provisionSecret == null || provisionSecret.isBlank()) {
+            if (ImpersonationContext.isActive()) {
+                throw new ProvisioningException(
+                    "Agent provisioning is not configured; View as cannot bind a user-scoped Agent token"
+                );
+            }
             log.warn("agent.provision-secret is unset — skipping per-user provisioning for {}", username);
             return new ProfileBootstrap(profile, authToken);
         }
@@ -154,9 +165,15 @@ public class AgentBridgeService {
         // every MCP call. Mint a dedicated, user-scoped, revocable MCP token
         // instead (authenticated by McpTokenAuthenticationFilter, not the session
         // filter). Fall back to the session token only if minting fails so the
-        // tab still opens.
+        // tab still opens — except during View as, where the session JWT is the
+        // administrator's and would skip the target user's policy.
         String agentToken = mintAgentToken(username);
         if (agentToken == null) {
+            if (ImpersonationContext.isActive()) {
+                throw new ProvisioningException(
+                    "Could not mint an MCP token for " + username + " while viewing as that user"
+                );
+            }
             agentToken = authToken == null ? "" : authToken;
         }
         callProvisioner(username, profile, agentToken, connectionId);

--- a/backend/src/main/java/com/dbaagent/service/AgentBridgeService.java
+++ b/backend/src/main/java/com/dbaagent/service/AgentBridgeService.java
@@ -176,6 +176,10 @@ public class AgentBridgeService {
             }
             agentToken = authToken == null ? "" : authToken;
         }
+        // The provisioner also mirrors this token onto every profile
+        // `deepsql.token` the already-running Hermes MCP subprocess watches.
+        // Profile switch does not respawn MCP; without that mirror, View as
+        // Agent chats keep the admin credential and skip policy.
         callProvisioner(username, profile, agentToken, connectionId);
         return new ProfileBootstrap(profile, agentToken);
     }

--- a/backend/src/main/java/com/dbaagent/service/AgentChatClient.java
+++ b/backend/src/main/java/com/dbaagent/service/AgentChatClient.java
@@ -136,7 +136,7 @@ public class AgentChatClient {
             throw new IllegalArgumentException("agent profile is required");
         }
         // Profiles are provisioned as u-<username>; the trusted-auth header is the
-        // bare username (nginx hard-codes X-Remote-User: admin for the browser path).
+        // bare username (browser /agent-api gets this from /api/auth/me via nginx).
         remoteUser = profile.startsWith("u-") ? profile.substring(2) : profile;
         postJson("/api/profile/switch", Map.of("name", profile));
     }

--- a/backend/src/main/java/com/dbaagent/service/AuthSessionService.java
+++ b/backend/src/main/java/com/dbaagent/service/AuthSessionService.java
@@ -155,6 +155,32 @@ public class AuthSessionService {
         response.addHeader(HttpHeaders.SET_COOKIE, buildRefreshCookie(sessionAuthentication.refreshToken()).toString());
     }
 
+    /**
+     * Rewrite the access cookie in place (same session id) so View as can stamp
+     * or clear {@code impUid} without rotating the refresh token. {@code impersonateUserId}
+     * null clears the claim.
+     */
+    public void reissueAccessToken(
+        HttpServletResponse response,
+        String sessionId,
+        User sessionOwner,
+        Long impersonateUserId
+    ) {
+        if (response == null || sessionId == null || sessionId.isBlank() || sessionOwner == null) {
+            return;
+        }
+        Role role = sessionOwner.getRoleEnum();
+        String accessToken = jwtUtil.generateAccessToken(
+            sessionOwner.getUsername(),
+            sessionId,
+            role,
+            role.getPermissions(),
+            Duration.ofMinutes(accessMinutes),
+            impersonateUserId
+        );
+        response.addHeader(HttpHeaders.SET_COOKIE, buildAccessCookie(accessToken).toString());
+    }
+
     public void writeImpersonationCookie(HttpServletResponse response, String cookieName, long targetUserId) {
         response.addHeader(HttpHeaders.SET_COOKIE, ResponseCookie.from(cookieName, Long.toString(targetUserId))
             .httpOnly(true)

--- a/backend/src/main/java/com/dbaagent/service/ChatRetrievalContextService.java
+++ b/backend/src/main/java/com/dbaagent/service/ChatRetrievalContextService.java
@@ -4,6 +4,7 @@ import com.dbaagent.model.CompanyKnowledgeEntry;
 import com.dbaagent.model.QualifiedTableName;
 import com.dbaagent.model.SchemaMetadata;
 import com.dbaagent.model.TrainingDataEmbedding;
+import com.dbaagent.service.security.AccessControlService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +29,8 @@ public class ChatRetrievalContextService {
     private final TrainingService trainingService;
     private final CompanyKnowledgeService companyKnowledgeService;
     private final ObjectMapper objectMapper;
+    private final UserDataAccessPolicyService userDataAccessPolicyService;
+    private final AccessControlService accessControlService;
 
     @Value("${app.chat.rag.general-top-k:20}")
     private int ragGeneralTopK;
@@ -57,6 +60,7 @@ public class ChatRetrievalContextService {
         String actualUserQuestion,
         SchemaMetadata schema
     ) {
+        SchemaMetadata scopedSchema = scopeSchema(connectionId, schema);
         RetrievalIntent retrievalIntent = detectRetrievalIntent(actualUserQuestion);
         if (isSimpleSchemaQuestion(actualUserQuestion)) {
             log.debug("Skipping RAG for simple schema question");
@@ -65,7 +69,7 @@ public class ChatRetrievalContextService {
             // is also a no-op without focus tables, so the section ends up empty (which
             // is the right behavior for "list all tables"-style queries).
             CompanyKnowledgeService.RelevantKnowledgeContext knowledgeContext =
-                companyKnowledgeService.selectFromRagHits(connectionId, List.of(), Set.of(), schema);
+                companyKnowledgeService.selectFromRagHits(connectionId, List.of(), Set.of(), scopedSchema);
             return new RetrievedContextResult(
                 "",
                 knowledgeContext.hintContext(),
@@ -85,19 +89,24 @@ public class ChatRetrievalContextService {
         long ragStart = System.currentTimeMillis();
         int retrievalTopK = resolveRetrievalTopK(retrievalIntent);
 
-        List<TrainingDataEmbedding> ragResults = trainingService.cachedRetrieveRelevant(
-            connectionId, actualUserQuestion, retrievalTopK);
-        ragResults = prioritizeTrainingDataByIntent(ragResults, retrievalIntent);
+        List<TrainingDataEmbedding> ragResults = scopeEmbeddings(connectionId, prioritizeTrainingDataByIntent(
+            trainingService.cachedRetrieveRelevant(connectionId, actualUserQuestion, retrievalTopK),
+            retrievalIntent
+        ));
 
-        String dbType = schema != null ? schema.getDbType() : null;
-        Set<QualifiedTableName> resolvedTables = schema == null
+        String dbType = scopedSchema != null ? scopedSchema.getDbType() : null;
+        Set<QualifiedTableName> resolvedTables = scopedSchema == null
             ? Set.of()
-            : trainingService.resolveRelevantTables(schema, actualUserQuestion, ragResults, dbType);
+            : trainingService.resolveRelevantTables(scopedSchema, actualUserQuestion, ragResults, dbType);
 
-        List<TrainingDataEmbedding> stage2Results = trainingService.retrieveTargetedByTables(
-            connectionId, resolvedTables, 100);
-        List<TrainingDataEmbedding> stage3Results = trainingService.deduplicateAgainstTargeted(
-            ragResults, stage2Results);
+        List<TrainingDataEmbedding> stage2Results = scopeEmbeddings(
+            connectionId,
+            trainingService.retrieveTargetedByTables(connectionId, resolvedTables, 100)
+        );
+        List<TrainingDataEmbedding> stage3Results = scopeEmbeddings(
+            connectionId,
+            trainingService.deduplicateAgainstTargeted(ragResults, stage2Results)
+        );
 
         List<TrainingDataEmbedding> allResults = new ArrayList<>(stage2Results);
         allResults.addAll(stage3Results);
@@ -110,7 +119,7 @@ public class ChatRetrievalContextService {
                 connectionId,
                 allResults,
                 extractTableNamesFromRag(allResults),
-                schema
+                scopedSchema
             );
 
         Set<String> ragTableNames = new LinkedHashSet<>(extractTableNamesFromRag(allResults));
@@ -153,20 +162,25 @@ public class ChatRetrievalContextService {
             return buildContext(connectionId, actualUserQuestion, schema);
         }
 
+        SchemaMetadata scopedSchema = scopeSchema(connectionId, schema);
         RetrievalIntent retrievalIntent = detectRetrievalIntent(actualUserQuestion);
         int retrievalTopK = resolveRetrievalTopK(retrievalIntent);
-        String dbType = schema.getDbType();
-        Set<QualifiedTableName> resolvedTables = resolveScopedTables(schema, requestedTables, dbType);
+        String dbType = scopedSchema.getDbType();
+        Set<QualifiedTableName> resolvedTables = resolveScopedTables(scopedSchema, requestedTables, dbType);
 
         String augmentedQuestion = actualUserQuestion + " tables: " + String.join(", ", requestedTables);
-        List<TrainingDataEmbedding> ragResults = trainingService.cachedRetrieveRelevant(
-            connectionId, augmentedQuestion, retrievalTopK);
-        ragResults = prioritizeTrainingDataByIntent(ragResults, retrievalIntent);
+        List<TrainingDataEmbedding> ragResults = scopeEmbeddings(connectionId, prioritizeTrainingDataByIntent(
+            trainingService.cachedRetrieveRelevant(connectionId, augmentedQuestion, retrievalTopK),
+            retrievalIntent
+        ));
 
         List<TrainingDataEmbedding> stage2Results = resolvedTables.isEmpty()
             ? List.of()
-            : trainingService.retrieveTargetedByTables(connectionId, resolvedTables, 100);
-        List<TrainingDataEmbedding> stage3Results = trainingService.deduplicateAgainstTargeted(ragResults, stage2Results);
+            : scopeEmbeddings(connectionId, trainingService.retrieveTargetedByTables(connectionId, resolvedTables, 100));
+        List<TrainingDataEmbedding> stage3Results = scopeEmbeddings(
+            connectionId,
+            trainingService.deduplicateAgainstTargeted(ragResults, stage2Results)
+        );
 
         List<TrainingDataEmbedding> allResults = new ArrayList<>(stage2Results);
         allResults.addAll(stage3Results);
@@ -179,7 +193,7 @@ public class ChatRetrievalContextService {
                 connectionId,
                 allResults,
                 selectorFocus,
-                schema
+                scopedSchema
             );
 
         Set<String> ragTableNames = new LinkedHashSet<>(requestedTables);
@@ -426,5 +440,23 @@ public class ChatRetrievalContextService {
                 .ifPresent(table -> resolved.add(trainingService.toQualifiedTableName(table, dbType)));
         }
         return resolved;
+    }
+
+    private SchemaMetadata scopeSchema(String connectionId, SchemaMetadata schema) {
+        return userDataAccessPolicyService.filterSchemaMetadata(
+            connectionId,
+            accessControlService.getCurrentUsername(),
+            accessControlService.isCurrentUserAdmin(),
+            schema
+        );
+    }
+
+    private List<TrainingDataEmbedding> scopeEmbeddings(String connectionId, List<TrainingDataEmbedding> embeddings) {
+        return userDataAccessPolicyService.filterRagEmbeddings(
+            connectionId,
+            accessControlService.getCurrentUsername(),
+            accessControlService.isCurrentUserAdmin(),
+            embeddings
+        );
     }
 }

--- a/backend/src/main/java/com/dbaagent/service/ChatService.java
+++ b/backend/src/main/java/com/dbaagent/service/ChatService.java
@@ -2649,7 +2649,12 @@ public class ChatService {
                     }
                 }
 
-                SchemaMetadata schema = schemaScannerService.scanSchema(connectionId);
+                SchemaMetadata schema = scopeSchemaForActor(
+                    connectionId,
+                    accessControlService.getCurrentUsername(),
+                    accessControlService.isCurrentUserAdmin(),
+                    schemaScannerService.scanSchema(connectionId)
+                );
                 AgentDecision schemaAwareDecision = earlyAgenticDecision.useAgenticFlow()
                     ? earlyAgenticDecision
                     : agentOrchestrator.previewDecision(agenticEnabled, actualUserQuestion, questionRoute);
@@ -2687,7 +2692,12 @@ public class ChatService {
             }
 
             // 1. Get Schema Context (needed for metadata fast path and schema-aware flows)
-            SchemaMetadata schema = schemaScannerService.scanSchema(connectionId);
+            SchemaMetadata schema = scopeSchemaForActor(
+                connectionId,
+                accessControlService.getCurrentUsername(),
+                accessControlService.isCurrentUserAdmin(),
+                schemaScannerService.scanSchema(connectionId)
+            );
             log.debug("Schema scan completed in {}ms", System.currentTimeMillis() - startTime);
 
             // 2. FAST PATH: Check if we can answer directly from cached metadata (no LLM needed)
@@ -3620,7 +3630,12 @@ public class ChatService {
                 prepared.effectiveQuestion()
             );
 
-            SchemaMetadata schema = preloadedMetadataSchema != null ? preloadedMetadataSchema : schemaScannerService.scanSchema(connectionId);
+            SchemaMetadata schema = scopeSchemaForActor(
+                connectionId,
+                actorUsername,
+                actorIsAdmin,
+                preloadedMetadataSchema != null ? preloadedMetadataSchema : schemaScannerService.scanSchema(connectionId)
+            );
             ChatResponse vaultFirstMetadataResponse = tryBuildVaultFirstMetadataResponse(
                 connectionId,
                 prepared.chatId(),
@@ -3761,7 +3776,12 @@ public class ChatService {
     @Nullable
     private SchemaMetadata tryLoadSchemaForMetadataResponse(String connectionId) {
         try {
-            return schemaScannerService.scanSchema(connectionId);
+            return scopeSchemaForActor(
+                connectionId,
+                accessControlService.getCurrentUsername(),
+                accessControlService.isCurrentUserAdmin(),
+                schemaScannerService.scanSchema(connectionId)
+            );
         } catch (SQLException e) {
             log.warn("Failed to load schema for metadata fast path on {}: {}", connectionId, e.getMessage());
             return null;
@@ -4074,6 +4094,24 @@ public class ChatService {
             return explicitUserId;
         }
         return accessControlService.getCurrentUsername();
+    }
+
+    private SchemaMetadata scopeSchemaForActor(
+        String connectionId,
+        String actorUsername,
+        boolean actorIsAdmin,
+        SchemaMetadata schema
+    ) {
+        if (schema == null) {
+            return null;
+        }
+        SchemaMetadata scoped = userDataAccessPolicyService.filterSchemaMetadata(
+            connectionId,
+            actorUsername,
+            actorIsAdmin,
+            schema
+        );
+        return scoped != null ? scoped : schema;
     }
 
     private String currentChatOwnerUsername() {
@@ -4938,7 +4976,12 @@ public class ChatService {
     public RetrievedContextResult debugRagContext(String connectionId, String question) {
         String actualQuestion = extractActualUserQuestion(question);
         try {
-            SchemaMetadata schema = schemaScannerService.scanSchema(connectionId);
+            SchemaMetadata schema = scopeSchemaForActor(
+                connectionId,
+                accessControlService.getCurrentUsername(),
+                accessControlService.isCurrentUserAdmin(),
+                schemaScannerService.scanSchema(connectionId)
+            );
             return chatRetrievalContextService.buildContext(connectionId, actualQuestion, schema);
         } catch (Exception e) {
             log.warn("Failed to load schema for debug RAG context, using empty schema: {}", e.getMessage());

--- a/backend/src/main/java/com/dbaagent/service/ConnectionChatAccessPolicyService.java
+++ b/backend/src/main/java/com/dbaagent/service/ConnectionChatAccessPolicyService.java
@@ -77,6 +77,12 @@ public class ConnectionChatAccessPolicyService {
     }
 
     @Transactional(readOnly = true)
+    public boolean hasActivePolicy(String connectionId) {
+        return connectionId != null && !connectionId.isBlank()
+            && policyRepository.existsByConnectionIdAndActiveTrue(connectionId);
+    }
+
+    @Transactional(readOnly = true)
     public EffectivePolicy resolveEffectivePolicy(String connectionId, String username, boolean actorIsAdmin) {
         if (actorIsAdmin || username == null || username.isBlank()) {
             return EffectivePolicy.none();
@@ -109,6 +115,8 @@ public class ConnectionChatAccessPolicyService {
         policy.setBlockedSensitivityCategories(parsedPolicy.blockedSensitivityCategories());
         policy.setDeniedTables(parsedPolicy.deniedTables());
         policy.setDeniedColumns(parsedPolicy.deniedColumns());
+        policy.setAllowedSchemas(parsedPolicy.allowedSchemas());
+        policy.setAllowAggregates(false);
         policy.setBlockMode(parsedPolicy.blockMode());
         policy.setRedactMode(parsedPolicy.redactMode());
         policy.setActive(active == null || active);
@@ -140,6 +148,8 @@ public class ConnectionChatAccessPolicyService {
             .blockedSensitivityCategories(parsedPolicy.blockedSensitivityCategories())
             .deniedTables(parsedPolicy.deniedTables())
             .deniedColumns(parsedPolicy.deniedColumns())
+            .allowedSchemas(parsedPolicy.allowedSchemas())
+            .allowAggregates(false)
             .impactedTables(parsedPolicy.impactedTables())
             .impactedColumns(parsedPolicy.impactedColumns())
             .blockMode(parsedPolicy.blockMode())
@@ -157,6 +167,8 @@ public class ConnectionChatAccessPolicyService {
             .blockedSensitivityCategories(policy.getBlockedSensitivityCategories())
             .deniedTables(policy.getDeniedTables())
             .deniedColumns(policy.getDeniedColumns())
+            .allowedSchemas(policy.getAllowedSchemas())
+            .allowAggregates(policy.isAllowAggregates())
             .blockMode(policy.isBlockMode())
             .redactMode(policy.isRedactMode())
             .active(policy.isActive())
@@ -170,6 +182,10 @@ public class ConnectionChatAccessPolicyService {
 
     private EffectivePolicy toEffectivePolicy(ConnectionChatAccessPolicy policy) {
         ParsedPolicy parsedPolicy = parsedFromPolicy(policy);
+        Set<String> storedSchemas = normalizeSet(policy.getAllowedSchemas());
+        Set<String> allowedSchemas = storedSchemas.isEmpty()
+            ? new LinkedHashSet<>(parsedPolicy.allowedSchemas())
+            : storedSchemas;
         return new EffectivePolicy(
             true,
             policy.getConnectionId(),
@@ -177,9 +193,10 @@ public class ConnectionChatAccessPolicyService {
             new LinkedHashSet<>(policy.getBlockedSensitivityCategories() == null ? List.of() : policy.getBlockedSensitivityCategories()),
             new LinkedHashSet<>(policy.getDeniedTables() == null ? List.of() : policy.getDeniedTables()),
             new LinkedHashSet<>(policy.getDeniedColumns() == null ? List.of() : policy.getDeniedColumns()),
-            new LinkedHashSet<>(parsedPolicy.allowedSchemas()),
+            allowedSchemas,
             policy.isBlockMode(),
             policy.isRedactMode(),
+            policy.isAllowAggregates(),
             policy.getPlainEnglishPolicy(),
             parsedPolicy.impactedTables(),
             parsedPolicy.impactedColumns()
@@ -689,12 +706,13 @@ public class ConnectionChatAccessPolicyService {
         Set<String> allowedSchemas,
         boolean blockMode,
         boolean redactMode,
+        boolean allowAggregates,
         String plainEnglishPolicy,
         List<String> impactedTables,
         List<String> impactedColumns
     ) {
         public static EffectivePolicy none() {
-            return new EffectivePolicy(false, null, null, Set.of(), Set.of(), Set.of(), Set.of(), false, false, null, List.of(), List.of());
+            return new EffectivePolicy(false, null, null, Set.of(), Set.of(), Set.of(), Set.of(), false, false, false, null, List.of(), List.of());
         }
 
         public boolean protectsAnything() {

--- a/backend/src/main/java/com/dbaagent/service/ImpersonationService.java
+++ b/backend/src/main/java/com/dbaagent/service/ImpersonationService.java
@@ -7,6 +7,7 @@ import com.dbaagent.model.UserAccountStatus;
 import com.dbaagent.repository.UserRepository;
 import com.dbaagent.security.CustomUserDetailsService;
 import com.dbaagent.security.ImpersonationContext;
+import com.dbaagent.security.JwtUtil;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -33,10 +34,18 @@ import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 /**
- * Admin-only profile switch. The admin session (JWT cookies) is unchanged;
- * a separate httpOnly cookie names the user to evaluate as. The JWT filter
- * overlays that principal onto the SecurityContext for every request except
- * the impersonation control plane, logout, and session refresh.
+ * Admin-only profile switch so an administrator can verify another user's
+ * connection ACLs and chat/editor policies.
+ *
+ * <p>The admin session stays the real session (logout/refresh/control-plane).
+ * Identity for policy is the target user: an httpOnly {@code impersonate_user}
+ * cookie plus an {@code impUid} claim on the access JWT. The JWT filter overlays
+ * that principal onto the SecurityContext for every request except the
+ * impersonation control plane, logout, and session refresh.
+ *
+ * <p>The {@code impUid} claim matters for callers that send the access token as
+ * a Bearer credential without cookies (Agent MCP fallback). Cookie-only overlay
+ * left those paths running as the administrator, which skipped policy.
  */
 @Service
 @RequiredArgsConstructor
@@ -49,12 +58,16 @@ public class ImpersonationService {
     private final CustomUserDetailsService userDetailsService;
     private final AuthSessionService authSessionService;
     private final SecurityEventService securityEventService;
+    private final JwtUtil jwtUtil;
 
     @Value("${security.auth.enabled:true}")
     private boolean authEnabled;
 
     @Value("${security.cookie.impersonate-name:" + DEFAULT_COOKIE_NAME + "}")
     private String impersonateCookieName;
+
+    @Value("${security.cookie.name:auth_token}")
+    private String accessCookieName;
 
     public ImpersonationContext.State start(
         User actor,
@@ -65,6 +78,7 @@ public class ImpersonationService {
         requireAdminActor(actor);
         User target = requireAllowedTarget(actor, targetUserId);
         authSessionService.writeImpersonationCookie(response, impersonateCookieName, target.getId());
+        rewriteAccessToken(request, response, actor, target.getId());
         securityEventService.log(SecurityEventService.EventRequest.builder()
             .eventType(SecurityEventType.IMPERSONATION_STARTED)
             .outcome(SecurityEventOutcome.SUCCESS)
@@ -91,6 +105,7 @@ public class ImpersonationService {
         requireAdminActor(actor);
         Optional<User> target = readTargetUser(request);
         authSessionService.clearImpersonationCookie(response, impersonateCookieName);
+        rewriteAccessToken(request, response, actor, null);
         ImpersonationContext.clear();
         target.ifPresent(stopped -> securityEventService.log(SecurityEventService.EventRequest.builder()
             .eventType(SecurityEventType.IMPERSONATION_STOPPED)
@@ -145,6 +160,10 @@ public class ImpersonationService {
      * Overlay the target principal when the admin JWT (or the auth-disabled
      * synthetic admin) is already in the SecurityContext. No-ops on the
      * impersonation control-plane, logout/refresh, MCP tokens, and invalid cookies.
+     *
+     * <p>The target is taken from the {@code impersonate_user} cookie first, then
+     * from the access token's {@code impUid} claim so Bearer callers without
+     * cookies still evaluate policy as the viewed-as user.
      */
     public void applyToRequest(HttpServletRequest request) {
         if (!shouldApply(request)) {
@@ -218,6 +237,14 @@ public class ImpersonationService {
     }
 
     private Long readTargetUserId(HttpServletRequest request) {
+        Long fromCookie = readTargetUserIdFromCookie(request);
+        if (fromCookie != null) {
+            return fromCookie;
+        }
+        return readTargetUserIdFromJwt(request);
+    }
+
+    private Long readTargetUserIdFromCookie(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
         if (cookies == null) {
             return null;
@@ -225,6 +252,69 @@ public class ImpersonationService {
         for (Cookie cookie : cookies) {
             if (impersonateCookieName.equals(cookie.getName())) {
                 return parseUserId(cookie.getValue());
+            }
+        }
+        return null;
+    }
+
+    private Long readTargetUserIdFromJwt(HttpServletRequest request) {
+        String jwt = readAccessJwt(request);
+        if (jwt == null) {
+            return null;
+        }
+        try {
+            return jwtUtil.extractImpersonateUserId(jwt);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private void rewriteAccessToken(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        User sessionOwner,
+        Long impersonateUserId
+    ) {
+        String sessionId = sessionIdFrom(request);
+        if (sessionId == null) {
+            return;
+        }
+        authSessionService.reissueAccessToken(response, sessionId, sessionOwner, impersonateUserId);
+    }
+
+    private String sessionIdFrom(HttpServletRequest request) {
+        Object attr = request.getAttribute("auth.sessionId");
+        if (attr instanceof String sid && !sid.isBlank()) {
+            return sid;
+        }
+        String jwt = readAccessJwt(request);
+        if (jwt == null) {
+            return null;
+        }
+        try {
+            String sessionId = jwtUtil.extractSessionId(jwt);
+            return sessionId == null || sessionId.isBlank() ? null : sessionId;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private String readAccessJwt(HttpServletRequest request) {
+        String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (authorization != null && authorization.startsWith("Bearer ")) {
+            String token = authorization.substring(7);
+            if (token.startsWith(McpTokenService.TOKEN_PREFIX)) {
+                return null;
+            }
+            return token.isBlank() ? null : token;
+        }
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return null;
+        }
+        for (Cookie cookie : cookies) {
+            if (accessCookieName.equals(cookie.getName())) {
+                return cookie.getValue();
             }
         }
         return null;

--- a/backend/src/main/java/com/dbaagent/service/QueryExecutionContext.java
+++ b/backend/src/main/java/com/dbaagent/service/QueryExecutionContext.java
@@ -1,6 +1,8 @@
 package com.dbaagent.service;
 
 import com.dbaagent.model.QueryExecutionOrigin;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 public record QueryExecutionContext(
     QueryExecutionOrigin origin,
@@ -19,7 +21,7 @@ public record QueryExecutionContext(
         return new QueryExecutionContext(
             QueryExecutionOrigin.CHAT,
             MutationMode.READ_ONLY_ONLY,
-            QueryActorContextHolder.currentUsername(),
+            resolveActorUsername(),
             false,
             false
         );
@@ -46,11 +48,15 @@ public record QueryExecutionContext(
     }
 
     public static QueryExecutionContext mcp(String actorUsername) {
+        return mcp(actorUsername, false);
+    }
+
+    public static QueryExecutionContext mcp(String actorUsername, boolean actorIsAdmin) {
         return new QueryExecutionContext(
             QueryExecutionOrigin.MCP,
             MutationMode.READ_ONLY_ONLY,
             actorUsername,
-            false,
+            actorIsAdmin,
             false
         );
     }
@@ -66,12 +72,32 @@ public record QueryExecutionContext(
     }
 
     public static QueryExecutionContext api(String actorUsername) {
+        return api(actorUsername, false);
+    }
+
+    public static QueryExecutionContext api(String actorUsername, boolean actorIsAdmin) {
         return new QueryExecutionContext(
             QueryExecutionOrigin.API,
             MutationMode.READ_ONLY_ONLY,
             actorUsername,
-            false,
+            actorIsAdmin,
             false
         );
+    }
+
+    private static String resolveActorUsername() {
+        String fromHolder = QueryActorContextHolder.currentUsername();
+        if (fromHolder != null && !fromHolder.isBlank()) {
+            return fromHolder;
+        }
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return null;
+        }
+        String name = authentication.getName();
+        if (name == null || name.isBlank() || "anonymousUser".equals(name)) {
+            return null;
+        }
+        return name;
     }
 }

--- a/backend/src/main/java/com/dbaagent/service/UserDataAccessPolicyService.java
+++ b/backend/src/main/java/com/dbaagent/service/UserDataAccessPolicyService.java
@@ -1,22 +1,34 @@
 package com.dbaagent.service;
 
+import com.dbaagent.model.DatabaseObject;
+import com.dbaagent.model.InferredTableRelationship;
+import com.dbaagent.model.QueryExecutionOrigin;
 import com.dbaagent.model.QueryRequest;
 import com.dbaagent.model.QueryResult;
-import com.dbaagent.model.DatabaseObject;
 import com.dbaagent.model.SchemaMetadata;
-import com.dbaagent.model.TableMetadata;
 import com.dbaagent.model.SecurityEventOutcome;
 import com.dbaagent.model.SecurityEventType;
+import com.dbaagent.model.TableMetadata;
+import com.dbaagent.model.TrainingDataEmbedding;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.sf.jsqlparser.expression.AnalyticExpression;
 import net.sf.jsqlparser.expression.BinaryExpression;
+import net.sf.jsqlparser.expression.CaseExpression;
+import net.sf.jsqlparser.expression.CastExpression;
 import net.sf.jsqlparser.expression.Expression;
-import net.sf.jsqlparser.expression.Parenthesis;
 import net.sf.jsqlparser.expression.Function;
-import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
+import net.sf.jsqlparser.expression.LongValue;
+import net.sf.jsqlparser.expression.NotExpression;
+import net.sf.jsqlparser.expression.Parenthesis;
+import net.sf.jsqlparser.expression.SignedExpression;
+import net.sf.jsqlparser.expression.WhenClause;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.ExplainStatement;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.select.AllColumns;
 import net.sf.jsqlparser.statement.select.AllTableColumns;
@@ -25,6 +37,9 @@ import net.sf.jsqlparser.statement.select.Join;
 import net.sf.jsqlparser.statement.select.ParenthesedSelect;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.statement.select.SetOperationList;
+import net.sf.jsqlparser.statement.select.WithItem;
+import net.sf.jsqlparser.util.TablesNamesFinder;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -45,6 +60,8 @@ public class UserDataAccessPolicyService {
         ".*\\b(show|list|export|get|give|find|fetch|retrieve|display|tell me|which)\\b.*\\b(email|emails|phone|phones|mobile|bank|credit card|card number|salary|income|ssn|passport|password|token|address)\\b.*",
         Pattern.CASE_INSENSITIVE
     );
+    private static final Set<String> SUMMARY_AGGREGATES = Set.of("sum", "avg");
+    private static final ObjectMapper RAG_METADATA_MAPPER = new ObjectMapper();
 
     private final ConnectionChatAccessPolicyService policyService;
     private final SecurityEventService securityEventService;
@@ -64,13 +81,7 @@ public class UserDataAccessPolicyService {
             || mentionsProtectedColumns(normalized, policy)
             || mentionsProtectedTables(normalized, policy);
 
-        boolean requestsAggregateOnly = normalized.contains("how many")
-            || normalized.contains("count")
-            || normalized.contains("trend")
-            || normalized.contains("summary")
-            || normalized.contains("breakdown");
-
-        if (policy.blockMode() && requestsSensitiveDetails && !requestsAggregateOnly) {
+        if (policy.blockMode() && requestsSensitiveDetails) {
             logPolicyEvent(SecurityEventType.CHAT_ACCESS_POLICY_BLOCKED, username, connectionId, "prompt_blocked", Map.of(
                 "message", truncate(message),
                 "blockedSensitivityCategories", policy.blockedSensitivityCategories(),
@@ -99,8 +110,20 @@ public class UserDataAccessPolicyService {
         QueryRequest queryRequest,
         QueryExecutionContext executionContext
     ) {
-        if (executionContext == null || executionContext.actorUsername() == null || executionContext.actorUsername().isBlank()) {
+        if (executionContext == null) {
+            throw new UserDataAccessPolicyException(
+                "DeepSQL could not determine who is running this query, so it was blocked.",
+                "POLICY_ACTOR_REQUIRED"
+            );
+        }
+        if (isActorExempt(executionContext.origin())) {
             return QueryGuardDecision.allow(ConnectionChatAccessPolicyService.EffectivePolicy.none());
+        }
+        if (executionContext.actorUsername() == null || executionContext.actorUsername().isBlank()) {
+            throw new UserDataAccessPolicyException(
+                "DeepSQL could not determine who is running this query, so it was blocked.",
+                "POLICY_ACTOR_REQUIRED"
+            );
         }
 
         ConnectionChatAccessPolicyService.EffectivePolicy policy = policyService.resolveEffectivePolicy(
@@ -115,37 +138,45 @@ public class UserDataAccessPolicyService {
         Map<String, ConnectionChatAccessPolicyService.ProtectionDescriptor> protectedObjects =
             policyService.buildProtectionDescriptors(policy);
 
+        Statement parsed;
         try {
-            Statement parsed = CCJSqlParserUtil.parse(queryRequest.getQuery());
-            if (parsed instanceof Select select && select.getPlainSelect() != null) {
-                enforceAllowedSchemas(select.getPlainSelect(), policy.allowedSchemas());
-                QueryInspection inspection = inspectPlainSelect(select.getPlainSelect(), protectedObjects);
-                if (inspection.selectsWildcardFromProtectedTable || inspection.rawProtectedColumnsSelected) {
-                    logPolicyEvent(SecurityEventType.CHAT_ACCESS_POLICY_BLOCKED, executionContext.actorUsername(), connectionId, "sql_blocked", Map.of(
-                        "query", truncate(queryRequest.getQuery()),
-                        "reason", inspection.reason,
-                        "protectedTables", inspection.protectedTables,
-                        "protectedColumns", inspection.protectedColumns
-                    ));
-                    throw new UserDataAccessPolicyException(
-                        "This query would return restricted data for your account, so DeepSQL blocked it before execution.",
-                        "POLICY_SQL_BLOCKED"
-                    );
-                }
-            }
-        } catch (UserDataAccessPolicyException e) {
-            throw e;
+            parsed = CCJSqlParserUtil.parse(queryRequest.getQuery());
         } catch (Exception e) {
-            String normalized = queryRequest.getQuery() == null ? "" : queryRequest.getQuery().toLowerCase(Locale.ROOT);
-            if (containsDangerousProtectedReference(normalized, protectedObjects)) {
-                logPolicyEvent(SecurityEventType.CHAT_ACCESS_POLICY_BLOCKED, executionContext.actorUsername(), connectionId, "sql_blocked_fallback", Map.of(
-                    "query", truncate(queryRequest.getQuery())
+            logPolicyEvent(SecurityEventType.CHAT_ACCESS_POLICY_BLOCKED, executionContext.actorUsername(), connectionId, "sql_unparseable", Map.of(
+                "query", truncate(queryRequest.getQuery())
+            ));
+            throw new UserDataAccessPolicyException(
+                "This query could not be verified against your access policy, so DeepSQL blocked it before execution.",
+                "POLICY_SQL_UNPARSEABLE"
+            );
+        }
+
+        try {
+            Statement inspectable = unwrapExplain(parsed);
+            if (!(inspectable instanceof Select select)) {
+                throw new UserDataAccessPolicyException(
+                    "This statement shape cannot be verified against your access policy, so DeepSQL blocked it.",
+                    "POLICY_SQL_UNHANDLED"
+                );
+            }
+            enforceAllowedSchemas(select, policy.allowedSchemas());
+            QueryInspection inspection = inspectSelect(select, protectedObjects, policy.allowAggregates());
+            if (inspection.selectsWildcardFromProtectedTable
+                || inspection.rawProtectedColumnsSelected
+                || inspection.unresolvedProtectedReference) {
+                logPolicyEvent(SecurityEventType.CHAT_ACCESS_POLICY_BLOCKED, executionContext.actorUsername(), connectionId, "sql_blocked", Map.of(
+                    "query", truncate(queryRequest.getQuery()),
+                    "reason", inspection.reason,
+                    "protectedTables", inspection.protectedTables,
+                    "protectedColumns", inspection.protectedColumns
                 ));
                 throw new UserDataAccessPolicyException(
-                    "This query appears to target restricted data for your account, so DeepSQL blocked it before execution.",
+                    "This query would return restricted data for your account, so DeepSQL blocked it before execution.",
                     "POLICY_SQL_BLOCKED"
                 );
             }
+        } catch (UserDataAccessPolicyException e) {
+            throw e;
         }
 
         return QueryGuardDecision.allow(policy);
@@ -203,6 +234,57 @@ public class UserDataAccessPolicyService {
         return filtered;
     }
 
+    public List<TrainingDataEmbedding> filterRagEmbeddings(
+        String connectionId,
+        String username,
+        boolean actorIsAdmin,
+        List<TrainingDataEmbedding> embeddings
+    ) {
+        if (embeddings == null || embeddings.isEmpty()) {
+            return embeddings == null ? List.of() : embeddings;
+        }
+        Set<String> allowedSchemas = allowedSchemasForActor(connectionId, username, actorIsAdmin);
+        if (allowedSchemas.isEmpty()) {
+            return embeddings;
+        }
+        return embeddings.stream()
+            .filter(embedding -> isRagMetadataInScope(allowedSchemas, embedding == null ? null : embedding.getMetadata()))
+            .toList();
+    }
+
+    public boolean isRagMetadataInScope(
+        String connectionId,
+        String username,
+        boolean actorIsAdmin,
+        String metadataJson
+    ) {
+        Set<String> allowedSchemas = allowedSchemasForActor(connectionId, username, actorIsAdmin);
+        if (allowedSchemas.isEmpty()) {
+            return true;
+        }
+        return isRagMetadataInScope(allowedSchemas, metadataJson);
+    }
+
+    public List<InferredTableRelationship> filterInferredRelationships(
+        String connectionId,
+        String username,
+        boolean actorIsAdmin,
+        List<InferredTableRelationship> relationships
+    ) {
+        if (relationships == null || relationships.isEmpty()) {
+            return relationships;
+        }
+        Set<String> allowedSchemas = allowedSchemasForActor(connectionId, username, actorIsAdmin);
+        if (allowedSchemas.isEmpty()) {
+            return relationships;
+        }
+        return relationships.stream()
+            .filter(relationship -> relationship != null
+                && ConnectionChatAccessPolicyService.isSchemaInScope(schemaFromTableRef(relationship.getSourceTable()), allowedSchemas)
+                && ConnectionChatAccessPolicyService.isSchemaInScope(schemaFromTableRef(relationship.getTargetTable()), allowedSchemas))
+            .toList();
+    }
+
     public void assertTableSchemaAllowed(
         String connectionId,
         String username,
@@ -237,8 +319,11 @@ public class UserDataAccessPolicyService {
             return "";
         }
         String normalized = normalizeName(tableRef);
-        int separator = normalized.lastIndexOf('.');
-        return separator > 0 ? normalized.substring(0, separator) : "";
+        String[] parts = normalized.split("\\.");
+        if (parts.length >= 2) {
+            return parts[parts.length - 2];
+        }
+        return "";
     }
 
     public QueryResult redactResult(
@@ -266,36 +351,23 @@ public class UserDataAccessPolicyService {
             return result;
         }
 
-        Set<String> protectedColumnNames = new LinkedHashSet<>();
-        descriptors.values().forEach(descriptor -> {
-            String qualifiedTable = descriptor.qualifiedTableName();
-            descriptor.restrictedColumns().forEach(column ->
-                protectedColumnNames.add(normalizeName(qualifiedTable + "." + column))
-            );
-            if (descriptor.protectWholeTable()) {
-                protectedColumnNames.add(normalizeName(qualifiedTable));
-            }
-        });
+        Set<Integer> redactIndexes = resolveRedactIndexes(result, descriptors);
+        if (redactIndexes.isEmpty()) {
+            return result;
+        }
 
         List<List<Object>> redactedRows = new ArrayList<>();
-        boolean redacted = false;
         for (List<Object> row : result.getRows()) {
             List<Object> redactedRow = new ArrayList<>();
             for (int i = 0; i < row.size(); i++) {
-                String column = i < result.getColumns().size() ? result.getColumns().get(i) : "";
                 Object value = row.get(i);
-                if (shouldRedactColumn(column, protectedColumnNames)) {
+                if (redactIndexes.contains(i)) {
                     redactedRow.add(redactValue(value));
-                    redacted = true;
                 } else {
                     redactedRow.add(value);
                 }
             }
             redactedRows.add(redactedRow);
-        }
-
-        if (!redacted) {
-            return result;
         }
 
         QueryResult redactedResult = new QueryResult(
@@ -315,6 +387,104 @@ public class UserDataAccessPolicyService {
         return redactedResult;
     }
 
+    private Set<Integer> resolveRedactIndexes(
+        QueryResult result,
+        Map<String, ConnectionChatAccessPolicyService.ProtectionDescriptor> descriptors
+    ) {
+        Set<Integer> indexes = new LinkedHashSet<>();
+        List<Set<ColumnReference>> provenance = resolveOutputProvenance(result.getQuery());
+        if (provenance != null && provenance.size() == result.getColumns().size()) {
+            for (int i = 0; i < provenance.size(); i++) {
+                Set<ColumnReference> sources = provenance.get(i);
+                if (sources.isEmpty()) {
+                    continue;
+                }
+                for (ColumnReference reference : sources) {
+                    if (isProtectedReference(descriptors, reference)) {
+                        indexes.add(i);
+                        break;
+                    }
+                }
+            }
+            return indexes;
+        }
+
+        Set<String> protectedColumnNames = new LinkedHashSet<>();
+        descriptors.values().forEach(descriptor -> {
+            String qualifiedTable = descriptor.qualifiedTableName();
+            descriptor.restrictedColumns().forEach(column ->
+                protectedColumnNames.add(normalizeName(qualifiedTable + "." + column))
+            );
+            if (descriptor.protectWholeTable()) {
+                protectedColumnNames.add(normalizeName(qualifiedTable));
+            }
+        });
+        for (int i = 0; i < result.getColumns().size(); i++) {
+            if (shouldRedactColumn(result.getColumns().get(i), protectedColumnNames)) {
+                indexes.add(i);
+            }
+        }
+        return indexes;
+    }
+
+    private List<Set<ColumnReference>> resolveOutputProvenance(String sql) {
+        if (sql == null || sql.isBlank()) {
+            return null;
+        }
+        try {
+            Statement parsed = unwrapExplain(CCJSqlParserUtil.parse(sql));
+            if (!(parsed instanceof Select select)) {
+                return null;
+            }
+            PlainSelect outermost = outermostPlainSelect(select);
+            if (outermost == null || outermost.getSelectItems() == null) {
+                return null;
+            }
+            Map<String, String> aliasToTable = buildAliasMap(outermost);
+            String defaultTableName = resolveDefaultTableName(outermost, aliasToTable);
+            List<Set<ColumnReference>> provenance = new ArrayList<>();
+            outermost.getSelectItems().forEach(item -> {
+                Set<ColumnReference> referenced = new LinkedHashSet<>();
+                Expression expression = item.getExpression();
+                if (expression instanceof AllColumns || expression instanceof AllTableColumns) {
+                    provenance.clear();
+                    return;
+                }
+                collectColumns(expression, referenced, aliasToTable, defaultTableName);
+                provenance.add(referenced);
+            });
+            return provenance.size() == outermost.getSelectItems().size() ? provenance : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private PlainSelect outermostPlainSelect(Select select) {
+        if (select == null) {
+            return null;
+        }
+        PlainSelect plainSelect = asPlainSelect(select);
+        if (plainSelect != null) {
+            return plainSelect;
+        }
+        SetOperationList setOperationList = asSetOperationList(select);
+        if (setOperationList != null && setOperationList.getSelects() != null && !setOperationList.getSelects().isEmpty()) {
+            return outermostPlainSelect(setOperationList.getSelects().getFirst());
+        }
+        if (select instanceof ParenthesedSelect parenthesedSelect) {
+            return outermostPlainSelect(parenthesedSelect.getSelect());
+        }
+        return null;
+    }
+
+    private PlainSelect asPlainSelect(Select select) {
+        return select instanceof PlainSelect plainSelect ? plainSelect : null;
+    }
+
+    private SetOperationList asSetOperationList(Select select) {
+        return select instanceof SetOperationList setOperationList ? setOperationList : null;
+    }
+
     private boolean mentionsProtectedColumns(String normalized, ConnectionChatAccessPolicyService.EffectivePolicy policy) {
         return policy.impactedColumns().stream().anyMatch(column -> normalized.contains(column.toLowerCase(Locale.ROOT))
             || normalized.contains(column.substring(column.indexOf('.') + 1).toLowerCase(Locale.ROOT)));
@@ -324,17 +494,35 @@ public class UserDataAccessPolicyService {
         return policy.impactedTables().stream().anyMatch(table -> normalized.contains(table.toLowerCase(Locale.ROOT)));
     }
 
-    private void enforceAllowedSchemas(PlainSelect select, Set<String> allowedSchemas) {
+    private Statement unwrapExplain(Statement parsed) {
+        if (parsed instanceof ExplainStatement explain && explain.getStatement() != null) {
+            return unwrapExplain(explain.getStatement());
+        }
+        return parsed;
+    }
+
+    private void enforceAllowedSchemas(Select select, Set<String> allowedSchemas) {
         if (allowedSchemas == null || allowedSchemas.isEmpty()) {
             return;
         }
-        Map<String, String> aliasToTable = buildAliasMap(select);
+        Set<String> cteNames = new LinkedHashSet<>();
+        collectCteNames(select, cteNames);
+        Set<String> tables = findReferencedTables(select);
         Set<String> referencedSchemas = new LinkedHashSet<>();
-        collectReferencedSchemas(select.getFromItem(), aliasToTable, referencedSchemas);
-        if (select.getJoins() != null) {
-            for (Join join : select.getJoins()) {
-                collectReferencedSchemas(join.getRightItem(), aliasToTable, referencedSchemas);
+        for (String tableName : tables) {
+            String normalized = normalizeName(tableName);
+            String bare = bareTableName(normalized);
+            if (cteNames.contains(bare) && !normalized.contains(".")) {
+                continue;
             }
+            String schema = schemaFromTableRef(normalized);
+            if (schema.isBlank()) {
+                throw new UserDataAccessPolicyException(
+                    "This query references an unqualified table which is outside your allowed schema scope.",
+                    "POLICY_SCHEMA_BLOCKED"
+                );
+            }
+            referencedSchemas.add(schema);
         }
         for (String schema : referencedSchemas) {
             if (!allowedSchemas.contains(normalizeName(schema))) {
@@ -346,45 +534,90 @@ public class UserDataAccessPolicyService {
         }
     }
 
-    private void collectReferencedSchemas(FromItem fromItem, Map<String, String> aliasToTable, Set<String> schemas) {
-        if (fromItem instanceof Table table) {
-            String schema = table.getSchemaName();
-            if (schema != null && !schema.isBlank()) {
-                schemas.add(schema);
-                return;
+    private Set<String> findReferencedTables(Select select) {
+        TablesNamesFinder finder = new TablesNamesFinder();
+        List<String> tableList = finder.getTableList((Statement) select);
+        return tableList == null ? Set.of() : new LinkedHashSet<>(tableList);
+    }
+
+    private void collectCteNames(Select select, Set<String> names) {
+        if (select == null) {
+            return;
+        }
+        if (select.getWithItemsList() != null) {
+            for (WithItem withItem : select.getWithItemsList()) {
+                if (withItem.getAlias() != null && withItem.getAlias().getName() != null) {
+                    names.add(normalizeName(withItem.getAlias().getName()));
+                }
+                if (withItem.getSelect() != null) {
+                    collectCteNames(withItem.getSelect(), names);
+                }
             }
-            String qualified = aliasToTable.get(normalizeName(table.getName()));
-            if (qualified != null && qualified.contains(".")) {
-                schemas.add(qualified.substring(0, qualified.indexOf('.')));
+        }
+        SetOperationList setOperationList = asSetOperationList(select);
+        if (setOperationList != null && setOperationList.getSelects() != null) {
+            for (Select part : setOperationList.getSelects()) {
+                collectCteNames(part, names);
             }
         }
     }
 
-    private boolean containsDangerousProtectedReference(
-        String normalizedSql,
-        Map<String, ConnectionChatAccessPolicyService.ProtectionDescriptor> protectedObjects
+    private QueryInspection inspectSelect(
+        Select select,
+        Map<String, ConnectionChatAccessPolicyService.ProtectionDescriptor> protectedObjects,
+        boolean allowAggregates
     ) {
-        for (ConnectionChatAccessPolicyService.ProtectionDescriptor descriptor : protectedObjects.values()) {
-            String qualified = normalizeName(descriptor.qualifiedTableName());
-            if (descriptor.protectWholeTable() && normalizedSql.contains(qualified)) {
-                return true;
-            }
-            for (String column : descriptor.restrictedColumns()) {
-                if (normalizedSql.contains(qualified + "." + normalizeName(column))) {
-                    return true;
+        QueryInspection inspection = new QueryInspection();
+        if (select == null) {
+            inspection.unresolvedProtectedReference = true;
+            inspection.reason = "Unhandled SELECT shape";
+            return inspection;
+        }
+        if (select.getWithItemsList() != null) {
+            for (WithItem withItem : select.getWithItemsList()) {
+                if (withItem.getSelect() != null) {
+                    inspection.merge(inspectSelect(withItem.getSelect(), protectedObjects, allowAggregates));
                 }
             }
         }
-        return false;
+        PlainSelect plainSelect = asPlainSelect(select);
+        if (plainSelect != null) {
+            inspection.merge(inspectPlainSelect(plainSelect, protectedObjects, allowAggregates));
+            return inspection;
+        }
+        SetOperationList setOperationList = asSetOperationList(select);
+        if (setOperationList != null && setOperationList.getSelects() != null) {
+            for (Select part : setOperationList.getSelects()) {
+                inspection.merge(inspectSelect(part, protectedObjects, allowAggregates));
+            }
+            return inspection;
+        }
+        if (select instanceof ParenthesedSelect parenthesedSelect && parenthesedSelect.getSelect() != null) {
+            inspection.merge(inspectSelect(parenthesedSelect.getSelect(), protectedObjects, allowAggregates));
+            return inspection;
+        }
+        inspection.unresolvedProtectedReference = true;
+        inspection.reason = "Unhandled SELECT shape";
+        return inspection;
     }
 
     private QueryInspection inspectPlainSelect(
         PlainSelect select,
-        Map<String, ConnectionChatAccessPolicyService.ProtectionDescriptor> protectedObjects
+        Map<String, ConnectionChatAccessPolicyService.ProtectionDescriptor> protectedObjects,
+        boolean allowAggregates
     ) {
         Map<String, String> aliasToTable = buildAliasMap(select);
         String defaultTableName = resolveDefaultTableName(select, aliasToTable);
         QueryInspection inspection = new QueryInspection();
+        boolean grouped = select.getGroupBy() != null;
+        inspectFromItem(select.getFromItem(), protectedObjects, allowAggregates, inspection);
+        if (select.getJoins() != null) {
+            for (Join join : select.getJoins()) {
+                inspectFromItem(join.getRightItem(), protectedObjects, allowAggregates, inspection);
+            }
+        }
+        inspectExpressionTree(select.getWhere(), aliasToTable, defaultTableName, protectedObjects, allowAggregates, inspection);
+        inspectExpressionTree(select.getHaving(), aliasToTable, defaultTableName, protectedObjects, allowAggregates, inspection);
         if (select.getSelectItems() == null) {
             return inspection;
         }
@@ -404,7 +637,7 @@ public class UserDataAccessPolicyService {
             if (expression instanceof AllTableColumns allTableColumns) {
                 String tableName = resolveQualifiedTableName(allTableColumns.getTable(), aliasToTable);
                 ConnectionChatAccessPolicyService.ProtectionDescriptor descriptor = lookupDescriptor(protectedObjects, tableName);
-                if (descriptor != null) {
+                if (descriptor != null && (descriptor.protectWholeTable() || !descriptor.restrictedColumns().isEmpty())) {
                     inspection.selectsWildcardFromProtectedTable = true;
                     inspection.reason = "SELECT table.* touches protected table";
                     inspection.protectedTables.add(descriptor.qualifiedTableName());
@@ -414,18 +647,33 @@ public class UserDataAccessPolicyService {
 
             Set<ColumnReference> referencedColumns = new LinkedHashSet<>();
             collectColumns(expression, referencedColumns, aliasToTable, defaultTableName);
-            boolean aggregateExpression = containsAggregate(expression);
+            if (containsSubselect(expression)) {
+                inspectExpressionTree(expression, aliasToTable, defaultTableName, protectedObjects, allowAggregates, inspection);
+            }
+            boolean aggregateExemption = !grouped && isCountStarOnly(expression);
+            if (allowAggregates && !grouped && isSummaryAggregate(expression)) {
+                aggregateExemption = true;
+            }
+            if (referencedColumns.isEmpty() && !isLiteralOrCountStar(expression) && mentionsAnyProtectedName(expression, protectedObjects)) {
+                inspection.unresolvedProtectedReference = true;
+                inspection.reason = "Protected column provenance could not be established";
+                return;
+            }
             for (ColumnReference reference : referencedColumns) {
-                ConnectionChatAccessPolicyService.ProtectionDescriptor descriptor = lookupDescriptor(protectedObjects, reference.tableName());
-                if (descriptor == null) {
+                if ((reference.tableName() == null || reference.tableName().isBlank()) && defaultTableName.isBlank()) {
+                    if (!protectedObjects.isEmpty()) {
+                        inspection.unresolvedProtectedReference = true;
+                        inspection.reason = "Protected column provenance could not be established";
+                    }
                     continue;
                 }
-                boolean protectedColumn = descriptor.protectWholeTable()
-                    || descriptor.restrictedColumns().stream().anyMatch(column -> normalizeName(column).equals(normalizeName(reference.columnName())));
-                if (protectedColumn) {
-                    inspection.protectedTables.add(descriptor.qualifiedTableName());
-                    inspection.protectedColumns.add(descriptor.qualifiedTableName() + "." + reference.columnName());
-                    if (!aggregateExpression) {
+                if (isProtectedReference(protectedObjects, reference)) {
+                    ConnectionChatAccessPolicyService.ProtectionDescriptor descriptor = lookupDescriptor(protectedObjects, reference.tableName());
+                    if (descriptor != null) {
+                        inspection.protectedTables.add(descriptor.qualifiedTableName());
+                        inspection.protectedColumns.add(descriptor.qualifiedTableName() + "." + reference.columnName());
+                    }
+                    if (!aggregateExemption) {
                         inspection.rawProtectedColumnsSelected = true;
                         inspection.reason = "Raw protected column selected";
                     }
@@ -433,6 +681,66 @@ public class UserDataAccessPolicyService {
             }
         });
         return inspection;
+    }
+
+    private void inspectFromItem(
+        FromItem fromItem,
+        Map<String, ConnectionChatAccessPolicyService.ProtectionDescriptor> protectedObjects,
+        boolean allowAggregates,
+        QueryInspection inspection
+    ) {
+        if (fromItem instanceof ParenthesedSelect parenthesedSelect) {
+            inspection.merge(inspectSelect(parenthesedSelect, protectedObjects, allowAggregates));
+        } else if (fromItem instanceof Select select) {
+            inspection.merge(inspectSelect(select, protectedObjects, allowAggregates));
+        }
+    }
+
+    private void inspectExpressionTree(
+        Expression expression,
+        Map<String, String> aliasToTable,
+        String defaultTableName,
+        Map<String, ConnectionChatAccessPolicyService.ProtectionDescriptor> protectedObjects,
+        boolean allowAggregates,
+        QueryInspection inspection
+    ) {
+        if (expression instanceof ParenthesedSelect parenthesedSelect) {
+            inspection.merge(inspectSelect(parenthesedSelect, protectedObjects, allowAggregates));
+            return;
+        }
+        if (expression instanceof Select select) {
+            inspection.merge(inspectSelect(select, protectedObjects, allowAggregates));
+            return;
+        }
+        if (expression instanceof Function function && function.getParameters() != null) {
+            for (Expression parameter : function.getParameters().getExpressions()) {
+                inspectExpressionTree(parameter, aliasToTable, defaultTableName, protectedObjects, allowAggregates, inspection);
+            }
+            return;
+        }
+        if (expression instanceof BinaryExpression binaryExpression) {
+            inspectExpressionTree(binaryExpression.getLeftExpression(), aliasToTable, defaultTableName, protectedObjects, allowAggregates, inspection);
+            inspectExpressionTree(binaryExpression.getRightExpression(), aliasToTable, defaultTableName, protectedObjects, allowAggregates, inspection);
+            return;
+        }
+        if (expression instanceof Parenthesis parenthesis) {
+            inspectExpressionTree(parenthesis.getExpression(), aliasToTable, defaultTableName, protectedObjects, allowAggregates, inspection);
+            return;
+        }
+        if (expression instanceof CastExpression castExpression) {
+            inspectExpressionTree(castExpression.getLeftExpression(), aliasToTable, defaultTableName, protectedObjects, allowAggregates, inspection);
+            return;
+        }
+        if (expression instanceof CaseExpression caseExpression) {
+            inspectExpressionTree(caseExpression.getSwitchExpression(), aliasToTable, defaultTableName, protectedObjects, allowAggregates, inspection);
+            if (caseExpression.getWhenClauses() != null) {
+                for (WhenClause whenClause : caseExpression.getWhenClauses()) {
+                    inspectExpressionTree(whenClause.getWhenExpression(), aliasToTable, defaultTableName, protectedObjects, allowAggregates, inspection);
+                    inspectExpressionTree(whenClause.getThenExpression(), aliasToTable, defaultTableName, protectedObjects, allowAggregates, inspection);
+                }
+            }
+            inspectExpressionTree(caseExpression.getElseExpression(), aliasToTable, defaultTableName, protectedObjects, allowAggregates, inspection);
+        }
     }
 
     private String resolveDefaultTableName(PlainSelect select, Map<String, String> aliasToTable) {
@@ -508,6 +816,10 @@ public class UserDataAccessPolicyService {
             }
             return;
         }
+        if (expression instanceof AnalyticExpression analyticExpression) {
+            collectColumns(analyticExpression.getExpression(), references, aliasToTable, defaultTableName);
+            return;
+        }
         if (expression instanceof BinaryExpression binaryExpression) {
             collectColumns(binaryExpression.getLeftExpression(), references, aliasToTable, defaultTableName);
             collectColumns(binaryExpression.getRightExpression(), references, aliasToTable, defaultTableName);
@@ -515,6 +827,29 @@ public class UserDataAccessPolicyService {
         }
         if (expression instanceof Parenthesis parenthesis) {
             collectColumns(parenthesis.getExpression(), references, aliasToTable, defaultTableName);
+            return;
+        }
+        if (expression instanceof CastExpression castExpression) {
+            collectColumns(castExpression.getLeftExpression(), references, aliasToTable, defaultTableName);
+            return;
+        }
+        if (expression instanceof SignedExpression signedExpression) {
+            collectColumns(signedExpression.getExpression(), references, aliasToTable, defaultTableName);
+            return;
+        }
+        if (expression instanceof NotExpression notExpression) {
+            collectColumns(notExpression.getExpression(), references, aliasToTable, defaultTableName);
+            return;
+        }
+        if (expression instanceof CaseExpression caseExpression) {
+            collectColumns(caseExpression.getSwitchExpression(), references, aliasToTable, defaultTableName);
+            if (caseExpression.getWhenClauses() != null) {
+                for (WhenClause whenClause : caseExpression.getWhenClauses()) {
+                    collectColumns(whenClause.getWhenExpression(), references, aliasToTable, defaultTableName);
+                    collectColumns(whenClause.getThenExpression(), references, aliasToTable, defaultTableName);
+                }
+            }
+            collectColumns(caseExpression.getElseExpression(), references, aliasToTable, defaultTableName);
         }
     }
 
@@ -550,16 +885,73 @@ public class UserDataAccessPolicyService {
         return null;
     }
 
-    private boolean containsAggregate(Expression expression) {
-        if (expression instanceof Function function) {
-            String name = function.getName();
-            return name != null && List.of("count", "sum", "avg", "min", "max", "array_agg", "string_agg").contains(name.toLowerCase(Locale.ROOT));
+    private boolean isProtectedReference(
+        Map<String, ConnectionChatAccessPolicyService.ProtectionDescriptor> protectedObjects,
+        ColumnReference reference
+    ) {
+        ConnectionChatAccessPolicyService.ProtectionDescriptor descriptor = lookupDescriptor(protectedObjects, reference.tableName());
+        if (descriptor == null) {
+            return false;
         }
-        if (expression instanceof BinaryExpression binaryExpression) {
-            return containsAggregate(binaryExpression.getLeftExpression()) || containsAggregate(binaryExpression.getRightExpression());
+        return descriptor.protectWholeTable()
+            || descriptor.restrictedColumns().stream().anyMatch(column -> normalizeName(column).equals(normalizeName(reference.columnName())));
+    }
+
+    private boolean isCountStarOnly(Expression expression) {
+        if (!(expression instanceof Function function)) {
+            return false;
         }
-        if (expression instanceof Parenthesis parenthesis) {
-            return containsAggregate(parenthesis.getExpression());
+        if (function.getName() == null || !"count".equalsIgnoreCase(function.getName())) {
+            return false;
+        }
+        if (function.isAllColumns()) {
+            return true;
+        }
+        if (function.getParameters() == null || function.getParameters().getExpressions() == null
+            || function.getParameters().getExpressions().isEmpty()) {
+            return true;
+        }
+        if (function.getParameters().getExpressions().size() != 1) {
+            return false;
+        }
+        Expression parameter = function.getParameters().getExpressions().getFirst();
+        if (parameter instanceof AllColumns) {
+            return true;
+        }
+        return parameter instanceof LongValue longValue && longValue.getValue() == 1;
+    }
+
+    private boolean isSummaryAggregate(Expression expression) {
+        if (!(expression instanceof Function function) || function.getName() == null) {
+            return false;
+        }
+        return SUMMARY_AGGREGATES.contains(function.getName().toLowerCase(Locale.ROOT));
+    }
+
+    private boolean isLiteralOrCountStar(Expression expression) {
+        return isCountStarOnly(expression)
+            || expression instanceof LongValue
+            || (expression != null && expression.getClass().getSimpleName().contains("Value"));
+    }
+
+    private boolean containsSubselect(Expression expression) {
+        return expression instanceof Select || expression instanceof ParenthesedSelect;
+    }
+
+    private boolean mentionsAnyProtectedName(
+        Expression expression,
+        Map<String, ConnectionChatAccessPolicyService.ProtectionDescriptor> protectedObjects
+    ) {
+        if (expression == null) {
+            return false;
+        }
+        String rendered = normalizeName(expression.toString());
+        for (ConnectionChatAccessPolicyService.ProtectionDescriptor descriptor : protectedObjects.values()) {
+            for (String column : descriptor.restrictedColumns()) {
+                if (rendered.contains(normalizeName(column))) {
+                    return true;
+                }
+            }
         }
         return false;
     }
@@ -585,6 +977,80 @@ public class UserDataAccessPolicyService {
         return "[redacted:" + rendered.length() + "]";
     }
 
+    private boolean isRagMetadataInScope(Set<String> allowedSchemas, String metadataJson) {
+        Set<String> tableRefs = extractTableRefsFromMetadata(metadataJson);
+        if (tableRefs.isEmpty()) {
+            return false;
+        }
+        for (String tableRef : tableRefs) {
+            if (!ConnectionChatAccessPolicyService.isSchemaInScope(schemaFromTableRef(tableRef), allowedSchemas)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private Set<String> extractTableRefsFromMetadata(String metadataJson) {
+        Set<String> tables = new LinkedHashSet<>();
+        if (metadataJson == null || metadataJson.isBlank()) {
+            return tables;
+        }
+        try {
+            JsonNode node = RAG_METADATA_MAPPER.readTree(metadataJson);
+            addTextualTable(tables, node, "tableName");
+            addTextualTable(tables, node, "objectName");
+            addTextualTable(tables, node, "schema");
+            addTextualTable(tables, node, "schemaName");
+            if (node.has("tablesUsed") && node.get("tablesUsed").isTextual()) {
+                for (String table : node.get("tablesUsed").asText("").split(",")) {
+                    addTableRef(tables, table);
+                }
+            }
+            addArrayTables(tables, node.get("linkedTables"));
+            if (node.has("linkedColumns") && node.get("linkedColumns").isArray()) {
+                for (JsonNode linkedColumn : node.get("linkedColumns")) {
+                    String columnReference = linkedColumn.asText("").trim();
+                    int lastDot = columnReference.lastIndexOf('.');
+                    if (lastDot > 0) {
+                        addTableRef(tables, columnReference.substring(0, lastDot));
+                    }
+                }
+            }
+        } catch (Exception ignored) {
+            return Set.of();
+        }
+        return tables;
+    }
+
+    private void addTextualTable(Set<String> tables, JsonNode node, String field) {
+        if (node != null && node.has(field) && node.get(field).isTextual()) {
+            addTableRef(tables, node.get(field).asText());
+        }
+    }
+
+    private void addArrayTables(Set<String> tables, JsonNode array) {
+        if (array == null || !array.isArray()) {
+            return;
+        }
+        for (JsonNode item : array) {
+            addTableRef(tables, item.asText());
+        }
+    }
+
+    private void addTableRef(Set<String> tables, String raw) {
+        if (raw == null) {
+            return;
+        }
+        String trimmed = raw.trim();
+        if (!trimmed.isBlank()) {
+            tables.add(trimmed);
+        }
+    }
+
+    private boolean isActorExempt(QueryExecutionOrigin origin) {
+        return origin == QueryExecutionOrigin.INTERNAL || origin == QueryExecutionOrigin.SCHEDULED;
+    }
+
     private void logPolicyEvent(SecurityEventType eventType, String username, String connectionId, String reason, Map<String, Object> metadata) {
         securityEventService.log(SecurityEventService.EventRequest.builder()
             .eventType(eventType)
@@ -605,6 +1071,11 @@ public class UserDataAccessPolicyService {
 
     private String normalizeName(String value) {
         return value == null ? "" : value.trim().replace("\"", "").replace("`", "").toLowerCase(Locale.ROOT);
+    }
+
+    private String bareTableName(String qualified) {
+        int separator = qualified.lastIndexOf('.');
+        return separator >= 0 ? qualified.substring(separator + 1) : qualified;
     }
 
     public record PromptDecision(
@@ -633,9 +1104,21 @@ public class UserDataAccessPolicyService {
     private static final class QueryInspection {
         private boolean selectsWildcardFromProtectedTable;
         private boolean rawProtectedColumnsSelected;
+        private boolean unresolvedProtectedReference;
         private String reason;
         private final List<String> protectedTables = new ArrayList<>();
         private final List<String> protectedColumns = new ArrayList<>();
+
+        private void merge(QueryInspection other) {
+            this.selectsWildcardFromProtectedTable |= other.selectsWildcardFromProtectedTable;
+            this.rawProtectedColumnsSelected |= other.rawProtectedColumnsSelected;
+            this.unresolvedProtectedReference |= other.unresolvedProtectedReference;
+            if (this.reason == null) {
+                this.reason = other.reason;
+            }
+            this.protectedTables.addAll(other.protectedTables);
+            this.protectedColumns.addAll(other.protectedColumns);
+        }
     }
 
     private record ColumnReference(String tableName, String columnName) {

--- a/backend/src/main/resources/db/migration/V115__chat_access_policy_allowed_schemas.sql
+++ b/backend/src/main/resources/db/migration/V115__chat_access_policy_allowed_schemas.sql
@@ -1,0 +1,3 @@
+ALTER TABLE connection_chat_access_policy
+    ADD COLUMN IF NOT EXISTS allowed_schemas jsonb,
+    ADD COLUMN IF NOT EXISTS allow_aggregates BOOLEAN NOT NULL DEFAULT FALSE;

--- a/backend/src/test/java/com/dbaagent/security/JwtUtilImpersonationClaimTest.java
+++ b/backend/src/test/java/com/dbaagent/security/JwtUtilImpersonationClaimTest.java
@@ -1,0 +1,58 @@
+package com.dbaagent.security;
+
+import com.dbaagent.model.Permission;
+import com.dbaagent.model.Role;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Duration;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class JwtUtilImpersonationClaimTest {
+
+    private JwtUtil jwtUtil;
+
+    @BeforeEach
+    void setUp() {
+        jwtUtil = new JwtUtil();
+        ReflectionTestUtils.setField(jwtUtil, "jwtSecret", "x".repeat(32));
+        ReflectionTestUtils.setField(jwtUtil, "authEnabled", true);
+        ReflectionTestUtils.setField(jwtUtil, "activeProfiles", "dev");
+        ReflectionTestUtils.setField(jwtUtil, "accessTokenMinutes", 15L);
+        jwtUtil.initialize();
+    }
+
+    @Test
+    void accessTokenRoundTripsImpersonateUserId() {
+        String token = jwtUtil.generateAccessToken(
+            "admin",
+            "sess-1",
+            Role.ADMIN,
+            Set.of(Permission.MANAGE_USERS),
+            Duration.ofMinutes(15),
+            2L
+        );
+
+        assertEquals("admin", jwtUtil.extractUsername(token));
+        assertEquals("sess-1", jwtUtil.extractSessionId(token));
+        assertEquals(2L, jwtUtil.extractImpersonateUserId(token));
+        assertEquals("ADMIN", jwtUtil.extractRole(token));
+    }
+
+    @Test
+    void accessTokenWithoutClaimHasNoImpersonateUserId() {
+        String token = jwtUtil.generateAccessToken(
+            "admin",
+            "sess-1",
+            Role.ADMIN,
+            Set.of(Permission.MANAGE_USERS),
+            Duration.ofMinutes(15)
+        );
+
+        assertNull(jwtUtil.extractImpersonateUserId(token));
+    }
+}

--- a/backend/src/test/java/com/dbaagent/service/AgentBridgeServiceImpersonationTest.java
+++ b/backend/src/test/java/com/dbaagent/service/AgentBridgeServiceImpersonationTest.java
@@ -1,0 +1,88 @@
+package com.dbaagent.service;
+
+import com.dbaagent.model.User;
+import com.dbaagent.security.ImpersonationContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AgentBridgeServiceImpersonationTest {
+
+    @Mock
+    private McpTokenService mcpTokenService;
+
+    private AgentBridgeService agentBridgeService;
+
+    @BeforeEach
+    void setUp() {
+        agentBridgeService = new AgentBridgeService(mcpTokenService);
+        ReflectionTestUtils.setField(agentBridgeService, "provisionEnabled", true);
+        ReflectionTestUtils.setField(agentBridgeService, "provisionSecret", "secret");
+        ReflectionTestUtils.setField(agentBridgeService, "provisionerUrl", "http://127.0.0.1:9/provision");
+        ReflectionTestUtils.setField(agentBridgeService, "sessionWindowDays", 7L);
+    }
+
+    @AfterEach
+    void tearDown() {
+        ImpersonationContext.clear();
+    }
+
+    @Test
+    void ensureProfileDoesNotFallBackToAdminSessionTokenWhileImpersonating() {
+        User admin = new User();
+        admin.setId(1L);
+        admin.setUsername("admin");
+        admin.setRole("ADMIN");
+        User editor = new User();
+        editor.setId(2L);
+        editor.setUsername("marts-editor");
+        editor.setRole("DEVELOPER");
+        ImpersonationContext.enter(new ImpersonationContext.State(admin, editor));
+
+        when(mcpTokenService.createTokenForUser(eq("marts-editor"), any(), any()))
+            .thenThrow(new IllegalStateException("mint failed"));
+
+        AgentBridgeService.ProvisioningException ex = assertThrows(
+            AgentBridgeService.ProvisioningException.class,
+            () -> agentBridgeService.ensureProfile("marts-editor", "admin-session-jwt", "conn-1")
+        );
+        assertEquals(
+            "Could not mint an MCP token for marts-editor while viewing as that user",
+            ex.getMessage()
+        );
+    }
+
+    @Test
+    void ensureProfileRefusesDisabledProvisioningWhileImpersonating() {
+        ReflectionTestUtils.setField(agentBridgeService, "provisionEnabled", false);
+        User admin = new User();
+        admin.setId(1L);
+        admin.setUsername("admin");
+        admin.setRole("ADMIN");
+        User editor = new User();
+        editor.setId(2L);
+        editor.setUsername("marts-editor");
+        editor.setRole("DEVELOPER");
+        ImpersonationContext.enter(new ImpersonationContext.State(admin, editor));
+
+        AgentBridgeService.ProvisioningException ex = assertThrows(
+            AgentBridgeService.ProvisioningException.class,
+            () -> agentBridgeService.ensureProfile("marts-editor", "admin-session-jwt", "conn-1")
+        );
+        assertEquals(
+            "Agent provisioning is disabled; View as cannot bind a user-scoped Agent token",
+            ex.getMessage()
+        );
+    }
+}

--- a/backend/src/test/java/com/dbaagent/service/ChatServiceRoutingTest.java
+++ b/backend/src/test/java/com/dbaagent/service/ChatServiceRoutingTest.java
@@ -164,6 +164,8 @@ class ChatServiceRoutingTest {
             .thenReturn(UserDataAccessPolicyService.PromptDecision.allow(ConnectionChatAccessPolicyService.EffectivePolicy.none()));
         lenient().when(userDataAccessPolicyService.decorateQuestionWithPolicy(any(), anyString()))
             .thenAnswer(invocation -> invocation.getArgument(1, String.class));
+        lenient().when(userDataAccessPolicyService.filterSchemaMetadata(any(), any(), anyBoolean(), any()))
+            .thenAnswer(invocation -> invocation.getArgument(3));
         lenient().when(contextAssembler.formatRowCount(anyLong()))
             .thenAnswer(invocation -> String.valueOf(invocation.getArgument(0, Long.class)));
         lenient().when(contextAssembler.formatBytes(anyLong()))

--- a/backend/src/test/java/com/dbaagent/service/ConnectionChatAccessPolicyServiceTest.java
+++ b/backend/src/test/java/com/dbaagent/service/ConnectionChatAccessPolicyServiceTest.java
@@ -115,6 +115,7 @@ class ConnectionChatAccessPolicyServiceTest {
                 "marts.fct_enrollment.currency",
                 "marts.dim_ott_subscription.currency"
             );
+        assertThat(preview.getAllowedSchemas()).containsExactly("marts");
     }
 
     @Test

--- a/backend/src/test/java/com/dbaagent/service/ImpersonationServiceTest.java
+++ b/backend/src/test/java/com/dbaagent/service/ImpersonationServiceTest.java
@@ -7,6 +7,7 @@ import com.dbaagent.model.UserAccountStatus;
 import com.dbaagent.repository.UserRepository;
 import com.dbaagent.security.CustomUserDetailsService;
 import com.dbaagent.security.ImpersonationContext;
+import com.dbaagent.security.JwtUtil;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,6 +55,9 @@ class ImpersonationServiceTest {
     @Mock
     private SecurityEventService securityEventService;
 
+    @Mock
+    private JwtUtil jwtUtil;
+
     @InjectMocks
     private ImpersonationService impersonationService;
 
@@ -61,6 +65,7 @@ class ImpersonationServiceTest {
     void setUp() {
         ReflectionTestUtils.setField(impersonationService, "authEnabled", true);
         ReflectionTestUtils.setField(impersonationService, "impersonateCookieName", "impersonate_user");
+        ReflectionTestUtils.setField(impersonationService, "accessCookieName", "auth_token");
     }
 
     @AfterEach
@@ -82,6 +87,7 @@ class ImpersonationServiceTest {
 
         assertEquals("marts-editor", state.targetUsername());
         verify(authSessionService).writeImpersonationCookie(response, "impersonate_user", 2L);
+        verify(authSessionService, never()).reissueAccessToken(any(), any(), any(), any());
         ArgumentCaptor<SecurityEventService.EventRequest> captor =
             ArgumentCaptor.forClass(SecurityEventService.EventRequest.class);
         verify(securityEventService).log(captor.capture());
@@ -131,6 +137,54 @@ class ImpersonationServiceTest {
         ResponseStatusException ex = assertThrows(ResponseStatusException.class,
             () -> impersonationService.start(editor, 5L, new MockHttpServletRequest(), new MockHttpServletResponse()));
         assertEquals(403, ex.getStatusCode().value());
+    }
+
+    @Test
+    void startRewritesAccessTokenWithImpersonationClaim() {
+        User admin = user(1L, "admin", "ADMIN");
+        User editor = user(2L, "marts-editor", "DEVELOPER");
+        when(userRepository.findById(2L)).thenReturn(Optional.of(editor));
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setAttribute("auth.sessionId", "sess-1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        impersonationService.start(admin, 2L, request, response);
+
+        verify(authSessionService).reissueAccessToken(response, "sess-1", admin, 2L);
+    }
+
+    @Test
+    void applySwapsPrincipalFromAccessTokenClaimWithoutCookie() {
+        User admin = user(1L, "admin", "ADMIN");
+        User editor = user(2L, "marts-editor", "DEVELOPER");
+        when(userRepository.findByUsername("admin")).thenReturn(Optional.of(admin));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(editor));
+        when(jwtUtil.extractImpersonateUserId("admin.jwt.with.imp")).thenReturn(2L);
+        UserDetails editorDetails = new org.springframework.security.core.userdetails.User(
+            "marts-editor",
+            "x",
+            List.of(new SimpleGrantedAuthority("ROLE_DEVELOPER"), new SimpleGrantedAuthority("USE_CHAT"))
+        );
+        when(userDetailsService.loadUserByUsername("marts-editor")).thenReturn(editorDetails);
+
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(
+                "admin",
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_ADMIN"))
+            )
+        );
+
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/connections/abc/query");
+        request.setServletPath("/connections/abc/query");
+        request.addHeader("Authorization", "Bearer admin.jwt.with.imp");
+
+        impersonationService.applyToRequest(request);
+
+        assertEquals("marts-editor", SecurityContextHolder.getContext().getAuthentication().getName());
+        assertTrue(ImpersonationContext.isActive());
+        assertEquals("marts-editor", ImpersonationContext.current().orElseThrow().targetUsername());
     }
 
     @Test

--- a/backend/src/test/java/com/dbaagent/service/QueryExecutionContextTest.java
+++ b/backend/src/test/java/com/dbaagent/service/QueryExecutionContextTest.java
@@ -18,6 +18,14 @@ class QueryExecutionContextTest {
     }
 
     @Test
+    void mcpFactoryHonoursAdminFlagFromSecurityContext() {
+        QueryExecutionContext ctx = QueryExecutionContext.mcp("admin", true);
+        assertThat(ctx.origin()).isEqualTo(QueryExecutionOrigin.MCP);
+        assertThat(ctx.actorUsername()).isEqualTo("admin");
+        assertThat(ctx.actorIsAdmin()).isTrue();
+    }
+
+    @Test
     void scheduledFactoryProducesMayMutateInternalActor() {
         QueryExecutionContext ctx = QueryExecutionContext.scheduled();
         assertThat(ctx.origin()).isEqualTo(QueryExecutionOrigin.SCHEDULED);

--- a/backend/src/test/java/com/dbaagent/service/UserDataAccessPolicyServiceTest.java
+++ b/backend/src/test/java/com/dbaagent/service/UserDataAccessPolicyServiceTest.java
@@ -65,6 +65,21 @@ class UserDataAccessPolicyServiceTest {
     }
 
     @Test
+    void evaluatePrompt_blocksProtectedColumnMentionEvenWhenAskingForACount() {
+        ConnectionChatAccessPolicyService.EffectivePolicy policy = policy();
+        when(policyService.resolveEffectivePolicy("conn-1", "analyst", false)).thenReturn(policy);
+
+        UserDataAccessPolicyService.PromptDecision blocked = service.evaluatePrompt(
+            "conn-1",
+            "analyst",
+            false,
+            "How many customer emails do we have?"
+        );
+
+        assertThat(blocked.allowed()).isFalse();
+    }
+
+    @Test
     void enforcePreExecution_blocksRawProtectedColumns() {
         when(policyService.resolveEffectivePolicy("conn-1", "analyst", false)).thenReturn(policy());
 
@@ -121,6 +136,7 @@ class UserDataAccessPolicyServiceTest {
             Set.of("marts"),
             true,
             true,
+            false,
             "Only schema marts",
             List.of(),
             List.of()
@@ -152,6 +168,7 @@ class UserDataAccessPolicyServiceTest {
             Set.of("marts"),
             true,
             true,
+            false,
             "Only marts; redact amount",
             List.of(),
             List.of("marts.fct_enrollment.amount")
@@ -181,6 +198,7 @@ class UserDataAccessPolicyServiceTest {
             Set.of("marts"),
             true,
             true,
+            false,
             "Only schema marts",
             List.of(),
             List.of()
@@ -208,6 +226,7 @@ class UserDataAccessPolicyServiceTest {
             Set.of("marts"),
             true,
             true,
+            false,
             "Only schema marts",
             List.of(),
             List.of()
@@ -245,6 +264,7 @@ class UserDataAccessPolicyServiceTest {
             Set.of("marts"),
             true,
             true,
+            false,
             "Only schema marts",
             List.of(),
             List.of()
@@ -259,6 +279,183 @@ class UserDataAccessPolicyServiceTest {
         service.assertTableSchemaAllowed("conn-1", "analyst", false, "marts.fct_enrollment");
     }
 
+    @Test
+    void enforcePreExecution_blocksUnionAndSubqueryOutsideAllowedSchema() {
+        stubSchemaPolicy();
+
+        assertThat(assertThrows(
+            UserDataAccessPolicyException.class,
+            () -> enforce("SELECT name FROM marts.fct_enrollment UNION SELECT name FROM sales.customers")
+        ).getErrorCode()).isEqualTo("POLICY_SCHEMA_BLOCKED");
+
+        assertThat(assertThrows(
+            UserDataAccessPolicyException.class,
+            () -> enforce("WITH x AS (SELECT * FROM crm.customers) SELECT * FROM x")
+        ).getErrorCode()).isEqualTo("POLICY_SCHEMA_BLOCKED");
+
+        assertThat(assertThrows(
+            UserDataAccessPolicyException.class,
+            () -> enforce("SELECT * FROM (SELECT * FROM sales.customers) t")
+        ).getErrorCode()).isEqualTo("POLICY_SCHEMA_BLOCKED");
+    }
+
+    @Test
+    void enforcePreExecution_failsClosedOnUnparseableAndUnhandledSql() {
+        stubSchemaPolicy();
+
+        assertThat(assertThrows(
+            UserDataAccessPolicyException.class,
+            () -> enforce("SELECT FROM")
+        ).getErrorCode()).isEqualTo("POLICY_SQL_UNPARSEABLE");
+
+        assertThat(assertThrows(
+            UserDataAccessPolicyException.class,
+            () -> enforce("ALTER TABLE marts.fct_enrollment RENAME TO fct_enrollment_x")
+        ).getErrorCode()).isEqualTo("POLICY_SQL_UNHANDLED");
+    }
+
+    @Test
+    void enforcePreExecution_failsClosedWhenActorIsMissingExceptInternalOrigins() {
+        assertThat(assertThrows(
+            UserDataAccessPolicyException.class,
+            () -> service.enforcePreExecution(
+                "conn-1",
+                new QueryRequest("SELECT 1", null, null),
+                new QueryExecutionContext(QueryExecutionOrigin.MCP, QueryExecutionContext.MutationMode.READ_ONLY_ONLY, null, false, false)
+            )
+        ).getErrorCode()).isEqualTo("POLICY_ACTOR_REQUIRED");
+
+        assertThat(service.enforcePreExecution(
+            "conn-1",
+            new QueryRequest("SELECT 1", null, null),
+            QueryExecutionContext.internal()
+        ).policy().present()).isFalse();
+    }
+
+    @Test
+    void enforcePreExecution_countStarIsAllowedButCountOfProtectedColumnIsNot() {
+        ConnectionChatAccessPolicyService.EffectivePolicy schemaPolicy = martsAmountPolicy();
+        when(policyService.resolveEffectivePolicy("conn-1", "analyst", false)).thenReturn(schemaPolicy);
+        when(policyService.buildProtectionDescriptors(schemaPolicy)).thenReturn(Map.of(
+            "marts.fct_enrollment",
+            descriptor("marts", "fct_enrollment", false, "amount")
+        ));
+
+        assertThat(enforce("SELECT COUNT(*) AS n FROM marts.fct_enrollment").policy().allowedSchemas())
+            .containsExactly("marts");
+
+        assertThat(assertThrows(
+            UserDataAccessPolicyException.class,
+            () -> enforce("SELECT COUNT(amount) FROM marts.fct_enrollment")
+        ).getErrorCode()).isEqualTo("POLICY_SQL_BLOCKED");
+
+        assertThat(assertThrows(
+            UserDataAccessPolicyException.class,
+            () -> enforce("SELECT MIN(amount) FROM marts.fct_enrollment")
+        ).getErrorCode()).isEqualTo("POLICY_SQL_BLOCKED");
+    }
+
+    @Test
+    void redactResult_usesSourceColumnNotOutputAlias() {
+        when(policyService.resolveEffectivePolicy("conn-1", "analyst", false)).thenReturn(policy());
+
+        QueryResult aliasHidden = service.redactResult(
+            "conn-1",
+            new QueryResult(
+                List.of("contact"),
+                List.of(List.of("a@example.com")),
+                1,
+                1L,
+                false,
+                12L,
+                "SELECT email AS contact FROM customer_profiles"
+            ),
+            chatContext()
+        );
+        assertThat(aliasHidden.getRows()).containsExactly(List.of("[redacted:13]"));
+
+        QueryResult aliasSafe = service.redactResult(
+            "conn-1",
+            new QueryResult(
+                List.of("email"),
+                List.of(List.of("Hotel One")),
+                1,
+                1L,
+                false,
+                12L,
+                "SELECT customer_name AS email FROM customer_profiles"
+            ),
+            chatContext()
+        );
+        assertThat(aliasSafe.getRows()).containsExactly(List.of("Hotel One"));
+    }
+
+    @Test
+    void filterRagEmbeddings_dropsOutOfScopeDocuments() {
+        stubSchemaPolicy();
+        var inScope = new com.dbaagent.model.TrainingDataEmbedding();
+        inScope.setMetadata("{\"tableName\":\"marts.fct_enrollment\"}");
+        var outOfScope = new com.dbaagent.model.TrainingDataEmbedding();
+        outOfScope.setMetadata("{\"tableName\":\"sales.customers\"}");
+        var unknown = new com.dbaagent.model.TrainingDataEmbedding();
+        unknown.setMetadata("{}");
+
+        assertThat(service.filterRagEmbeddings("conn-1", "analyst", false, List.of(inScope, outOfScope, unknown)))
+            .containsExactly(inScope);
+    }
+
+    private void stubSchemaPolicy() {
+        ConnectionChatAccessPolicyService.EffectivePolicy schemaPolicy = new ConnectionChatAccessPolicyService.EffectivePolicy(
+            true,
+            "conn-1",
+            "analyst",
+            Set.of(),
+            Set.of(),
+            Set.of(),
+            Set.of("marts"),
+            true,
+            true,
+            false,
+            "Only schema marts",
+            List.of(),
+            List.of()
+        );
+        when(policyService.resolveEffectivePolicy("conn-1", "analyst", false)).thenReturn(schemaPolicy);
+        lenient().when(policyService.buildProtectionDescriptors(schemaPolicy)).thenReturn(Map.of());
+    }
+
+    private ConnectionChatAccessPolicyService.EffectivePolicy martsAmountPolicy() {
+        return new ConnectionChatAccessPolicyService.EffectivePolicy(
+            true,
+            "conn-1",
+            "analyst",
+            Set.of(),
+            Set.of(),
+            Set.of("marts.fct_enrollment.amount"),
+            Set.of("marts"),
+            true,
+            true,
+            false,
+            "Only marts; redact amount",
+            List.of(),
+            List.of("marts.fct_enrollment.amount")
+        );
+    }
+
+    private UserDataAccessPolicyService.QueryGuardDecision enforce(String sql) {
+        return service.enforcePreExecution("conn-1", new QueryRequest(sql, null, null), chatContext());
+    }
+
+    private QueryExecutionContext chatContext() {
+        return new QueryExecutionContext(
+            QueryExecutionOrigin.CHAT,
+            QueryExecutionContext.MutationMode.READ_ONLY_ONLY,
+            "analyst",
+            false,
+            false
+        );
+    }
+
     private ConnectionChatAccessPolicyService.EffectivePolicy policy() {
         return new ConnectionChatAccessPolicyService.EffectivePolicy(
             true,
@@ -270,6 +467,7 @@ class UserDataAccessPolicyServiceTest {
             Set.of(),
             true,
             true,
+            false,
             "No PII",
             List.of(),
             List.of("customer_profiles.email", "customer_profiles.phone_number")

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -105,6 +105,7 @@ server {
     location /agent-api/ {
         # Require a valid DeepSQL session before reaching the agent.
         auth_request /__agent_auth;
+        auth_request_set $deepsql_user $upstream_http_x_remote_user;
 
         # Compose service on the internal network. Literal hostname resolves
         # via Docker DNS. If the agent container is down this route returns
@@ -119,9 +120,10 @@ server {
         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header   X-Forwarded-Proto $scheme;
         # Identity for trusted-proxy mode inside the agent container.
-        # DeepSQL's auth_request already verified the session; the agent
-        # accepts this header instead of its own login form.
-        proxy_set_header   X-Remote-User     admin;
+        # DeepSQL's auth_request already verified the session; stamp the
+        # *effective* user from /api/auth/me (View as overlays the target).
+        # Never hardcode admin — that ran every Agent tab as the admin MCP token.
+        proxy_set_header   X-Remote-User     $deepsql_user;
         proxy_read_timeout 300s;
         proxy_send_timeout 300s;
         proxy_connect_timeout 10s;

--- a/docs/root/CLAUDE.md
+++ b/docs/root/CLAUDE.md
@@ -21,9 +21,14 @@ Do NOT ask "should I update CLAUDE.md?" - just update it as part of task complet
 - Batch multiple related changes into a single commit
 - Provide a custom commit message if needed
 
-## Recent Changes
+- 2026-08-20: Chat access policy enforcement is fail-closed. `UserDataAccessPolicyService`
+  walks the whole parse tree (`TablesNamesFinder` plus CTEs/UNIONs/subqueries), denies
+  unparseable or unhandled SQL, requires an actor except `INTERNAL`/`SCHEDULED`, and
+  exempts only `COUNT(*)` / `COUNT(1)` without `GROUP BY`. MCP and Editor queries take
+  the actor from `SecurityContext` (MCP tokens included). Allowed schemas are persisted
+  on the policy row. RAG, brain relationships, and vault-first metadata are schema-scoped.
+  Public dashboard share is refused on connections with an active policy.
 
-- 2026-08-17: `McpSqlGuardService` (and the matching MCP JS shim) no longer treats
   `COMMENT` / `CALL` / `REPLACE` as mutating when they appear as table, column, or
   function names. The guard matches statement verbs: mutating CTEs, `WITH … DELETE`,
   `FOR UPDATE`, and `EXPLAIN DELETE`. `SELECT * FROM comment` is allowed. Dashboards

--- a/docs/root/CLAUDE.md
+++ b/docs/root/CLAUDE.md
@@ -822,9 +822,9 @@ though the properties themselves still sit in `application*.properties`.
       - `DELETE /api/admin/users/{id}` - Delete user (ADMIN only)
       - `GET /api/admin/roles` - Get all roles with permissions (ADMIN only)
       - `GET /api/admin/impersonate` - List switchable users and current profile-switch status (ADMIN only)
-      - `POST /api/admin/impersonate` - `{ userId }` start viewing the product as that user (ADMIN only; cannot target admins or self)
+      - `POST /api/admin/impersonate` - `{ userId }` start viewing the product as that user (ADMIN only; cannot target admins or self). Sets `impersonate_user` cookie and restamps the access JWT with `impUid` so policy (and Agent Bearer fallback) run as the target while the JWT subject stays the admin.
       - `DELETE /api/admin/impersonate` - Stop profile switch and restore the admin session
-      - `GET /api/auth/me` - Get current user's profile including role/permissions; while switching, this is the **target** user plus `impersonating` / `impersonatorUsername`
+      - `GET /api/auth/me` - Get current user's profile including role/permissions; while switching, this is the **target** user plus `impersonating` / `impersonatorUsername`. Also sets `X-Remote-User` to the effective username for nginx `/agent-api` auth_request.
     - **Frontend Components**:
       - `PermissionGuard.jsx` - Wrapper component for permission-based rendering
       - `UsersTab.jsx` - Admin user management tab in Workspace

--- a/scripts/local-agent-provisioner.py
+++ b/scripts/local-agent-provisioner.py
@@ -56,12 +56,47 @@ def write_token_file(home: Path, token: str) -> Path:
     MCP subprocess (which re-reads this file on every request, see
     deepsql-phase1-lib.js readTokenFile) never observes a partially-written
     token mid-rotation. 0600 — same secrecy bar as the profile .env."""
+    home.mkdir(parents=True, exist_ok=True)
     path = token_file_for(home)
     tmp = path.with_suffix(f".tmp-{os.getpid()}")
     tmp.write_text((token or "") + "\n")
     os.chmod(tmp, 0o600)
     os.replace(tmp, path)
     return path
+
+
+def iter_profile_homes(hermes_home: Path):
+    """Yield each ``profiles/<name>`` directory under a Hermes home."""
+    profiles = hermes_home / "profiles"
+    if not profiles.is_dir():
+        return
+    for child in profiles.iterdir():
+        if child.is_dir():
+            yield child
+
+
+def mirror_token_for_live_mcp(hermes_home: Path, token: str) -> list[Path]:
+    """Copy the provisioned token onto every file a live MCP process might read.
+
+    Hermes starts one DeepSQL MCP stdio server from whichever profile first
+    loaded ``mcp_servers``, then keeps that subprocess for the life of the
+    Agent API. ``POST /api/profile/switch`` is explicitly ``process_wide=False``
+    — it sets a cookie / thread-local for sessions, but does **not** respawn
+    MCP with the target profile's ``DEEPSQL_AUTH_TOKEN``.
+
+    The MCP client re-reads ``DEEPSQL_TOKEN_FILE`` per request (mtime cache).
+    Writing only ``profiles/u-<target>/deepsql.token`` therefore leaves the
+    already-running server on the previous user's credential (in practice the
+    admin who first opened the Agent tab). View as / a new chat thread then
+    executes SQL as admin and skips chat-access policy.
+
+    Mirror onto ``$HERMES_HOME/deepsql.token`` and every profile token file so
+    whichever path the live process was started with picks up the rotation.
+    """
+    written = [write_token_file(hermes_home, token)]
+    for home in iter_profile_homes(hermes_home):
+        written.append(write_token_file(home, token))
+    return written
 
 
 def ensure_profile(name: str) -> Path:
@@ -210,6 +245,11 @@ class Handler(BaseHTTPRequestHandler):
             token_file = write_token_file(home, token)
             write_profile_mcp(home, user=user, token=token, token_file=token_file)
             write_profile_env(home, user=user, token=token, token_file=token_file)
+            mirrored = mirror_token_for_live_mcp(HERMES_HOME, token)
+            sys.stderr.write(
+                f"[agent-provisioner] mirrored MCP token for {user} onto "
+                f"{len(mirrored)} live token file(s)\n"
+            )
         except Exception as e:
             return self._send(500, {"error": str(e)})
         return self._send(200, {"ok": True, "profile": profile, "home": str(home)})
@@ -243,6 +283,44 @@ class Handler(BaseHTTPRequestHandler):
         return self._send(200, {"ok": True, "profile": profile, "home": str(home)})
 
 
+def _self_test() -> int:
+    """Prove token mirroring covers the process-global MCP watch path."""
+    import tempfile
+    import traceback
+
+    hermes_home = Path(tempfile.mkdtemp(prefix="deepsql-provisioner-test-"))
+    try:
+        admin = hermes_home / "profiles" / "u-admin"
+        editor = hermes_home / "profiles" / "u-marts-editor"
+        admin.mkdir(parents=True)
+        editor.mkdir(parents=True)
+        write_token_file(admin, "dsql_mcp_admin.old")
+        write_token_file(editor, "dsql_mcp_editor.old")
+
+        rotated = "dsql_mcp_editor.live"
+        written = mirror_token_for_live_mcp(hermes_home, rotated)
+        paths = {p.resolve() for p in written}
+        expected = {
+            token_file_for(hermes_home).resolve(),
+            token_file_for(admin).resolve(),
+            token_file_for(editor).resolve(),
+        }
+        if paths != expected:
+            raise AssertionError(f"mirrored paths {paths} != {expected}")
+        for path in expected:
+            body = path.read_text().strip()
+            if body != rotated:
+                raise AssertionError(f"{path} still {body!r}, expected {rotated!r}")
+        print("ok: live MCP token is mirrored onto every profile token file")
+        return 0
+    except Exception:
+        traceback.print_exc()
+        return 1
+    finally:
+        import shutil
+        shutil.rmtree(hermes_home, ignore_errors=True)
+
+
 def main():
     if not SECRET:
         print("AGENT_PROVISION_SECRET is required", file=sys.stderr)
@@ -258,4 +336,6 @@ def main():
 
 
 if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "--self-test":
+        sys.exit(_self_test())
     main()

--- a/src/components/AgentChat/AgentChatPanel.jsx
+++ b/src/components/AgentChat/AgentChatPanel.jsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from 'react'
 import { ArrowUp, Plus, Square, Loader2, Database, Sparkles, Hash, Table2, Clock, AlertCircle } from 'lucide-react'
 import { agentChatAPI, withConnectionContext } from '@/lib/api/agentClient'
 import { agentConversationAPI } from '@/lib/api/client'
+import { useAuth } from '@/hooks/useAuth'
 import AgentMarkdown from './AgentMarkdown'
 import { sanitizeAssistantAnswer } from './sanitizeAssistantAnswer'
 import styles from './AgentChatPanel.module.css'
@@ -41,6 +42,7 @@ const SUGGESTIONS = [
 ]
 
 export default function AgentChatPanel({ connectionId, connectionName }) {
+  const { username } = useAuth()
   const [sessionId, setSessionId] = useState(null)
   const [booting, setBooting] = useState(true)
   const [bootError, setBootError] = useState(null)
@@ -113,7 +115,7 @@ export default function AgentChatPanel({ connectionId, connectionName }) {
     } finally {
       setBooting(false)
     }
-  }, [connectionId])
+  }, [connectionId, username])
 
   useEffect(() => { boot() }, [boot])
   useEffect(() => { if (listRef.current) listRef.current.scrollTop = listRef.current.scrollHeight }, [messages])

--- a/src/components/sections/AgentChatSection.jsx
+++ b/src/components/sections/AgentChatSection.jsx
@@ -1,8 +1,10 @@
 import { useConnectionManager } from '@/lib/hooks/useConnectionManager'
+import { useAuth } from '@/hooks/useAuth'
 import AgentChatPanel from '@/components/AgentChat/AgentChatPanel'
 
 export default function AgentChatSection() {
   const { connectionId, selectedConnection } = useConnectionManager()
+  const { username } = useAuth()
 
   if (!connectionId) {
     return (
@@ -12,10 +14,11 @@ export default function AgentChatSection() {
     )
   }
 
-  // Remount on connection change so the chat re-bootstraps a fresh session.
+  // Remount on connection *or* identity change so View as re-bootstraps the
+  // target user's agent profile instead of keeping the admin MCP session.
   return (
     <AgentChatPanel
-      key={connectionId}
+      key={`${username || 'anon'}:${connectionId}`}
       connectionId={connectionId}
       connectionName={selectedConnection?.connectionName}
     />

--- a/src/components/sections/ShareMenu.jsx
+++ b/src/components/sections/ShareMenu.jsx
@@ -16,6 +16,7 @@ export default function ShareMenu({ savedId, initialPublic, initialToken, initia
   const [pwInput, setPwInput] = useState('')
   const [pwEditing, setPwEditing] = useState(false)
   const [pwBusy, setPwBusy] = useState(false)
+  const [shareError, setShareError] = useState('')
   const ref = useRef(null)
 
   useEffect(() => {
@@ -41,6 +42,7 @@ export default function ShareMenu({ savedId, initialPublic, initialToken, initia
   const togglePublic = async () => {
     if (busy || !savedId) return
     setBusy(true)
+    setShareError('')
     try {
       if (!pub) {
         const res = await savedDashboardsAPI.enableShare(savedId)
@@ -48,7 +50,10 @@ export default function ShareMenu({ savedId, initialPublic, initialToken, initia
       } else {
         await savedDashboardsAPI.disableShare(savedId); setPub(false); onPublicChange?.(false)
       }
-    } catch { /* leave state as-is on failure */ } finally { setBusy(false) }
+    } catch (err) {
+      const message = err?.response?.data?.message || err?.message || 'Failed to update sharing'
+      setShareError(message)
+    } finally { setBusy(false) }
   }
 
   const savePassword = async () => {
@@ -105,6 +110,7 @@ export default function ShareMenu({ savedId, initialPublic, initialToken, initia
                 <span className={styles.knob}>{busy && <Loader2 size={10} className={styles.spin} />}</span>
               </button>
             </div>
+            {shareError ? <div className={styles.error}>{shareError}</div> : null}
             {pub ? (
               <>
                 <div className={styles.hint}>Anyone with this link can view — read-only, no login. Turn off to revoke.</div>

--- a/src/components/sections/ShareMenu.module.css
+++ b/src/components/sections/ShareMenu.module.css
@@ -42,6 +42,7 @@
   color: #111318;
 }
 .hint { font-size: 12px; color: #8b909b; line-height: 1.4; }
+.error { font-size: 12px; color: #b91c1c; line-height: 1.4; }
 
 .linkRow { display: flex; gap: 6px; align-items: center; }
 .input {

--- a/src/components/tabs/admin/UsersTab.jsx
+++ b/src/components/tabs/admin/UsersTab.jsx
@@ -1086,10 +1086,17 @@ function ConnectionAccessModal({ user, data, loading, onClose, onSave, onRevoke,
                           Assign the connection first, then save a per-user chat policy for it.
                         </div>
                       )}
+                      {assignment?.chatAccessPolicy?.allowedSchemas?.length > 0 && (
+                        <div className="mt-2 text-xs text-gray-600">
+                          <span className="font-medium">Resolved scope:</span>{' '}
+                          {assignment.chatAccessPolicy.allowedSchemas.join(', ')}
+                        </div>
+                      )}
 
                       {preview && (
                         <div className="mt-3 rounded-md border border-gray-200 bg-gray-50 p-3 text-sm text-gray-700 space-y-2">
                           <div><span className="font-medium">Blocked sensitivity:</span> {(preview.blockedSensitivityCategories || []).join(', ') || 'None'}</div>
+                          <div><span className="font-medium">Allowed schemas:</span> {(preview.allowedSchemas || []).join(', ') || 'All schemas'}</div>
                           <div><span className="font-medium">Impacted tables:</span> {(preview.impactedTables || []).join(', ') || 'None'}</div>
                           <div><span className="font-medium">Impacted columns:</span> {(preview.impactedColumns || []).join(', ') || 'None'}</div>
                           <div><span className="font-medium">Modes:</span> {preview.blockMode ? 'Block' : 'Allow'} + {preview.redactMode ? 'Redact' : 'Pass through'}</div>

--- a/src/hooks/useAuth.jsx
+++ b/src/hooks/useAuth.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, createContext, useContext, useMemo, useCallback } 
 import { useNavigate, useLocation } from 'react-router-dom'
 import { getActionPermission, getActionConfig } from '@/lib/actions'
 import { authAPI, setupAPI, adminAPI, AUTH_CHANGE_EVENT } from '@/lib/api/client'
+import { clearAgentRemoteUser } from '@/lib/api/agentClient'
 import { queryClient } from '@/lib/queryClient'
 import { useChatStore } from '@/lib/stores/useChatStore'
 import { useConnectionStore } from '@/lib/stores/useConnectionStore'
@@ -205,12 +206,14 @@ export function AuthProvider({ children }) {
 
   const startImpersonation = useCallback(async (userId) => {
     const payload = await adminAPI.startImpersonation(userId)
+    clearAgentRemoteUser()
     applyAuthPayload(payload, { resetSession: true })
     return payload
   }, [applyAuthPayload])
 
   const stopImpersonation = useCallback(async () => {
     const payload = await adminAPI.stopImpersonation()
+    clearAgentRemoteUser()
     applyAuthPayload(payload, { resetSession: true })
     return payload
   }, [applyAuthPayload])

--- a/src/lib/api/agentClient.js
+++ b/src/lib/api/agentClient.js
@@ -31,6 +31,8 @@ export function clearAgentRemoteUser() {
   agentRemoteUser = null
   agentCsrfToken = null
 }
+
+function withAgentAuthHeaders(headers = {}) {
   if (agentRemoteUser) {
     headers["X-Remote-User"] = agentRemoteUser;
   }

--- a/src/lib/api/agentClient.js
+++ b/src/lib/api/agentClient.js
@@ -27,7 +27,10 @@ let agentCsrfToken = null;
  */
 let agentRemoteUser = null;
 
-function withAgentAuthHeaders(headers = {}) {
+export function clearAgentRemoteUser() {
+  agentRemoteUser = null
+  agentCsrfToken = null
+}
   if (agentRemoteUser) {
     headers["X-Remote-User"] = agentRemoteUser;
   }
@@ -165,8 +168,10 @@ export const agentChatAPI = {
 
   /** Subscribe to a turn's SSE stream. Returns the EventSource (caller may .close()). */
   streamChat(streamId, { onToken, onTool, onToolComplete, onEnd, onError } = {}) {
+    const qs = new URLSearchParams({ stream_id: streamId })
+    if (agentRemoteUser) qs.set('remote_user', agentRemoteUser)
     const es = new EventSource(
-      `${AGENT_BASE}/api/chat/stream?stream_id=${encodeURIComponent(streamId)}`,
+      `${AGENT_BASE}/api/chat/stream?${qs.toString()}`,
       { withCredentials: true },
     );
     let done = false;

--- a/vite.config.js
+++ b/vite.config.js
@@ -73,6 +73,17 @@ export default defineConfig({
             if (typeof incoming === 'string' && incoming.trim()) {
               lastRemoteUser = incoming.trim()
             }
+            try {
+              const url = new URL(req.url, 'http://vite.local')
+              const fromQuery = url.searchParams.get('remote_user')
+              if (fromQuery && fromQuery.trim()) {
+                lastRemoteUser = fromQuery.trim()
+                url.searchParams.delete('remote_user')
+                proxyReq.path = url.pathname + url.search
+              }
+            } catch {
+              /* keep lastRemoteUser */
+            }
             if (lastRemoteUser) {
               proxyReq.setHeader('X-Remote-User', lastRemoteUser)
             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What was going wrong

A **new Agent chat thread** while Viewing as `marts-editor` still returned `crm.customers` rows (including `amount`). SQL Editor already blocked `crm`. Direct MCP API calls with a marts-editor token also blocked `crm`. The Agent path did not.

End-to-end logs for the failing turn (`session=fca723ca8171`, 14:14 UTC):

1. `/api/agent/session` minted MCP token **257** for `marts-editor` and provisioned `u-marts-editor`.
2. Hermes `POST /api/profile/switch` returned **200** three times; the session JSON is tagged `"profile": "u-marts-editor"`.
3. `mcp__deepsql__get_brain_context` and `mcp__deepsql__execute_sql` authenticated as **admin** token **253**.
4. Audit: `EDITOR_QUERY_EXECUTED` / `clientType=mcp` / `user_id=1` (`admin@demo.local`) / `SELECT … FROM crm.customers` / `rowCount=2`.
5. Token 257 `last_used_at` is only the Spring `probeMcpAuth` right after mint — Hermes never sent it.
6. `u-marts-editor` has **no** `mcp-stderr.log`; `u-admin` MCP was started on Aug 18 and reused.

Hermes keeps **one** DeepSQL MCP stdio process, started from the first loaded profile (`u-admin`). `POST /api/profile/switch` is explicitly `process_wide=False` (cookie / thread-local only). A new chat does not respawn MCP. `resolveEffectivePolicy(..., actorIsAdmin=true)` returns `none()`, so schema and column policy never run.

`probeMcpAuth` only proves the minted token works against Spring, not that the live MCP process will use it.

## Fix

`scripts/local-agent-provisioner.py` (the Agent container's `/provision` handler) now mirrors the minted token onto `$HERMES_HOME/deepsql.token` **and every** `profiles/*/deepsql.token`. The long-lived MCP client re-reads `DEEPSQL_TOKEN_FILE` per request (mtime cache), so the next `execute_sql` authenticates as the viewed-as user and policy applies.

Chat-path policy is also fail-closed for unparseable/unhandled SQL and missing actors, and walks CTEs, UNIONs, and nested `FROM`/`WHERE` selects.

## Merge with main

Resolved conflicts with `main` (`#70` whole-statement schema allowlist + nested protected-table inspectability, `#72` brain endpoint authz).

Kept this branch's recursive SELECT walker and fail-closed parse/actor rules. Took main's `assertProtectedTablesAreInspectable` / `namesMatch` so a qualified protection (`public.customer_profiles`) does not catch the same table name in another schema, while an unqualified nested reference still fails closed.

`UserDataAccessPolicyServiceTest` (24) and `BrainControllerAuthorizationSafetyTest` (2) pass after the merge.

## How to verify

1. View as `marts-editor`, Agent tab, **New chat**.
2. Ask: `show me all customer information from crm tables`.
3. Expect a policy block, not Acme/Globex rows. `security_event.user_id` for that SQL must be the editor, not admin.

Rebuild/restart `deepsql-agent` so the container picks up the provisioner change, or copy `scripts/local-agent-provisioner.py` onto `/opt/deepsql-agent/provisioner.py` and restart the provisioner process, then reopen the Agent tab (triggers `/provision`).

## Re-test after the fix

Same prompt in a new Agent thread while Viewing as marts-editor. Agent refused CRM; audit `user_id=2` / `clientAgent=marts-editor`.

[Agent refuses CRM while viewing as marts-editor](https://cursor.com/agents/bc-019fe687-99b1-76fd-80fa-dd213aecc497/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_view_as_crm_blocked.webp)
[agent_view_as_crm_policy_block.mp4](https://cursor.com/agents/bc-019fe687-99b1-76fd-80fa-dd213aecc497/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_view_as_crm_policy_block.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe687-99b1-76fd-80fa-dd213aecc497?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe687-99b1-76fd-80fa-dd213aecc497&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

