### PR TITLE
chore(release): DeepSQL v1.3.0 — Desktop IDE first ship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ for product tags (`vMAJOR.MINOR.PATCH`).
 
 Product releases follow a **weekly cadence** (Saturday 09:00 America/Los_Angeles). See `docs/oss-ux/RELEASE.md`.
 
+## [1.3.0] — 2026-08-24
+
+### Added
+
+- **DeepSQL Desktop** — first-ship Electron thin client (`desktop/`) with direct TLS and SSH-tunnel transports, connection profiles, OS keychain secrets, and native chrome (#73).
+- Desktop release workflow (`.github/workflows/desktop-release.yml`) for macOS / Windows / Linux installers on `desktop-v*` tags.
+- Enforceable Agent brain-note proposals with non-blocking save bubbles (#75).
+- Schema documentation dedupe / `CODE_DERIVED` compatibility initializers (`V116`) (#74, #77).
+
+### Fixed
+
+- Cross-user MCP credential leak in the Agent tab — provisioner no longer last-writer-wins across Hermes profiles; MCP tokens bind to declared client identity (#78).
+- View as Agent enforces the target user’s data policy on new Agent threads (#71).
+- Chat schema allowlist enumerates the whole statement (#70).
+- Brain endpoints require connection content authorization (#72).
+- Review queue approvals: stale pending counts, bulk `failures[]`, approval path unwedge (#74, #77).
+- Editor CSV export bounded; concurrent-run guards and cancel audit (#76).
+
+### Changed
+
+- Documented CORS loopback wildcards required for Desktop SSH tunnels (`CORS_ALLOWED_ORIGINS`).
+- `@deepsql/mcp` → `0.27.1`.
+- DeepSQL Desktop package → `1.0.0` (cut installers with `desktop-v1.0.0`).
+
+### Notes
+
+- Open follow-up: dashboard workspaces + custom roles (#80) intentionally not in this cut.
+
 ## [1.2.0] — 2026-08-19
 
 ### Added
@@ -82,6 +110,7 @@ First public OSS release.
 - Residual high-severity items tracked in `docs/oss-ux/OSS_SECURITY_REVIEW.md` (IDOR sweep, SET preamble allowlist, SSRF hardening, share-password defaults) are deferred past this cut.
 - Primary distribution path remains `docker compose up --build` (no pre-built container registry in this release).
 
+[1.3.0]: https://github.com/DeepSQLAI/deepsql/releases/tag/v1.3.0
 [1.2.0]: https://github.com/DeepSQLAI/deepsql/releases/tag/v1.2.0
 [1.1.0]: https://github.com/DeepSQLAI/deepsql/releases/tag/v1.1.0
 [1.0.0]: https://github.com/DeepSQLAI/deepsql/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ control except the prompts you send to the endpoint you chose.
 📄 **[Read the whitepaper](https://deepsql.ai/whitepaper)** — the architecture and the
 reasoning behind it.
 
+📦 **Latest release: [v1.3.0](https://github.com/DeepSQLAI/deepsql/releases/tag/v1.3.0)** —
+DeepSQL Desktop first ship + Agent/Brain/Editor hardening. Notes:
+[`docs/releases/RELEASE_NOTES-v1.3.0.md`](docs/releases/RELEASE_NOTES-v1.3.0.md).
+
 ---
 
 ## Quick start

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.dbaagent</groupId>
     <artifactId>dba-agent-backend</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
     <name>DBA Agent Backend</name>
     <description>Backend service for DBA Agent with secure credential storage and schema analysis</description>
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,5 +1,7 @@
 # DeepSQL Desktop
 
+**Version 1.0.0** — first public Desktop cut (ships with DeepSQL product `v1.3.0`).
+
 A cross-platform desktop client for a self-hosted DeepSQL server. It connects to
 the VM (or bare metal) running the DeepSQL stack either **directly over TLS** or
 through an **SSH tunnel**, and presents the DeepSQL UI in a native window with

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "deepsql-desktop",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deepsql-desktop",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "electron-updater": "^6.8.9",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,9 +1,9 @@
 {
   "name": "deepsql-desktop",
   "productName": "DeepSQL",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
-  "description": "DeepSQL desktop client — connect to a self-hosted DeepSQL VM over TLS or an SSH tunnel.",
+  "description": "DeepSQL desktop client \u2014 connect to a self-hosted DeepSQL VM over TLS or an SSH tunnel.",
   "license": "Apache-2.0",
   "author": {
     "name": "DeepSQL",
@@ -37,7 +37,7 @@
   "build": {
     "appId": "com.deepsql.desktop",
     "productName": "DeepSQL",
-    "copyright": "Copyright © DeepSQL",
+    "copyright": "Copyright \u00a9 DeepSQL",
     "directories": {
       "output": "release",
       "buildResources": "build"
@@ -80,7 +80,7 @@
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
       "extendInfo": {
-        "NSHumanReadableCopyright": "Copyright © DeepSQL"
+        "NSHumanReadableCopyright": "Copyright \u00a9 DeepSQL"
       }
     },
     "dmg": {

--- a/docs/oss-ux/RELEASE.md
+++ b/docs/oss-ux/RELEASE.md
@@ -19,10 +19,11 @@ Cron for the weekly automation: `CRON_TZ=America/Los_Angeles 0 9 * * 6`.
 
 | Surface | Where | Current |
 |---------|-------|---------|
-| Product / Git tag | `vMAJOR.MINOR.PATCH` | `v1.2.0` |
-| Backend JAR | `backend/pom.xml` `<version>` | `1.2.0` |
+| Product / Git tag | `vMAJOR.MINOR.PATCH` | `v1.3.0` |
+| Backend JAR | `backend/pom.xml` `<version>` | `1.3.0` |
 | Frontend package | root `package.json` | `0.1.0` (internal) |
-| MCP / CLI npm | `mcp/package.json` | `0.27.0` |
+| MCP / CLI npm | `mcp/package.json` | `0.27.1` |
+| DeepSQL Desktop | `desktop/package.json` + `desktop-v*` tags | `1.0.0` |
 
 Tag the **product** version (`v1.1.0`). Keep backend `pom.xml` in lockstep with the tag for the JAR filename. MCP may continue its own semver when publishing `@deepsql/mcp` to npm.
 
@@ -102,8 +103,19 @@ gh release create v1.1.0 \
 
 Docker Compose remains the primary install path (`docker compose up --build`); the JAR + frontend tarball support air-gapped / non-Compose operators.
 
+### DeepSQL Desktop (optional, separate tag)
+
+Desktop installers are **not** produced by the product `v*.*.*` workflow. After the product release is published:
+
+1. Confirm `desktop/package.json` version matches the intended Desktop cut (e.g. `1.0.0`).
+2. Tag and push `desktop-v1.0.0` (annotated).
+3. `.github/workflows/desktop-release.yml` builds macOS / Windows / Linux on native runners and attaches installers to that GitHub Release.
+
+Setup and CORS requirements: [`desktop/README.md`](../../desktop/README.md).
+
 ## Post-release
 
 - Confirm the Release page lists every file and checksums verify.
+- If Desktop shipped in this cycle, confirm the `desktop-v*` Release has platform installers.
 - Announce with the tag URL + one-line upgrade note.
 - Bump versions on `main` for the next cycle only after the tag is cut (avoid tagging a commit whose pom still says the previous version).

--- a/docs/releases/RELEASE_NOTES-v1.3.0.md
+++ b/docs/releases/RELEASE_NOTES-v1.3.0.md
@@ -1,0 +1,103 @@
+# DeepSQL v1.3.0
+
+**Weekly product cut** — DeepSQL Desktop (IDE) first ship, plus Agent/Brain/Editor hardening on top of `v1.2.0`.
+
+## Highlights
+
+### DeepSQL Desktop (headline)
+
+Native Electron client for a self-hosted DeepSQL server — the biggest addition in this cut (#73).
+
+- **Thin client, not a second frontend** — embeds the live DeepSQL UI from your VM origin (no bundled SPA, no version skew).
+- **Two transports** — direct TLS (system / pinned / custom CA / TOFU) or in-process SSH tunnel (`ssh2`, no `ssh` binary).
+- **Connection profiles** — per-profile sessions; secrets stored as OS keychain ciphertext when available.
+- **CORS requirement** — SSH tunnels use `http://127.0.0.1:<sticky-port>`, so the VM must allow loopback wildcards in `CORS_ALLOWED_ORIGINS` (`http://127.0.0.1:*,http://localhost:*`). Documented in `desktop/README.md`, `README.md`, and `docs/root/SELF_HOST_GUIDE.md`.
+- **Installers** — tag `desktop-v1.0.0` after this product cut to run `.github/workflows/desktop-release.yml` (macOS / Windows / Linux native runners).
+
+```bash
+cd desktop
+npm install
+npm start          # or: npm run dev
+# headless Linux GUI: xvfb-run npm start
+```
+
+### Agent & security
+
+- **MCP credential isolation** — Agent provisioner no longer mirrors tokens across every Hermes profile (cross-user last-writer-wins leak closed) (#78).
+- **MCP token identity binding** — server refuses a token whose owner does not match `X-DeepSQL-Client-Agent` when that header names a DeepSQL user.
+- **View as Agent** — impersonated Agent sessions enforce the *target* user’s chat/data policy (#71).
+- **Schema allowlist** — chat policy schema allowlist walks the whole statement, not only outer `FROM`/`JOIN` (#70).
+- **Brain endpoint authz** — Brain APIs require connection content access, not merely authentication (#72).
+
+### Brain & Review
+
+- **Review queue approvals** — `CODE_DERIVED` CHECK compatibility, stale-list refresh, bulk decide surfaces `failures[]` (#74).
+- **Suggestion approval unwedge** — schema-doc dedupe / upsert path so approvals stick; knowledge counts refresh live (#77).
+- **Enforceable Agent writes** — non-blocking save bubbles; Agent only offers brain-note saves when the user can manage content (#75).
+
+### Editor
+
+- **CSV export bound** — export no longer re-runs unbounded / 10-minute queries that outrun the proxy (#76).
+- Concurrent-run guards and cancel auditing for Editor query sessions (#76).
+
+## Install / upgrade
+
+```bash
+git clone https://github.com/DeepSQLAI/deepsql.git
+cd deepsql
+git checkout v1.3.0
+cp .env.example .env
+# set SECURITY_JWT_SECRET, ENCRYPTION_KEY (or ENCRYPTION_KEYS), and DEEPSQL_CHAT_* in .env
+# for Desktop tunnels, include loopback wildcards in CORS_ALLOWED_ORIGINS
+docker compose up --build -d
+```
+
+From `v1.2.0`: pull/checkout `v1.3.0` and rebuild Compose (or swap JAR + frontend tarball from this Release). Schema is managed by `ddl-auto=update`. Hand SQL changelog `V116` (schema documentation dedupe) is optional when not relying on `ddl-auto=update` / startup initializers.
+
+Air-gapped: download artifacts below, verify `SHA256SUMS`, follow `docs/oss-ux/RELEASE.md`.
+
+### Optional: DeepSQL Desktop
+
+See [`desktop/README.md`](../../desktop/README.md). After the product tag is published, cut Desktop installers with:
+
+```bash
+git tag -a desktop-v1.0.0 -m "DeepSQL Desktop v1.0.0"
+git push origin desktop-v1.0.0
+```
+
+## Artifacts in this release
+
+| File | Contents |
+|------|----------|
+| `deepsql-1.3.0-source.tar.gz` / `.zip` | Source tree at this tag |
+| `dba-agent-backend-1.3.0.jar` | Spring Boot executable |
+| `deepsql-frontend-1.3.0.tar.gz` | Production static UI |
+| `deepsql-mcp-0.27.1.tgz` | CLI + MCP server package |
+| `sbom-*.cdx.json` | CycloneDX SBOMs |
+| `SHA256SUMS` / `SHA512SUMS` | Integrity hashes |
+| `manifest.json` | Machine-readable inventory |
+
+Desktop installers (dmg / zip / exe / AppImage / deb) attach to the separate `desktop-v1.0.0` GitHub Release when that tag is pushed.
+
+```bash
+sha256sum -c SHA256SUMS
+```
+
+## Verify
+
+```bash
+python3 scripts/self-host/e2e-agent-check.py
+python3 scripts/self-host/e2e-multischema-check.py
+# Desktop (optional):
+cd desktop && npm run selftest:tunnel && npm run smoke -- --url https://your-deepsql-origin
+```
+
+Expect `AGENT_OK True`, `DASH_OK True`, and `✓ Multi-schema E2E OK`.
+
+## Not in this cut
+
+- **Workspaces & custom roles** (#80) — still open; merge after the favorite-endpoint authorization fix and rebase onto this release.
+
+## Cadence
+
+Product releases are cut **weekly, Saturday 09:00 America/Los_Angeles**. See `docs/oss-ux/RELEASE.md` and `docs/oss-ux/WEEKLY_RELEASE_AUTOMATION.md`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Weekly product cut **v1.3.0** — **DeepSQL Desktop (IDE) first ship** as the headline, plus Agent/Brain/Editor hardening landed on `main` since `v1.2.0`.

## Release contents

- Bump `backend/pom.xml` → `1.3.0`
- Bump `desktop/package.json` → `1.0.0` (installers via separate `desktop-v1.0.0` tag)
- `CHANGELOG.md` + `docs/releases/RELEASE_NOTES-v1.3.0.md`
- `docs/oss-ux/RELEASE.md` version table + Desktop tagging notes
- Root `README.md` + `desktop/README.md` release pointers

## Included since v1.2.0

| PR | Topic |
|----|--------|
| #73 | **DeepSQL Desktop** — Electron thin client (TLS + SSH tunnel) |
| #78 | Agent MCP cross-user credential leak closed |
| #77 / #74 | Brain review approvals + schema-doc dedupe |
| #75 | Enforceable Agent writes / non-blocking save bubbles |
| #76 | Editor CSV export bound + concurrency/cancel audit |
| #71 | View as Agent enforces target user policy |
| #70 | Schema allowlist walks whole statement |
| #72 | Brain endpoint connection authz |

**Not included:** #80 (workspaces & custom roles) — still open; favorite-endpoint auth fix required first.

## After merge

```bash
git checkout main && git pull
git tag -a v1.3.0 -m "DeepSQL v1.3.0"
git push origin v1.3.0
# optional Desktop installers:
git tag -a desktop-v1.0.0 -m "DeepSQL Desktop v1.0.0"
git push origin desktop-v1.0.0
```

Tag push triggers `.github/workflows/release.yml` for product artifacts; `desktop-v*` triggers `.github/workflows/desktop-release.yml`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ce91e70-c67b-48c6-84b3-05bb9d06231a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ce91e70-c67b-48c6-84b3-05bb9d06231a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

