### PR TITLE
fix: authorize every connection-scoped endpoint (116 were unguarded)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -709,6 +709,73 @@ it against a real database — not a theoretical hardening pass.
   `catch (ResponseStatusException e) { throw e; }` a 403 is swallowed and reported as a
   server error, so a client cannot tell "not yours" from "broken". The safety test
   asserts this too.
+- **Then it happened again, on 12 more controllers — 116 endpoints, zero checks.**
+  `BrainControllerAuthorizationSafetyTest` hardcodes one `Path.of(...)`, so it could not
+  see `SlowQueryController` (43), `SlowQueryAnalyticsController` (13),
+  `SchemaChangeController` (13), `SentinelAnalyticsController` (10),
+  `PerformanceActionController` (9), `QueryPerformanceController` (8),
+  `QueryPlanController` (8), `IndexAdvisorController` (7),
+  `PerformanceInsightsController` (5), `AdvisorController` (3),
+  `ResourceLimitsController` (3) or `BusinessRuleController` (3). Verified live, not
+  inferred: a DEVELOPER holding **no grant on any connection** read literal-bearing
+  slow-query SQL with real customer ids and names
+  (`/slow-query-analytics/{id}/query/{fp}/samples` → 200 while
+  `/slow-log-source/{id}` → 403 in the same session), enumerated another tenant's
+  schema, and **deleted that tenant's analysis history** via
+  `DELETE /slow-queries/history/connection/{id}`. All 116 are now guarded.
+  `ConnectionScopedAuthorizationSafetyTest` replaces the per-file approach: it scans
+  **every** `*Controller.java`, so a new controller is covered the day it is written.
+  Writing it immediately found 9 more unguarded endpoints in controllers nobody was
+  looking at, including `StatsController`, `ProjectController`, `DashboardController`
+  and a destructive `DELETE /sentinel/demo/cleanup/{connectionId}`.
+- **Two endpoints decrypted another user's credentials before anyone checked access.**
+  `GET /slow-query-analytics/{id}/tenant-column-suggestions` and `/config` reach
+  `suggestTenantColumns` → `getJdbcTemplateForBackgroundJob` →
+  `credentialService.getDecryptedConnection`, opening a live JDBC session to the target
+  database. An unguarded read is not only a data leak; it can be a credential-use
+  primitive. Check before the work, not after.
+- **A path-variable sweep is not enough — ids in the request body need their own
+  check.** Four holes survived exactly that kind of fix: `snapshots/compare` (two
+  snapshot ids, no `connectionId` at all — it would diff tenant A's schema against
+  tenant B's), `PUT /performance-actions/batch-status` (an arbitrary `actionIds` list,
+  no scope), and `changes/acknowledge` / `regressions/acknowledge` (path connection
+  authorized, body ids unchecked). `allChangesBelongTo` / `allComparisonsBelongTo`
+  verify membership, and **an id that resolves to nothing fails too** — otherwise
+  unknown ids can be mixed into an otherwise valid batch. The safety test has a
+  dedicated case for body-supplied id collections.
+- **An id is not a capability.** For `alertId`, `actionId`, `regressionId`,
+  `recommendationId`, `fingerprintId`, `planId`, `ruleId`, `snapshotId`, `historyId`:
+  resolve the owning connection and assert on that. Several services had no such
+  accessor, so `findConnectionIdFor*` was added to `QueryPerformanceService`,
+  `QueryPlanCacheService`, `SentinelAnalyticsService`, `BusinessRuleMemoryService`,
+  `SlowQueryAlertService`, `QueryFingerprintService` and `SchemaChangeTrackingService`.
+  These helpers report **404, not 403**, for an unknown id — a 403 confirms the row
+  exists, turning the endpoint into an id oracle. `regressionId` is a sequential
+  `Long`, so that mattered.
+- **Never take the actor from the request.** `POST /slow-queries/alerts/{id}/acknowledge`
+  took `@RequestParam String userId`, and three acknowledge endpoints took
+  `acknowledgedBy` defaulting to the literal string `"user"` — so the audit trail was
+  unauthenticated free text and could name any colleague. All seven sites now use
+  `accessControlService.requireCurrentUsername()`. The parameters are still accepted
+  (wire compatibility) and ignored.
+- **Guarded vs unguarded is an existence oracle.** A guarded endpoint 404s an unknown
+  connection id (`resolveCurrentUserAccess` wraps the lookup); an unguarded one returned
+  200. That difference alone enumerated valid connection ids.
+- **A `@ControllerAdvice` catch-all swallows a 403 the same way an in-method one does,
+  and it is easier to miss because it lives in another file.**
+  `IndexAdvisorExceptionHandler` has `@ExceptionHandler(Exception.class)`, so the newly
+  added guard on `/index-advisor/{id}/health-report` returned
+  `500 "Index operation failed"` with the 403's text in the body — the denial held, but
+  the response blamed the index store. Found by *testing the fix*, not by reading it: the
+  other 24 endpoints returned 403 and this one did not. It now has an
+  `@ExceptionHandler(ResponseStatusException.class)` that preserves the status, and
+  `ConnectionScopedAuthorizationSafetyTest` asserts every advice with a catch-all also
+  handles `ResponseStatusException`.
+- **`@CrossOrigin(origins = "*")` on a controller is dead code here, and worth
+  deleting.** `SentinelAnalyticsController` carried it. Tested: an evil-origin preflight
+  gets `403` with no `Access-Control-Allow-Origin` (the `SecurityConfig` allowlist wins),
+  while an allowed origin gets `200` + ACAO — so the annotation never had effect. It
+  still reads like an intentional hole to the next person.
 
 ### MCP & CLI Release Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -749,18 +749,48 @@ it against a real database — not a theoretical hardening pass.
   accessor, so `findConnectionIdFor*` was added to `QueryPerformanceService`,
   `QueryPlanCacheService`, `SentinelAnalyticsService`, `BusinessRuleMemoryService`,
   `SlowQueryAlertService`, `QueryFingerprintService` and `SchemaChangeTrackingService`.
-  These helpers report **404, not 403**, for an unknown id — a 403 confirms the row
-  exists, turning the endpoint into an id oracle. `regressionId` is a sequential
-  `Long`, so that mattered.
+  These helpers report **404 for both** "no such id" and "not yours", via
+  `assertCanRead/ManageConnectionContentOrNotFound`. The first attempt only 404'd the
+  *unknown* case and left an authorized-but-denied row at 403, which still confirms the
+  row exists — a review caught that the code comments claimed a property the code did not
+  have. `query_performance_regression.id` is a sequential `Long`, so walking 1..N would
+  have mapped every tenant's regressions. Same answer
+  `DashboardWorkspaceService.assertCanReadDashboard` already gives. Endpoints keyed on a
+  **connectionId** keep 403: the caller already knows that connection exists, so an
+  actionable "access denied" is better than a misleading 404.
 - **Never take the actor from the request.** `POST /slow-queries/alerts/{id}/acknowledge`
-  took `@RequestParam String userId`, and three acknowledge endpoints took
-  `acknowledgedBy` defaulting to the literal string `"user"` — so the audit trail was
-  unauthenticated free text and could name any colleague. All seven sites now use
-  `accessControlService.requireCurrentUsername()`. The parameters are still accepted
-  (wire compatibility) and ignored.
+  took `@RequestParam String userId`; `acknowledgedBy` defaulted to the literal string
+  `"user"`; `resolvedBy`, `updatedBy` and Sentinel's `initiatedBy` came from the request
+  body — so the audit trail was unauthenticated free text and could name any colleague.
+  All of them now use `accessControlService.requireCurrentUsername()`. The parameters are
+  still accepted (wire compatibility) and ignored, which is noted at each site so nobody
+  re-wires them.
 - **Guarded vs unguarded is an existence oracle.** A guarded endpoint 404s an unknown
   connection id (`resolveCurrentUserAccess` wraps the lookup); an unguarded one returned
   200. That difference alone enumerated valid connection ids.
+- **A scanner built on an allowlist of id names can only catch the ids someone
+  remembered.** `ConnectionScopedAuthorizationSafetyTest` first matched
+  `body.contains("connectionId")` plus a hand-written list
+  (`alertId|actionId|regressionId|…`). Both halves leaked: `ProjectController.createProject`
+  reads `request.getConnectionId()` — **capital C** — and `projectId` was not in the list,
+  so `POST /projects` and `GET|PUT|DELETE /projects/{projectId}` were invisible while the
+  suite reported every case green. Now the connection match is case-insensitive and *any*
+  `@PathVariable …Id` counts as connection-owned until proven otherwise, with genuine
+  exceptions in `NOT_CONNECTION_OWNED_IDS` carrying a reason. Inverting it immediately
+  surfaced four `PlaybookController` endpoints — those turned out to be true negatives
+  (`Playbook` has no `connectionId`; playbooks are global templates), and
+  `playbookExemptionHoldsOnlyWhilePlaybooksAreConnectionFree` fails the build if a
+  `connectionId` is ever added to that entity. **A safety test that reports green is
+  evidence only about what it can see.**
+- **Two path variables are as dangerous as a body id.**
+  `POST /schema-changes/{connectionId}/snapshots/{snapshotId}/set-baseline` authorized the
+  connection and then flipped *whatever snapshot id it was handed* to BASELINE and pointed
+  that connection's drift config at it — so manage access on A could retarget B's snapshot
+  and bind A's baseline to it. `setBaseline` now refuses a snapshot whose `connectionId`
+  differs, in the service as well as the controller, and **throws rather than silently
+  skipping**: no-op'ing the snapshot write while still writing the drift config would leave
+  the config pointing at another connection's snapshot. When a handler takes an id
+  alongside a `connectionId`, authorizing the connection is half the check.
 - **A `@ControllerAdvice` catch-all swallows a 403 the same way an in-method one does,
   and it is easier to miss because it lives in another file.**
   `IndexAdvisorExceptionHandler` has `@ExceptionHandler(Exception.class)`, so the newly

--- a/backend/src/main/java/com/dbaagent/controller/AdvisorController.java
+++ b/backend/src/main/java/com/dbaagent/controller/AdvisorController.java
@@ -3,6 +3,7 @@ package com.dbaagent.controller;
 import com.dbaagent.model.IndexRecommendation;
 import com.dbaagent.model.PerformanceAnalysis;
 import com.dbaagent.service.DatabaseAdvisorService;
+import com.dbaagent.service.security.AccessControlService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -10,6 +11,15 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+/**
+ * REST API for the performance advisor (analysis, missing indexes, health summary).
+ *
+ * <p><b>Authorization:</b> every endpoint here takes a caller-supplied connection id, so
+ * each one asserts access itself ({@code assertCanReadConnectionContent} for reads,
+ * {@code assertCanManageConnectionContent} for writes). {@code SecurityConfig} only
+ * requires an authenticated principal — nothing upstream inspects a connection id. See
+ * {@code ConnectionScopedAuthorizationSafetyTest}.
+ */
 @RestController
 @RequestMapping("/advisor")
 @RequiredArgsConstructor
@@ -17,6 +27,7 @@ import java.util.List;
 public class AdvisorController {
 
     private final DatabaseAdvisorService advisorService;
+    private final AccessControlService accessControlService;
 
     /**
      * Get comprehensive performance analysis
@@ -25,6 +36,7 @@ public class AdvisorController {
     public ResponseEntity<PerformanceAnalysis> analyzePerformance(
         @PathVariable String connectionId
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             log.info("Performance analysis requested for connection: {}", connectionId);
             PerformanceAnalysis analysis = advisorService.analyzePerformance(connectionId);
@@ -44,6 +56,7 @@ public class AdvisorController {
     public ResponseEntity<List<IndexRecommendation>> getMissingIndexes(
         @PathVariable String connectionId
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             log.info("Index recommendations requested for connection: {}", connectionId);
             PerformanceAnalysis analysis = advisorService.analyzePerformance(connectionId);
@@ -63,6 +76,7 @@ public class AdvisorController {
     public ResponseEntity<HealthSummary> getHealthSummary(
         @PathVariable String connectionId
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             log.info("Health summary requested for connection: {}", connectionId);
             PerformanceAnalysis analysis = advisorService.analyzePerformance(connectionId);

--- a/backend/src/main/java/com/dbaagent/controller/BusinessRuleController.java
+++ b/backend/src/main/java/com/dbaagent/controller/BusinessRuleController.java
@@ -2,6 +2,7 @@ package com.dbaagent.controller;
 
 import com.dbaagent.model.brain.BrainRule;
 import com.dbaagent.service.BusinessRuleMemoryService;
+import com.dbaagent.service.security.AccessControlService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,6 +12,12 @@ import java.util.Map;
 
 /**
  * API endpoints for connection-scoped learned SQL business rules.
+ *
+ * <p><b>Authorization:</b> every endpoint here takes a caller-supplied connection id, so
+ * each one asserts access itself ({@code assertCanReadConnectionContent} for reads,
+ * {@code assertCanManageConnectionContent} for writes). {@code SecurityConfig} only
+ * requires an authenticated principal — nothing upstream inspects a connection id. See
+ * {@code ConnectionScopedAuthorizationSafetyTest}.
  */
 @RestController
 @RequestMapping("/business-rules")
@@ -18,6 +25,7 @@ import java.util.Map;
 public class BusinessRuleController {
 
     private final BusinessRuleMemoryService businessRuleMemoryService;
+    private final AccessControlService accessControlService;
 
     /**
      * Returns all active rules for the connection plus the subset applicable to an optional question.
@@ -26,6 +34,7 @@ public class BusinessRuleController {
     public ResponseEntity<Map<String, Object>> getRules(
             @PathVariable String connectionId,
             @RequestParam(required = false) String question) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         List<BrainRule> activeRules = businessRuleMemoryService.getActiveRules(connectionId);
         List<BusinessRuleMemoryService.SqlGuardrail> applicable = businessRuleMemoryService
             .resolveApplicableGuardrails(connectionId, question, null);
@@ -49,6 +58,7 @@ public class BusinessRuleController {
     public ResponseEntity<Map<String, Object>> learn(
             @PathVariable String connectionId,
             @RequestBody LearnRuleRequest request) {
+        accessControlService.assertCanManageConnectionContent(connectionId);
         int learned = businessRuleMemoryService.learnFromFeedback(
             connectionId,
             request.text(),
@@ -70,6 +80,10 @@ public class BusinessRuleController {
      */
     @DeleteMapping("/rule/{ruleId}")
     public ResponseEntity<Map<String, Object>> deactivateRule(@PathVariable String ruleId) {
+        String connectionId = businessRuleMemoryService.findConnectionIdForRule(ruleId)
+                .orElseThrow(() -> new org.springframework.web.server.ResponseStatusException(
+                        org.springframework.http.HttpStatus.NOT_FOUND, "Rule not found"));
+        accessControlService.assertCanManageConnectionContent(connectionId);
         boolean deactivated = businessRuleMemoryService.deactivateRule(ruleId);
         return ResponseEntity.ok(Map.of(
             "ruleId", ruleId,

--- a/backend/src/main/java/com/dbaagent/controller/DashboardController.java
+++ b/backend/src/main/java/com/dbaagent/controller/DashboardController.java
@@ -1,6 +1,7 @@
 package com.dbaagent.controller;
 
 import com.dbaagent.service.DashboardService;
+import com.dbaagent.service.security.AccessControlService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -8,6 +9,12 @@ import org.springframework.web.bind.annotation.*;
 
 /**
  * REST API for performance dashboard
+ *
+ * <p><b>Authorization:</b> every endpoint here takes a caller-supplied connection id, so
+ * each one asserts access itself ({@code assertCanReadConnectionContent} for reads,
+ * {@code assertCanManageConnectionContent} for writes). {@code SecurityConfig} only
+ * requires an authenticated principal — nothing upstream inspects a connection id. See
+ * {@code ConnectionScopedAuthorizationSafetyTest}.
  */
 @RestController
 @RequestMapping("/dashboard")
@@ -16,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class DashboardController {
 
     private final DashboardService dashboardService;
+    private final AccessControlService accessControlService;
 
     /**
      * Get performance dashboard data for a connection
@@ -26,6 +34,7 @@ public class DashboardController {
         @RequestParam(required = false, defaultValue = "30") Integer days
     ) {
         try {
+            accessControlService.assertCanReadConnectionContent(connectionId);
             log.info("Fetching performance dashboard for connection: {}, days: {}", connectionId, days);
 
             DashboardService.DashboardData data = dashboardService.getDashboardData(connectionId, days);

--- a/backend/src/main/java/com/dbaagent/controller/IndexAdvisorController.java
+++ b/backend/src/main/java/com/dbaagent/controller/IndexAdvisorController.java
@@ -2,6 +2,7 @@ package com.dbaagent.controller;
 
 import com.dbaagent.service.IndexAdvisorService;
 import com.dbaagent.service.PerformanceMonitoringService;
+import com.dbaagent.service.security.AccessControlService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +13,12 @@ import java.util.Map;
 
 /**
  * REST API for enhanced index advisor functionality
+ *
+ * <p><b>Authorization:</b> every endpoint here takes a caller-supplied connection id, so
+ * each one asserts access itself ({@code assertCanReadConnectionContent} for reads,
+ * {@code assertCanManageConnectionContent} for writes). {@code SecurityConfig} only
+ * requires an authenticated principal — nothing upstream inspects a connection id. See
+ * {@code ConnectionScopedAuthorizationSafetyTest}.
  */
 @RestController
 @RequestMapping("/index-advisor")
@@ -21,12 +28,14 @@ public class IndexAdvisorController {
 
     private final IndexAdvisorService indexAdvisorService;
     private final PerformanceMonitoringService performanceMonitoringService;
+    private final AccessControlService accessControlService;
 
     /**
      * Get comprehensive index health report
      */
     @GetMapping("/{connectionId}/health-report")
     public ResponseEntity<Map<String, Object>> getHealthReport(@PathVariable String connectionId) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return ResponseEntity.ok(indexAdvisorService.getIndexHealthReport(connectionId));
     }
 
@@ -35,6 +44,7 @@ public class IndexAdvisorController {
      */
     @GetMapping("/{connectionId}/unused")
     public ResponseEntity<List<Map<String, Object>>> getUnusedIndexes(@PathVariable String connectionId) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return ResponseEntity.ok(performanceMonitoringService.getUnusedIndexes(connectionId));
     }
 
@@ -43,6 +53,7 @@ public class IndexAdvisorController {
      */
     @GetMapping("/{connectionId}/duplicates")
     public ResponseEntity<List<Map<String, Object>>> getDuplicateIndexes(@PathVariable String connectionId) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return ResponseEntity.ok(performanceMonitoringService.getDuplicateIndexes(connectionId));
     }
 
@@ -53,6 +64,7 @@ public class IndexAdvisorController {
     public ResponseEntity<Map<String, Object>> estimateIndexCreation(
             @PathVariable String connectionId,
             @RequestBody Map<String, Object> request) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
 
         String tableName = (String) request.get("tableName");
         @SuppressWarnings("unchecked")
@@ -75,6 +87,7 @@ public class IndexAdvisorController {
     public ResponseEntity<Map<String, Object>> estimateIndexDrop(
             @PathVariable String connectionId,
             @RequestBody Map<String, Object> request) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
 
         String tableName = (String) request.get("tableName");
         String indexName = (String) request.get("indexName");
@@ -94,6 +107,7 @@ public class IndexAdvisorController {
     public ResponseEntity<List<Map<String, Object>>> getIndexUsageStats(
             @PathVariable String connectionId,
             @PathVariable String tableName) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return ResponseEntity.ok(performanceMonitoringService.getIndexUsageStats(connectionId, tableName));
     }
 
@@ -102,6 +116,7 @@ public class IndexAdvisorController {
      */
     @GetMapping("/{connectionId}/cache-stats")
     public ResponseEntity<Map<String, Double>> getCacheStats(@PathVariable String connectionId) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return ResponseEntity.ok(performanceMonitoringService.getCacheHitRatios(connectionId));
     }
 }

--- a/backend/src/main/java/com/dbaagent/controller/IndexAdvisorExceptionHandler.java
+++ b/backend/src/main/java/com/dbaagent/controller/IndexAdvisorExceptionHandler.java
@@ -61,6 +61,27 @@ public class IndexAdvisorExceptionHandler {
         return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(body);
     }
 
+    /**
+     * An authorization denial is a deliberate answer, not a failure of this feature.
+     * {@code handleGeneric} below matches {@code Exception}, so without this more specific
+     * handler a {@code ResponseStatusException} from
+     * {@code assertCanReadConnectionContent} was reported as
+     * {@code 500 "Index operation failed"} — the denial still held, but the caller could
+     * not tell "not yours" from "the index store is broken", and the message named the
+     * wrong subsystem. Verified: a non-granted user hitting
+     * {@code /index-advisor/{id}/health-report} got a 500 whose body carried the 403 text.
+     */
+    @ExceptionHandler(org.springframework.web.server.ResponseStatusException.class)
+    public ResponseEntity<Map<String, Object>> handleStatus(
+            org.springframework.web.server.ResponseStatusException ex) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("timestamp", Instant.now().toString());
+        body.put("status", ex.getStatusCode().value());
+        body.put("error", ex.getStatusCode().toString());
+        body.put("message", ex.getReason() != null ? ex.getReason() : ex.getMessage());
+        return ResponseEntity.status(ex.getStatusCode()).body(body);
+    }
+
     /** Any other uncaught error from these endpoints → a clean message, not an opaque 500. */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Map<String, Object>> handleGeneric(Exception ex) {

--- a/backend/src/main/java/com/dbaagent/controller/PerformanceActionController.java
+++ b/backend/src/main/java/com/dbaagent/controller/PerformanceActionController.java
@@ -12,11 +12,14 @@ import com.dbaagent.service.PerformanceActionAggregatorService;
 import com.dbaagent.service.PerformanceActionAggregatorService.ActionSummary;
 import com.dbaagent.service.PerformanceActionAggregatorService.RefreshResult;
 import com.dbaagent.service.SlowQueryHistoryService;
+import com.dbaagent.service.security.AccessControlService;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
@@ -28,6 +31,12 @@ import java.util.Set;
 /**
  * REST controller for unified performance actions.
  * Provides endpoints for listing, filtering, refreshing, and managing performance recommendations.
+ *
+ * <p><b>Authorization:</b> every endpoint here takes a caller-supplied connection id, so
+ * each one asserts access itself ({@code assertCanReadConnectionContent} for reads,
+ * {@code assertCanManageConnectionContent} for writes). {@code SecurityConfig} only
+ * requires an authenticated principal — nothing upstream inspects a connection id. See
+ * {@code ConnectionScopedAuthorizationSafetyTest}.
  */
 @RestController
 @RequestMapping("/performance-actions")
@@ -40,6 +49,7 @@ public class PerformanceActionController {
 
     private final PerformanceActionAggregatorService aggregatorService;
     private final SlowQueryHistoryService slowQueryHistoryService;
+    private final AccessControlService accessControlService;
 
     /**
      * Get all pending performance actions for a connection, sorted by ROI.
@@ -47,6 +57,7 @@ public class PerformanceActionController {
     @GetMapping("/{connectionId}")
     public ResponseEntity<List<PerformanceAction>> getActions(
             @PathVariable String connectionId) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         log.debug("Getting performance actions for connection: {}", connectionId);
         List<PerformanceAction> actions = aggregatorService.getAggregatedActions(connectionId);
         return ResponseEntity.ok(actions);
@@ -59,6 +70,7 @@ public class PerformanceActionController {
     public ResponseEntity<List<PerformanceAction>> getTopActions(
             @PathVariable String connectionId,
             @RequestParam(defaultValue = "10") int limit) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         log.debug("Getting top {} actions for connection: {}", limit, connectionId);
         List<PerformanceAction> actions = aggregatorService.getTopActions(connectionId, limit);
         return ResponseEntity.ok(actions);
@@ -71,6 +83,7 @@ public class PerformanceActionController {
     public ResponseEntity<List<PerformanceAction>> getActionsByCategory(
             @PathVariable String connectionId,
             @PathVariable ActionCategory category) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         log.debug("Getting actions for connection {} by category: {}", connectionId, category);
         List<PerformanceAction> actions = aggregatorService.getActionsByCategory(connectionId, category);
         return ResponseEntity.ok(actions);
@@ -83,6 +96,7 @@ public class PerformanceActionController {
     public ResponseEntity<List<PerformanceAction>> getActionsBySource(
             @PathVariable String connectionId,
             @PathVariable ActionSource source) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         log.debug("Getting actions for connection {} by source: {}", connectionId, source);
         List<PerformanceAction> actions = aggregatorService.getActionsBySource(connectionId, source);
         return ResponseEntity.ok(actions);
@@ -94,6 +108,7 @@ public class PerformanceActionController {
     @GetMapping("/{connectionId}/summary")
     public ResponseEntity<ActionSummary> getSummary(
             @PathVariable String connectionId) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         log.debug("Getting action summary for connection: {}", connectionId);
         ActionSummary summary = aggregatorService.getSummary(connectionId);
         return ResponseEntity.ok(summary);
@@ -105,6 +120,7 @@ public class PerformanceActionController {
     @PostMapping("/{connectionId}/refresh")
     public ResponseEntity<RefreshResult> refreshActions(
             @PathVariable String connectionId) {
+        accessControlService.assertCanManageConnectionContent(connectionId);
         log.info("Refreshing performance actions for connection: {}", connectionId);
         RefreshResult result = aggregatorService.refreshActions(connectionId);
         return ResponseEntity.ok(result);
@@ -118,10 +134,13 @@ public class PerformanceActionController {
             @PathVariable String actionId,
             @RequestBody StatusUpdateRequest request) {
         log.info("Updating action {} status to: {}", actionId, request.getStatus());
+        assertCanManageAction(actionId);
+        // The resolver is the authenticated caller, never request.getResolvedBy():
+        // that was client-supplied, so the audit trail could name anyone.
         PerformanceAction updated = aggregatorService.updateStatus(
                 actionId,
                 request.getStatus(),
-                request.getResolvedBy(),
+                accessControlService.requireCurrentUsername(),
                 request.getNotes());
         return ResponseEntity.ok(updated);
     }
@@ -134,12 +153,13 @@ public class PerformanceActionController {
             @RequestBody BatchStatusUpdateRequest request) {
         log.info("Batch updating {} actions to status: {}",
                 request.getActionIds().size(), request.getStatus());
+        request.getActionIds().forEach(this::assertCanManageAction);
 
         List<PerformanceAction> updated = request.getActionIds().stream()
                 .map(id -> aggregatorService.updateStatus(
                         id,
                         request.getStatus(),
-                        request.getResolvedBy(),
+                        accessControlService.requireCurrentUsername(),
                         request.getNotes()))
                 .toList();
 
@@ -158,6 +178,7 @@ public class PerformanceActionController {
         }
         PerformanceAction action = actionOpt.get();
         String connectionId = action.getConnectionId();
+        accessControlService.assertCanReadConnectionContent(connectionId);
         String tableName = action.getTargetObject();
         if (tableName == null || tableName.isBlank()) {
             return ResponseEntity.ok(new AffectedQueriesResponse(List.of(), 0));
@@ -272,5 +293,17 @@ public class PerformanceActionController {
         private final String queryText;
         private final Double avgExecutionTimeMs;
         private final Long callCount;
+    }
+
+    /**
+     * Authorize a write keyed only on an action id. The action carries its own
+     * connectionId, so resolve that first and assert against it — an action id
+     * is not a capability. An unknown id reports 404 rather than 403 so the
+     * endpoint cannot be used to probe which action ids exist.
+     */
+    private void assertCanManageAction(String actionId) {
+        PerformanceAction action = aggregatorService.getActionById(actionId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Action not found"));
+        accessControlService.assertCanManageConnectionContent(action.getConnectionId());
     }
 }

--- a/backend/src/main/java/com/dbaagent/controller/PerformanceActionController.java
+++ b/backend/src/main/java/com/dbaagent/controller/PerformanceActionController.java
@@ -298,12 +298,13 @@ public class PerformanceActionController {
     /**
      * Authorize a write keyed only on an action id. The action carries its own
      * connectionId, so resolve that first and assert against it — an action id
-     * is not a capability. An unknown id reports 404 rather than 403 so the
-     * endpoint cannot be used to probe which action ids exist.
+     * is not a capability. An unknown id and one on a connection the caller cannot
+     * manage both report 404, so the endpoint cannot be used to probe which action
+     * ids exist.
      */
     private void assertCanManageAction(String actionId) {
         PerformanceAction action = aggregatorService.getActionById(actionId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Action not found"));
-        accessControlService.assertCanManageConnectionContent(action.getConnectionId());
+        accessControlService.assertCanManageConnectionContentOrNotFound(action.getConnectionId(), "Action");
     }
 }

--- a/backend/src/main/java/com/dbaagent/controller/PerformanceInsightsController.java
+++ b/backend/src/main/java/com/dbaagent/controller/PerformanceInsightsController.java
@@ -5,6 +5,7 @@ import com.dbaagent.model.DatabaseConnection;
 import com.dbaagent.model.PerformanceSnapshot;
 import com.dbaagent.service.CredentialService;
 import com.dbaagent.service.PerformanceInsightsService;
+import com.dbaagent.service.security.AccessControlService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,12 @@ import java.util.*;
 /**
  * Performance Insights Controller
  * Provides AWS RDS Performance Insights-style APIs
+ *
+ * <p><b>Authorization:</b> every endpoint here takes a caller-supplied connection id, so
+ * each one asserts access itself ({@code assertCanReadConnectionContent} for reads,
+ * {@code assertCanManageConnectionContent} for writes). {@code SecurityConfig} only
+ * requires an authenticated principal — nothing upstream inspects a connection id. See
+ * {@code ConnectionScopedAuthorizationSafetyTest}.
  */
 @RestController
 @RequestMapping("/performance-insights")
@@ -27,6 +34,7 @@ public class PerformanceInsightsController {
 
     private final PerformanceInsightsService performanceInsightsService;
     private final CredentialService credentialService;
+    private final AccessControlService accessControlService;
 
     /**
      * GET /api/performance-insights/{connectionId}
@@ -36,6 +44,7 @@ public class PerformanceInsightsController {
     public ResponseEntity<?> getSnapshots(
             @PathVariable String connectionId,
             @RequestParam(defaultValue = "1") int hours) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
 
         try {
             log.info("Fetching performance snapshots for connection: {}, hours: {}", connectionId, hours);
@@ -75,6 +84,7 @@ public class PerformanceInsightsController {
     public ResponseEntity<?> getRecentSnapshots(
             @PathVariable String connectionId,
             @RequestParam(defaultValue = "12") int limit) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
 
         try {
             log.info("Fetching {} recent performance snapshots for connection: {}", limit, connectionId);
@@ -107,6 +117,7 @@ public class PerformanceInsightsController {
      */
     @PostMapping("/{connectionId}/collect")
     public ResponseEntity<?> collectSnapshot(@PathVariable String connectionId) {
+        accessControlService.assertCanManageConnectionContent(connectionId);
 
         try {
             log.info("Manual snapshot collection triggered for connection: {}", connectionId);
@@ -145,6 +156,7 @@ public class PerformanceInsightsController {
     public ResponseEntity<?> getSummary(
             @PathVariable String connectionId,
             @RequestParam(defaultValue = "1") int hours) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
 
         try {
             log.info("Fetching performance summary for connection: {}, hours: {}", connectionId, hours);
@@ -237,6 +249,7 @@ public class PerformanceInsightsController {
      */
     @GetMapping("/table-usage/{connectionId}")
     public ResponseEntity<?> getTableUsage(@PathVariable String connectionId) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
 
         try {
             log.info("Fetching table usage for connection: {}", connectionId);

--- a/backend/src/main/java/com/dbaagent/controller/ProjectController.java
+++ b/backend/src/main/java/com/dbaagent/controller/ProjectController.java
@@ -2,6 +2,7 @@ package com.dbaagent.controller;
 
 import com.dbaagent.model.Project;
 import com.dbaagent.service.ProjectService;
+import com.dbaagent.service.security.AccessControlService;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -9,11 +10,21 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+/**
+ * REST API for projects, optionally filtered by connection.
+ *
+ * <p><b>Authorization:</b> every endpoint here takes a caller-supplied connection id, so
+ * each one asserts access itself ({@code assertCanReadConnectionContent} for reads,
+ * {@code assertCanManageConnectionContent} for writes). {@code SecurityConfig} only
+ * requires an authenticated principal — nothing upstream inspects a connection id. See
+ * {@code ConnectionScopedAuthorizationSafetyTest}.
+ */
 @RestController
 @RequestMapping("/projects")
 @RequiredArgsConstructor
 public class ProjectController {
     private final ProjectService projectService;
+    private final AccessControlService accessControlService;
 
     @PostMapping
     public ResponseEntity<Project> createProject(@RequestBody CreateProjectRequest request) {
@@ -29,6 +40,9 @@ public class ProjectController {
     public ResponseEntity<List<Project>> listProjects(
         @RequestParam(required = false) String connectionId
     ) {
+        if (connectionId != null) {
+            accessControlService.assertCanReadConnectionContent(connectionId);
+        }
         List<Project> projects = connectionId != null
             ? projectService.getProjectsByConnection(connectionId)
             : projectService.getAllProjects();

--- a/backend/src/main/java/com/dbaagent/controller/ProjectController.java
+++ b/backend/src/main/java/com/dbaagent/controller/ProjectController.java
@@ -8,16 +8,21 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * REST API for projects, optionally filtered by connection.
  *
- * <p><b>Authorization:</b> every endpoint here takes a caller-supplied connection id, so
- * each one asserts access itself ({@code assertCanReadConnectionContent} for reads,
- * {@code assertCanManageConnectionContent} for writes). {@code SecurityConfig} only
- * requires an authenticated principal — nothing upstream inspects a connection id. See
- * {@code ConnectionScopedAuthorizationSafetyTest}.
+ * <p><b>Authorization:</b> a project belongs to a connection, so every endpoint is gated
+ * on that connection's ACL — directly where the request carries a {@code connectionId},
+ * and via the project's own {@code connectionId} where the path carries only a
+ * {@code projectId}. {@code SecurityConfig} only requires an authenticated principal;
+ * nothing upstream inspects a connection id.
+ *
+ * <p>The id-keyed endpoints report 404 rather than 403 for a project the caller may not
+ * touch, so the route cannot be used to test which project ids exist.
  */
 @RestController
 @RequestMapping("/projects")
@@ -28,6 +33,7 @@ public class ProjectController {
 
     @PostMapping
     public ResponseEntity<Project> createProject(@RequestBody CreateProjectRequest request) {
+        accessControlService.assertCanManageConnectionContent(request.getConnectionId());
         Project project = projectService.createProject(
             request.getName(),
             request.getDescription(),
@@ -42,18 +48,26 @@ public class ProjectController {
     ) {
         if (connectionId != null) {
             accessControlService.assertCanReadConnectionContent(connectionId);
+            return ResponseEntity.ok(projectService.getProjectsByConnection(connectionId));
         }
-        List<Project> projects = connectionId != null
-            ? projectService.getProjectsByConnection(connectionId)
-            : projectService.getAllProjects();
-        return ResponseEntity.ok(projects);
+        // No filter means "every project on every connection", which cannot be authorized
+        // against a single connection's grants — so it is scoped to the caller instead.
+        // Access is resolved once per distinct connection, not once per project:
+        // ConnectionAccessService.resolveAccess is uncached and hits the grant table, and
+        // many projects share a connection.
+        Map<String, Boolean> readable = new HashMap<>();
+        return ResponseEntity.ok(projectService.getAllProjects().stream()
+            .filter(p -> readable.computeIfAbsent(
+                    String.valueOf(p.getConnectionId()), c -> canRead(p.getConnectionId())))
+            .toList());
     }
 
     @GetMapping("/{projectId}")
     public ResponseEntity<Project> getProject(@PathVariable String projectId) {
-        return projectService.getProject(projectId)
-            .map(ResponseEntity::ok)
-            .orElse(ResponseEntity.notFound().build());
+        Project project = requireProject(projectId);
+        accessControlService.assertCanReadConnectionContentOrNotFound(
+                project.getConnectionId(), "Project");
+        return ResponseEntity.ok(project);
     }
 
     @PutMapping("/{projectId}")
@@ -61,6 +75,7 @@ public class ProjectController {
         @PathVariable String projectId,
         @RequestBody UpdateProjectRequest request
     ) {
+        assertCanManageProject(projectId);
         return projectService.updateProject(projectId, request.getName(), request.getDescription())
             .map(ResponseEntity::ok)
             .orElse(ResponseEntity.notFound().build());
@@ -68,6 +83,7 @@ public class ProjectController {
 
     @DeleteMapping("/{projectId}")
     public ResponseEntity<Void> deleteProject(@PathVariable String projectId) {
+        assertCanManageProject(projectId);
         return projectService.deleteProject(projectId)
             ? ResponseEntity.ok().build()
             : ResponseEntity.notFound().build();
@@ -78,6 +94,31 @@ public class ProjectController {
         private String name;
         private String description;
         private String connectionId;
+    }
+
+    private Project requireProject(String projectId) {
+        return projectService.getProject(projectId)
+            .orElseThrow(() -> new org.springframework.web.server.ResponseStatusException(
+                    org.springframework.http.HttpStatus.NOT_FOUND, "Project not found"));
+    }
+
+    /** A project id is not a capability: authorize the connection that owns the project. */
+    private void assertCanManageProject(String projectId) {
+        accessControlService.assertCanManageConnectionContentOrNotFound(
+                requireProject(projectId).getConnectionId(), "Project");
+    }
+
+    /** Non-throwing read check, for filtering a cross-connection list. */
+    private boolean canRead(String connectionId) {
+        if (connectionId == null) {
+            return false;
+        }
+        try {
+            accessControlService.assertCanReadConnectionContent(connectionId);
+            return true;
+        } catch (org.springframework.web.server.ResponseStatusException e) {
+            return false;
+        }
     }
 
     @Data

--- a/backend/src/main/java/com/dbaagent/controller/QueryPerformanceController.java
+++ b/backend/src/main/java/com/dbaagent/controller/QueryPerformanceController.java
@@ -280,14 +280,15 @@ public class QueryPerformanceController {
      * Authorize a write keyed only on a regression id. The regression carries
      * its own connectionId, so resolve that and assert against it — a
      * regression id is not a capability, and these ids are sequential Longs,
-     * so they are trivially enumerable. An unknown id reports 404 so the
-     * endpoint cannot be used to probe which regressions exist.
+     * so they are trivially enumerable — walking 1..N would otherwise map out every
+     * tenant's regressions. An unknown id and one the caller cannot manage both report
+     * 404, so the response does not distinguish them.
      */
     private void assertCanManageRegression(Long regressionId) {
         String connectionId = queryPerformanceService.findConnectionIdForRegression(regressionId)
                 .orElseThrow(() -> new org.springframework.web.server.ResponseStatusException(
                         org.springframework.http.HttpStatus.NOT_FOUND, "Regression not found"));
-        accessControlService.assertCanManageConnectionContent(connectionId);
+        accessControlService.assertCanManageConnectionContentOrNotFound(connectionId, "Regression");
     }
 
     /** The authenticated caller. Never trust a client-supplied actor name. */

--- a/backend/src/main/java/com/dbaagent/controller/QueryPerformanceController.java
+++ b/backend/src/main/java/com/dbaagent/controller/QueryPerformanceController.java
@@ -3,6 +3,7 @@ package com.dbaagent.controller;
 import com.dbaagent.model.QueryPerformanceHistory;
 import com.dbaagent.model.QueryPerformanceRegression;
 import com.dbaagent.service.QueryPerformanceService;
+import com.dbaagent.service.security.AccessControlService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +13,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * REST API for per-query performance history, trends, and regressions.
+ *
+ * <p><b>Authorization:</b> every endpoint here takes a caller-supplied connection id, so
+ * each one asserts access itself ({@code assertCanReadConnectionContent} for reads,
+ * {@code assertCanManageConnectionContent} for writes). {@code SecurityConfig} only
+ * requires an authenticated principal — nothing upstream inspects a connection id. See
+ * {@code ConnectionScopedAuthorizationSafetyTest}.
+ */
 @RestController
 @RequestMapping("/query-performance")
 @Slf4j
@@ -20,6 +30,9 @@ public class QueryPerformanceController {
     @Autowired
     private QueryPerformanceService queryPerformanceService;
 
+    @Autowired
+    private AccessControlService accessControlService;
+
     /**
      * Record a query execution
      */
@@ -27,6 +40,7 @@ public class QueryPerformanceController {
     public ResponseEntity<Map<String, Object>> recordQueryExecution(@RequestBody Map<String, Object> request) {
         try {
             String connectionId = (String) request.get("connectionId");
+            accessControlService.assertCanManageConnectionContent(connectionId);
             String queryText = (String) request.get("queryText");
             Double executionTimeMs = ((Number) request.get("executionTimeMs")).doubleValue();
             Long rowsExamined = request.get("rowsExamined") != null ?
@@ -62,6 +76,7 @@ public class QueryPerformanceController {
     @GetMapping("/queries/{connectionId}")
     public ResponseEntity<Map<String, Object>> getTrackedQueries(@PathVariable String connectionId) {
         try {
+            accessControlService.assertCanReadConnectionContent(connectionId);
             List<Map<String, Object>> queries = queryPerformanceService.getTrackedQueries(connectionId);
 
             Map<String, Object> response = new HashMap<>();
@@ -91,6 +106,7 @@ public class QueryPerformanceController {
             @RequestParam(defaultValue = "7") int days
     ) {
         try {
+            accessControlService.assertCanReadConnectionContent(connectionId);
             List<QueryPerformanceHistory> history = queryPerformanceService.getQueryHistory(
                     connectionId, queryHash, days
             );
@@ -122,6 +138,7 @@ public class QueryPerformanceController {
             @RequestParam(defaultValue = "7") int days
     ) {
         try {
+            accessControlService.assertCanReadConnectionContent(connectionId);
             Map<String, Object> trendData = queryPerformanceService.getPerformanceTrend(
                     connectionId, queryHash, days
             );
@@ -151,6 +168,7 @@ public class QueryPerformanceController {
             @RequestParam(defaultValue = "false") boolean unacknowledgedOnly
     ) {
         try {
+            accessControlService.assertCanReadConnectionContent(connectionId);
             List<QueryPerformanceRegression> regressions = queryPerformanceService.getRegressions(
                     connectionId, unacknowledgedOnly
             );
@@ -181,8 +199,8 @@ public class QueryPerformanceController {
             @RequestBody(required = false) Map<String, String> request
     ) {
         try {
-            String acknowledgedBy = request != null ? request.get("acknowledgedBy") : "user";
-            queryPerformanceService.acknowledgeRegression(regressionId, acknowledgedBy);
+            assertCanManageRegression(regressionId);
+            queryPerformanceService.acknowledgeRegression(regressionId, actor());
 
             Map<String, Object> response = new HashMap<>();
             response.put("success", true);
@@ -209,6 +227,7 @@ public class QueryPerformanceController {
             @RequestBody Map<String, String> request
     ) {
         try {
+            assertCanManageRegression(regressionId);
             String resolutionNotes = request.get("resolutionNotes");
             queryPerformanceService.resolveRegression(regressionId, resolutionNotes);
 
@@ -234,6 +253,7 @@ public class QueryPerformanceController {
     @PostMapping("/analyze/{connectionId}")
     public ResponseEntity<Map<String, Object>> triggerAnalysis(@PathVariable String connectionId) {
         try {
+            accessControlService.assertCanManageConnectionContent(connectionId);
             // This will be run async, so just trigger it
             new Thread(() -> {
                 log.info("Manual performance analysis triggered for connection: {}", connectionId);
@@ -254,5 +274,24 @@ public class QueryPerformanceController {
             error.put("message", e.getMessage());
             return ResponseEntity.badRequest().body(error);
         }
+    }
+
+    /**
+     * Authorize a write keyed only on a regression id. The regression carries
+     * its own connectionId, so resolve that and assert against it — a
+     * regression id is not a capability, and these ids are sequential Longs,
+     * so they are trivially enumerable. An unknown id reports 404 so the
+     * endpoint cannot be used to probe which regressions exist.
+     */
+    private void assertCanManageRegression(Long regressionId) {
+        String connectionId = queryPerformanceService.findConnectionIdForRegression(regressionId)
+                .orElseThrow(() -> new org.springframework.web.server.ResponseStatusException(
+                        org.springframework.http.HttpStatus.NOT_FOUND, "Regression not found"));
+        accessControlService.assertCanManageConnectionContent(connectionId);
+    }
+
+    /** The authenticated caller. Never trust a client-supplied actor name. */
+    private String actor() {
+        return accessControlService.requireCurrentUsername();
     }
 }

--- a/backend/src/main/java/com/dbaagent/controller/QueryPlanController.java
+++ b/backend/src/main/java/com/dbaagent/controller/QueryPlanController.java
@@ -108,7 +108,10 @@ public class QueryPlanController {
     public ResponseEntity<Map<String, Object>> acknowledgeRegressions(
             @PathVariable String connectionId,
             @RequestBody List<String> comparisonIds,
-            @RequestParam(required = false, defaultValue = "user") String acknowledgedBy) {
+            @RequestParam(required = false) String acknowledgedBy) {
+            // Accepted for wire compatibility and deliberately ignored: the actor is
+            // taken from the security context below. It previously defaulted to the
+            // literal string "user", so the trail named nobody.
         accessControlService.assertCanManageConnectionContent(connectionId);
 
         if (!planCacheService.allComparisonsBelongTo(connectionId, comparisonIds)) {
@@ -135,12 +138,13 @@ public class QueryPlanController {
     /**
      * Authorize a write keyed only on a plan id. The cached plan carries its own
      * connectionId, so resolve that and assert against it. An unknown id reports
-     * 404 so the endpoint cannot be used to probe which plan ids exist.
+     * 404 — as does a plan belonging to a connection the caller cannot manage, so the
+     * endpoint cannot be used to probe which plan ids exist.
      */
     private void assertCanManagePlan(String planId) {
         String connectionId = planCacheService.findConnectionIdForPlan(planId)
                 .orElseThrow(() -> new org.springframework.web.server.ResponseStatusException(
                         org.springframework.http.HttpStatus.NOT_FOUND, "Plan not found"));
-        accessControlService.assertCanManageConnectionContent(connectionId);
+        accessControlService.assertCanManageConnectionContentOrNotFound(connectionId, "Plan");
     }
 }

--- a/backend/src/main/java/com/dbaagent/controller/QueryPlanController.java
+++ b/backend/src/main/java/com/dbaagent/controller/QueryPlanController.java
@@ -3,6 +3,7 @@ package com.dbaagent.controller;
 import com.dbaagent.model.QueryPlanCache;
 import com.dbaagent.model.QueryPlanComparison;
 import com.dbaagent.service.QueryPlanCacheService;
+import com.dbaagent.service.security.AccessControlService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +14,12 @@ import java.util.Map;
 
 /**
  * REST API for query plan caching and comparison
+ *
+ * <p><b>Authorization:</b> every endpoint here takes a caller-supplied connection id, so
+ * each one asserts access itself ({@code assertCanReadConnectionContent} for reads,
+ * {@code assertCanManageConnectionContent} for writes). {@code SecurityConfig} only
+ * requires an authenticated principal — nothing upstream inspects a connection id. See
+ * {@code ConnectionScopedAuthorizationSafetyTest}.
  */
 @RestController
 @RequestMapping("/query-plans")
@@ -21,6 +28,7 @@ import java.util.Map;
 public class QueryPlanController {
 
     private final QueryPlanCacheService planCacheService;
+    private final AccessControlService accessControlService;
 
     /**
      * Capture execution plan for a query
@@ -29,6 +37,7 @@ public class QueryPlanController {
     public ResponseEntity<QueryPlanCache> capturePlan(
             @PathVariable String connectionId,
             @RequestBody Map<String, Object> request) {
+        accessControlService.assertCanManageConnectionContent(connectionId);
 
         String query = (String) request.get("query");
         boolean analyze = Boolean.TRUE.equals(request.get("analyze"));
@@ -46,6 +55,7 @@ public class QueryPlanController {
      */
     @GetMapping("/{connectionId}/recent")
     public ResponseEntity<List<QueryPlanCache>> getRecentPlans(@PathVariable String connectionId) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return ResponseEntity.ok(planCacheService.getRecentPlans(connectionId));
     }
 
@@ -56,6 +66,7 @@ public class QueryPlanController {
     public ResponseEntity<List<QueryPlanCache>> getPlansForQuery(
             @PathVariable String connectionId,
             @PathVariable String queryHash) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return ResponseEntity.ok(planCacheService.getPlansForQuery(connectionId, queryHash));
     }
 
@@ -64,6 +75,7 @@ public class QueryPlanController {
      */
     @PostMapping("/plans/{planId}/set-baseline")
     public ResponseEntity<Map<String, String>> setBaseline(@PathVariable String planId) {
+        assertCanManagePlan(planId);
         planCacheService.setBaseline(planId);
         return ResponseEntity.ok(Map.of(
                 "status", "success",
@@ -76,6 +88,7 @@ public class QueryPlanController {
      */
     @GetMapping("/{connectionId}/regressions")
     public ResponseEntity<List<QueryPlanComparison>> getRegressions(@PathVariable String connectionId) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return ResponseEntity.ok(planCacheService.getRegressions(connectionId));
     }
 
@@ -84,6 +97,7 @@ public class QueryPlanController {
      */
     @GetMapping("/{connectionId}/regressions/unacknowledged")
     public ResponseEntity<List<QueryPlanComparison>> getUnacknowledgedRegressions(@PathVariable String connectionId) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return ResponseEntity.ok(planCacheService.getUnacknowledgedRegressions(connectionId));
     }
 
@@ -95,8 +109,14 @@ public class QueryPlanController {
             @PathVariable String connectionId,
             @RequestBody List<String> comparisonIds,
             @RequestParam(required = false, defaultValue = "user") String acknowledgedBy) {
+        accessControlService.assertCanManageConnectionContent(connectionId);
 
-        int count = planCacheService.acknowledgeRegressions(comparisonIds, acknowledgedBy);
+        if (!planCacheService.allComparisonsBelongTo(connectionId, comparisonIds)) {
+            throw new org.springframework.web.server.ResponseStatusException(
+                    org.springframework.http.HttpStatus.NOT_FOUND, "Regression not found for this connection");
+        }
+        int count = planCacheService.acknowledgeRegressions(
+                comparisonIds, accessControlService.requireCurrentUsername());
         return ResponseEntity.ok(Map.of(
                 "status", "success",
                 "acknowledgedCount", count
@@ -108,6 +128,19 @@ public class QueryPlanController {
      */
     @GetMapping("/{connectionId}/stats")
     public ResponseEntity<Map<String, Object>> getPlanStats(@PathVariable String connectionId) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return ResponseEntity.ok(planCacheService.getPlanStats(connectionId));
+    }
+
+    /**
+     * Authorize a write keyed only on a plan id. The cached plan carries its own
+     * connectionId, so resolve that and assert against it. An unknown id reports
+     * 404 so the endpoint cannot be used to probe which plan ids exist.
+     */
+    private void assertCanManagePlan(String planId) {
+        String connectionId = planCacheService.findConnectionIdForPlan(planId)
+                .orElseThrow(() -> new org.springframework.web.server.ResponseStatusException(
+                        org.springframework.http.HttpStatus.NOT_FOUND, "Plan not found"));
+        accessControlService.assertCanManageConnectionContent(connectionId);
     }
 }

--- a/backend/src/main/java/com/dbaagent/controller/ResourceLimitsController.java
+++ b/backend/src/main/java/com/dbaagent/controller/ResourceLimitsController.java
@@ -2,6 +2,7 @@ package com.dbaagent.controller;
 
 import com.dbaagent.model.ResourceLimits;
 import com.dbaagent.repository.ResourceLimitsRepository;
+import com.dbaagent.service.security.AccessControlService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +15,12 @@ import java.util.UUID;
 /**
  * Resource Limits Configuration Controller
  * Manages capacity limits for Sentinel-DBA analytics
+ *
+ * <p><b>Authorization:</b> every endpoint here takes a caller-supplied connection id, so
+ * each one asserts access itself ({@code assertCanReadConnectionContent} for reads,
+ * {@code assertCanManageConnectionContent} for writes). {@code SecurityConfig} only
+ * requires an authenticated principal — nothing upstream inspects a connection id. See
+ * {@code ConnectionScopedAuthorizationSafetyTest}.
  */
 @RestController
 @RequestMapping("/resource-limits")
@@ -23,6 +30,7 @@ import java.util.UUID;
 public class ResourceLimitsController {
 
     private final ResourceLimitsRepository resourceLimitsRepository;
+    private final AccessControlService accessControlService;
 
     /**
      * GET /api/resource-limits/{connectionId}
@@ -31,6 +39,7 @@ public class ResourceLimitsController {
     @GetMapping("/{connectionId}")
     public ResponseEntity<?> getResourceLimits(@PathVariable String connectionId) {
         try {
+            accessControlService.assertCanReadConnectionContent(connectionId);
             log.info("Fetching resource limits for connection: {}", connectionId);
 
             var limits = resourceLimitsRepository.findByConnectionId(connectionId);
@@ -61,6 +70,7 @@ public class ResourceLimitsController {
     @PostMapping
     public ResponseEntity<?> saveResourceLimits(@RequestBody ResourceLimitsRequest request) {
         try {
+            accessControlService.assertCanManageConnectionContent(request.getConnectionId());
             log.info("Saving resource limits for connection: {}", request.getConnectionId());
 
             // Check if limits already exist
@@ -120,6 +130,7 @@ public class ResourceLimitsController {
     @DeleteMapping("/{connectionId}")
     public ResponseEntity<?> deleteResourceLimits(@PathVariable String connectionId) {
         try {
+            accessControlService.assertCanManageConnectionContent(connectionId);
             log.info("Deleting resource limits for connection: {}", connectionId);
 
             resourceLimitsRepository.findByConnectionId(connectionId)

--- a/backend/src/main/java/com/dbaagent/controller/SchemaChangeController.java
+++ b/backend/src/main/java/com/dbaagent/controller/SchemaChangeController.java
@@ -80,8 +80,14 @@ public class SchemaChangeController {
             @PathVariable String connectionId,
             @PathVariable String snapshotId) {
         accessControlService.assertCanManageConnectionContent(connectionId);
+        assertSnapshotBelongsTo(connectionId, snapshotId);
 
-        schemaChangeService.setBaseline(connectionId, snapshotId);
+        try {
+            schemaChangeService.setBaseline(connectionId, snapshotId);
+        } catch (IllegalArgumentException e) {
+            throw new org.springframework.web.server.ResponseStatusException(
+                    org.springframework.http.HttpStatus.NOT_FOUND, e.getMessage());
+        }
         return ResponseEntity.ok(Map.of(
                 "status", "success",
                 "message", "Snapshot set as baseline"
@@ -98,7 +104,15 @@ public class SchemaChangeController {
 
         assertCanReadSnapshot(snapshotId1);
         assertCanReadSnapshot(snapshotId2);
-        return ResponseEntity.ok(schemaChangeService.compareSnapshots(snapshotId1, snapshotId2));
+        try {
+            return ResponseEntity.ok(schemaChangeService.compareSnapshots(snapshotId1, snapshotId2));
+        } catch (IllegalArgumentException e) {
+            // Missing snapshot, or two snapshots from different connections. Both are
+            // "not something you can compare", not a server fault — a 500 here would read
+            // as a broken feature and hide the real reason.
+            throw new org.springframework.web.server.ResponseStatusException(
+                    org.springframework.http.HttpStatus.NOT_FOUND, e.getMessage());
+        }
     }
 
     // ==================== Change Endpoints ====================
@@ -128,7 +142,10 @@ public class SchemaChangeController {
     public ResponseEntity<Map<String, Object>> acknowledgeChanges(
             @PathVariable String connectionId,
             @RequestBody List<String> changeIds,
-            @RequestParam(required = false, defaultValue = "user") String acknowledgedBy) {
+            @RequestParam(required = false) String acknowledgedBy) {
+            // Accepted for wire compatibility and deliberately ignored: the actor is
+            // taken from the security context below. It previously defaulted to the
+            // literal string "user", so the trail named nobody.
         accessControlService.assertCanManageConnectionContent(connectionId);
 
         assertChangesBelongTo(connectionId, changeIds);
@@ -145,7 +162,10 @@ public class SchemaChangeController {
     @PostMapping("/{connectionId}/changes/acknowledge-all")
     public ResponseEntity<Map<String, Object>> acknowledgeAllChanges(
             @PathVariable String connectionId,
-            @RequestParam(required = false, defaultValue = "user") String acknowledgedBy) {
+            @RequestParam(required = false) String acknowledgedBy) {
+            // Accepted for wire compatibility and deliberately ignored: the actor is
+            // taken from the security context below. It previously defaulted to the
+            // literal string "user", so the trail named nobody.
         accessControlService.assertCanManageConnectionContent(connectionId);
 
         int count = schemaChangeService.acknowledgeAllChanges(
@@ -207,13 +227,14 @@ public class SchemaChangeController {
     /**
      * Authorize a read keyed only on a snapshot id. The snapshot carries its own
      * connectionId, so resolve that and assert against it. An unknown id reports
-     * 404 so the endpoint cannot be used to probe which snapshots exist.
+     * 404 — as does a snapshot on a connection the caller cannot read, so the endpoint
+     * cannot be used to probe which snapshots exist.
      */
     private void assertCanReadSnapshot(String snapshotId) {
         String connectionId = schemaChangeService.findConnectionIdForSnapshot(snapshotId)
                 .orElseThrow(() -> new org.springframework.web.server.ResponseStatusException(
                         org.springframework.http.HttpStatus.NOT_FOUND, "Snapshot not found"));
-        accessControlService.assertCanReadConnectionContent(connectionId);
+        accessControlService.assertCanReadConnectionContentOrNotFound(connectionId, "Snapshot");
     }
 
     /**
@@ -225,6 +246,21 @@ public class SchemaChangeController {
         if (!schemaChangeService.allChangesBelongTo(connectionId, changeIds)) {
             throw new org.springframework.web.server.ResponseStatusException(
                     org.springframework.http.HttpStatus.NOT_FOUND, "Change not found for this connection");
+        }
+    }
+
+    /**
+     * The snapshot id is a separate path variable from the connection id, so authorizing
+     * the connection says nothing about the snapshot. Without this a caller with manage
+     * access on connection A could flip connection B's snapshot to BASELINE and point A's
+     * drift config at it — the same body/path id-mismatch class as
+     * {@code changes/acknowledge}, just split across two path variables instead.
+     */
+    private void assertSnapshotBelongsTo(String connectionId, String snapshotId) {
+        String owner = schemaChangeService.findConnectionIdForSnapshot(snapshotId).orElse(null);
+        if (!connectionId.equals(owner)) {
+            throw new org.springframework.web.server.ResponseStatusException(
+                    org.springframework.http.HttpStatus.NOT_FOUND, "Snapshot not found");
         }
     }
 }

--- a/backend/src/main/java/com/dbaagent/controller/SchemaChangeController.java
+++ b/backend/src/main/java/com/dbaagent/controller/SchemaChangeController.java
@@ -4,6 +4,7 @@ import com.dbaagent.model.SchemaChange;
 import com.dbaagent.model.SchemaDriftConfig;
 import com.dbaagent.model.SchemaSnapshot;
 import com.dbaagent.service.SchemaChangeTrackingService;
+import com.dbaagent.service.security.AccessControlService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +15,12 @@ import java.util.Map;
 
 /**
  * REST API for schema change tracking and drift detection
+ *
+ * <p><b>Authorization:</b> every endpoint here takes a caller-supplied connection id, so
+ * each one asserts access itself ({@code assertCanReadConnectionContent} for reads,
+ * {@code assertCanManageConnectionContent} for writes). {@code SecurityConfig} only
+ * requires an authenticated principal — nothing upstream inspects a connection id. See
+ * {@code ConnectionScopedAuthorizationSafetyTest}.
  */
 @RestController
 @RequestMapping("/schema-changes")
@@ -23,6 +30,7 @@ public class SchemaChangeController {
 
     private final SchemaChangeTrackingService schemaChangeService;
     private final com.dbaagent.service.SchemaSnapshotService schemaSnapshotService;
+    private final AccessControlService accessControlService;
 
     // ==================== Snapshot Endpoints ====================
 
@@ -35,6 +43,7 @@ public class SchemaChangeController {
             @RequestParam(required = false) String name,
             @RequestParam(required = false, defaultValue = "MANUAL") String type,
             @RequestParam(required = false) String notes) {
+        accessControlService.assertCanManageConnectionContent(connectionId);
 
         SchemaSnapshot.SnapshotType snapshotType = SchemaSnapshot.SnapshotType.valueOf(type.toUpperCase());
         // Was: schemaChangeService.captureSnapshot — moved into
@@ -50,6 +59,7 @@ public class SchemaChangeController {
      */
     @GetMapping("/{connectionId}/snapshots")
     public ResponseEntity<List<SchemaSnapshot>> getSnapshots(@PathVariable String connectionId) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return ResponseEntity.ok(schemaChangeService.getSnapshots(connectionId));
     }
 
@@ -58,6 +68,7 @@ public class SchemaChangeController {
      */
     @GetMapping("/{connectionId}/snapshots/recent")
     public ResponseEntity<List<SchemaSnapshot>> getRecentSnapshots(@PathVariable String connectionId) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return ResponseEntity.ok(schemaChangeService.getRecentSnapshots(connectionId));
     }
 
@@ -68,6 +79,7 @@ public class SchemaChangeController {
     public ResponseEntity<Map<String, String>> setBaseline(
             @PathVariable String connectionId,
             @PathVariable String snapshotId) {
+        accessControlService.assertCanManageConnectionContent(connectionId);
 
         schemaChangeService.setBaseline(connectionId, snapshotId);
         return ResponseEntity.ok(Map.of(
@@ -84,6 +96,8 @@ public class SchemaChangeController {
             @RequestParam String snapshotId1,
             @RequestParam String snapshotId2) {
 
+        assertCanReadSnapshot(snapshotId1);
+        assertCanReadSnapshot(snapshotId2);
         return ResponseEntity.ok(schemaChangeService.compareSnapshots(snapshotId1, snapshotId2));
     }
 
@@ -94,6 +108,7 @@ public class SchemaChangeController {
      */
     @GetMapping("/{connectionId}/changes")
     public ResponseEntity<List<SchemaChange>> getChanges(@PathVariable String connectionId) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return ResponseEntity.ok(schemaChangeService.getChanges(connectionId));
     }
 
@@ -102,6 +117,7 @@ public class SchemaChangeController {
      */
     @GetMapping("/{connectionId}/changes/unacknowledged")
     public ResponseEntity<List<SchemaChange>> getUnacknowledgedChanges(@PathVariable String connectionId) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return ResponseEntity.ok(schemaChangeService.getUnacknowledgedChanges(connectionId));
     }
 
@@ -113,8 +129,10 @@ public class SchemaChangeController {
             @PathVariable String connectionId,
             @RequestBody List<String> changeIds,
             @RequestParam(required = false, defaultValue = "user") String acknowledgedBy) {
+        accessControlService.assertCanManageConnectionContent(connectionId);
 
-        int count = schemaChangeService.acknowledgeChanges(changeIds, acknowledgedBy);
+        assertChangesBelongTo(connectionId, changeIds);
+        int count = schemaChangeService.acknowledgeChanges(changeIds, accessControlService.requireCurrentUsername());
         return ResponseEntity.ok(Map.of(
                 "status", "success",
                 "acknowledgedCount", count
@@ -128,8 +146,10 @@ public class SchemaChangeController {
     public ResponseEntity<Map<String, Object>> acknowledgeAllChanges(
             @PathVariable String connectionId,
             @RequestParam(required = false, defaultValue = "user") String acknowledgedBy) {
+        accessControlService.assertCanManageConnectionContent(connectionId);
 
-        int count = schemaChangeService.acknowledgeAllChanges(connectionId, acknowledgedBy);
+        int count = schemaChangeService.acknowledgeAllChanges(
+                connectionId, accessControlService.requireCurrentUsername());
         return ResponseEntity.ok(Map.of(
                 "status", "success",
                 "acknowledgedCount", count
@@ -141,6 +161,7 @@ public class SchemaChangeController {
      */
     @GetMapping("/{connectionId}/changes/stats")
     public ResponseEntity<Map<String, Object>> getChangeStats(@PathVariable String connectionId) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return ResponseEntity.ok(schemaChangeService.getChangeStats(connectionId));
     }
 
@@ -151,6 +172,7 @@ public class SchemaChangeController {
      */
     @GetMapping("/{connectionId}/drift-config")
     public ResponseEntity<SchemaDriftConfig> getDriftConfig(@PathVariable String connectionId) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return schemaChangeService.getDriftConfig(connectionId)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
@@ -163,6 +185,7 @@ public class SchemaChangeController {
     public ResponseEntity<SchemaDriftConfig> configureDriftDetection(
             @PathVariable String connectionId,
             @RequestBody SchemaDriftConfig config) {
+        accessControlService.assertCanManageConnectionContent(connectionId);
 
         return ResponseEntity.ok(schemaChangeService.configureDriftDetection(connectionId, config));
     }
@@ -172,11 +195,36 @@ public class SchemaChangeController {
      */
     @PostMapping("/{connectionId}/drift-check")
     public ResponseEntity<Map<String, Object>> triggerDriftCheck(@PathVariable String connectionId) {
+        accessControlService.assertCanManageConnectionContent(connectionId);
         List<SchemaChange> changes = schemaChangeService.checkDrift(connectionId);
         return ResponseEntity.ok(Map.of(
                 "status", "success",
                 "changesDetected", changes.size(),
                 "changes", changes
         ));
+    }
+
+    /**
+     * Authorize a read keyed only on a snapshot id. The snapshot carries its own
+     * connectionId, so resolve that and assert against it. An unknown id reports
+     * 404 so the endpoint cannot be used to probe which snapshots exist.
+     */
+    private void assertCanReadSnapshot(String snapshotId) {
+        String connectionId = schemaChangeService.findConnectionIdForSnapshot(snapshotId)
+                .orElseThrow(() -> new org.springframework.web.server.ResponseStatusException(
+                        org.springframework.http.HttpStatus.NOT_FOUND, "Snapshot not found"));
+        accessControlService.assertCanReadConnectionContent(connectionId);
+    }
+
+    /**
+     * The change ids arrive in the request body, so the path-variable check alone
+     * does not constrain them — a caller authorized on their own connection could
+     * otherwise acknowledge another connection's changes.
+     */
+    private void assertChangesBelongTo(String connectionId, List<String> changeIds) {
+        if (!schemaChangeService.allChangesBelongTo(connectionId, changeIds)) {
+            throw new org.springframework.web.server.ResponseStatusException(
+                    org.springframework.http.HttpStatus.NOT_FOUND, "Change not found for this connection");
+        }
     }
 }

--- a/backend/src/main/java/com/dbaagent/controller/SentinelAnalyticsController.java
+++ b/backend/src/main/java/com/dbaagent/controller/SentinelAnalyticsController.java
@@ -232,7 +232,9 @@ public class SentinelAnalyticsController {
             String deploymentTag = (String) eventData.get("deploymentTag");
             @SuppressWarnings("unchecked")
             List<String> affectedTables = (List<String>) eventData.get("affectedTables");
-            String initiatedBy = (String) eventData.get("initiatedBy");
+            // The actor is the authenticated caller; an "initiatedBy" in the body
+            // would let anyone attribute a deployment event to a colleague.
+            String initiatedBy = accessControlService.requireCurrentUsername();
 
             log.info("Logging deployment event: {} for connection {}", deploymentVersion, connectionId);
 
@@ -273,7 +275,9 @@ public class SentinelAnalyticsController {
             String tableName = (String) eventData.get("tableName");
             String changeType = (String) eventData.get("changeType");
             String description = (String) eventData.get("description");
-            String initiatedBy = (String) eventData.get("initiatedBy");
+            // The actor is the authenticated caller; an "initiatedBy" in the body
+            // would let anyone attribute a deployment event to a colleague.
+            String initiatedBy = accessControlService.requireCurrentUsername();
 
             log.info("Logging schema change event: {} on table {}", changeType, tableName);
 
@@ -526,13 +530,13 @@ public class SentinelAnalyticsController {
     /**
      * Authorize a write keyed only on a recommendation id. The recommendation
      * carries its own connectionId, so resolve that and assert against it — a
-     * recommendation id is not a capability. An unknown id reports 404 so the
-     * endpoint cannot be used to probe which recommendations exist.
+     * recommendation id is not a capability. An unknown id and one on a connection the
+     * caller cannot manage both report 404, so the two are indistinguishable.
      */
     private void assertCanManageRecommendation(String recommendationId) {
         String connectionId = sentinelAnalytics.findConnectionIdForRecommendation(recommendationId)
                 .orElseThrow(() -> new org.springframework.web.server.ResponseStatusException(
                         org.springframework.http.HttpStatus.NOT_FOUND, "Recommendation not found"));
-        accessControlService.assertCanManageConnectionContent(connectionId);
+        accessControlService.assertCanManageConnectionContentOrNotFound(connectionId, "Recommendation");
     }
 }

--- a/backend/src/main/java/com/dbaagent/controller/SentinelAnalyticsController.java
+++ b/backend/src/main/java/com/dbaagent/controller/SentinelAnalyticsController.java
@@ -5,6 +5,7 @@ import com.dbaagent.model.DatabaseEvent;
 import com.dbaagent.model.SentinelRecommendation;
 import com.dbaagent.service.EventCorrelationService;
 import com.dbaagent.service.SentinelAnalyticsService;
+import com.dbaagent.service.security.AccessControlService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -23,16 +24,22 @@ import java.util.Map;
  * - Contextual Attribution: Event correlation
  * - Velocity & Acceleration: Growth derivatives
  * - AI Recommendations: Actionable insights
+ *
+ * <p><b>Authorization:</b> every endpoint here takes a caller-supplied connection id, so
+ * each one asserts access itself ({@code assertCanReadConnectionContent} for reads,
+ * {@code assertCanManageConnectionContent} for writes). {@code SecurityConfig} only
+ * requires an authenticated principal — nothing upstream inspects a connection id. See
+ * {@code ConnectionScopedAuthorizationSafetyTest}.
  */
 @RestController
 @RequestMapping("/sentinel")
 @RequiredArgsConstructor
 @Slf4j
-@CrossOrigin(origins = "*")
 public class SentinelAnalyticsController {
 
     private final SentinelAnalyticsService sentinelAnalytics;
     private final EventCorrelationService eventCorrelation;
+    private final AccessControlService accessControlService;
 
     /**
      * GET /api/sentinel/death-clock/{connectionId}
@@ -41,6 +48,7 @@ public class SentinelAnalyticsController {
      */
     @GetMapping("/death-clock/{connectionId}")
     public ResponseEntity<Map<String, Object>> getDeathClock(@PathVariable String connectionId) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             log.info("Fetching Death Clock for connection: {}", connectionId);
 
@@ -72,6 +80,7 @@ public class SentinelAnalyticsController {
     public ResponseEntity<Map<String, Object>> getForecasts(
             @PathVariable String connectionId,
             @RequestParam(required = false) String tableName) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
 
         try {
             log.info("Fetching forecasts for connection: {}, table: {}", connectionId, tableName);
@@ -112,6 +121,7 @@ public class SentinelAnalyticsController {
     public ResponseEntity<Map<String, Object>> generateForecast(
             @PathVariable String connectionId,
             @RequestParam String tableName) {
+        accessControlService.assertCanManageConnectionContent(connectionId);
 
         try {
             log.info("Generating forecast for connection: {}, table: {}", connectionId, tableName);
@@ -145,6 +155,7 @@ public class SentinelAnalyticsController {
             @PathVariable String connectionId,
             @RequestParam String tableName,
             @RequestParam(defaultValue = "30") int historicalDays) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
 
         try {
             log.info("Calculating velocity/acceleration for table: {}", tableName);
@@ -181,6 +192,7 @@ public class SentinelAnalyticsController {
     public ResponseEntity<Map<String, Object>> getEvents(
             @PathVariable String connectionId,
             @RequestParam(required = false) Integer days) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
 
         try {
             int daysToFetch = days != null ? days : 30;
@@ -215,6 +227,7 @@ public class SentinelAnalyticsController {
     public ResponseEntity<Map<String, Object>> logDeploymentEvent(@RequestBody Map<String, Object> eventData) {
         try {
             String connectionId = (String) eventData.get("connectionId");
+            accessControlService.assertCanManageConnectionContent(connectionId);
             String deploymentVersion = (String) eventData.get("deploymentVersion");
             String deploymentTag = (String) eventData.get("deploymentTag");
             @SuppressWarnings("unchecked")
@@ -256,6 +269,7 @@ public class SentinelAnalyticsController {
     public ResponseEntity<Map<String, Object>> logSchemaChangeEvent(@RequestBody Map<String, Object> eventData) {
         try {
             String connectionId = (String) eventData.get("connectionId");
+            accessControlService.assertCanManageConnectionContent(connectionId);
             String tableName = (String) eventData.get("tableName");
             String changeType = (String) eventData.get("changeType");
             String description = (String) eventData.get("description");
@@ -297,6 +311,7 @@ public class SentinelAnalyticsController {
             @PathVariable String connectionId,
             @RequestParam(required = false) String status,
             @RequestParam(required = false) String priority) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
 
         try {
             log.info("Fetching recommendations for connection: {} (status: {}, priority: {})",
@@ -342,8 +357,9 @@ public class SentinelAnalyticsController {
             @RequestBody Map<String, String> statusData) {
 
         try {
+            assertCanManageRecommendation(recommendationId);
             String status = statusData.get("status");
-            String updatedBy = statusData.get("updatedBy");
+            String updatedBy = accessControlService.requireCurrentUsername();
 
             log.info("Updating recommendation {} status to: {}", recommendationId, status);
 
@@ -376,6 +392,7 @@ public class SentinelAnalyticsController {
      */
     @GetMapping("/summary/{connectionId}")
     public ResponseEntity<Map<String, Object>> getSentinelSummary(@PathVariable String connectionId) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             log.info("Generating Sentinel-DBA summary for connection: {}", connectionId);
 
@@ -504,5 +521,18 @@ public class SentinelAnalyticsController {
                 mostUrgent.getConfidenceScore(),
                 pendingRecs.size()
         );
+    }
+
+    /**
+     * Authorize a write keyed only on a recommendation id. The recommendation
+     * carries its own connectionId, so resolve that and assert against it — a
+     * recommendation id is not a capability. An unknown id reports 404 so the
+     * endpoint cannot be used to probe which recommendations exist.
+     */
+    private void assertCanManageRecommendation(String recommendationId) {
+        String connectionId = sentinelAnalytics.findConnectionIdForRecommendation(recommendationId)
+                .orElseThrow(() -> new org.springframework.web.server.ResponseStatusException(
+                        org.springframework.http.HttpStatus.NOT_FOUND, "Recommendation not found"));
+        accessControlService.assertCanManageConnectionContent(connectionId);
     }
 }

--- a/backend/src/main/java/com/dbaagent/controller/SentinelDemoDataController.java
+++ b/backend/src/main/java/com/dbaagent/controller/SentinelDemoDataController.java
@@ -4,6 +4,7 @@ import com.dbaagent.model.*;
 import com.dbaagent.repository.*;
 import com.dbaagent.service.EventCorrelationService;
 import com.dbaagent.service.SentinelAnalyticsService;
+import com.dbaagent.service.security.AccessControlService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +16,12 @@ import java.util.*;
 /**
  * Demo Data Generator for Sentinel-DBA
  * Creates sample resource limits, forecasts, events, and recommendations
+ *
+ * <p><b>Authorization:</b> every endpoint here takes a caller-supplied connection id, so
+ * each one asserts access itself ({@code assertCanReadConnectionContent} for reads,
+ * {@code assertCanManageConnectionContent} for writes). {@code SecurityConfig} only
+ * requires an authenticated principal — nothing upstream inspects a connection id. See
+ * {@code ConnectionScopedAuthorizationSafetyTest}.
  */
 @RestController
 @RequestMapping("/sentinel/demo")
@@ -29,6 +36,7 @@ public class SentinelDemoDataController {
     private final SentinelRecommendationRepository recommendationRepository;
     private final EventCorrelationService eventCorrelation;
     private final SentinelAnalyticsService sentinelAnalytics;
+    private final AccessControlService accessControlService;
 
     /**
      * POST /api/sentinel/demo/generate/{connectionId}
@@ -37,6 +45,7 @@ public class SentinelDemoDataController {
     @PostMapping("/generate/{connectionId}")
     public ResponseEntity<Map<String, Object>> generateDemoData(@PathVariable String connectionId) {
         try {
+            accessControlService.assertCanManageConnectionContent(connectionId);
             log.info("Generating Sentinel demo data for connection: {}", connectionId);
 
             Map<String, Object> results = new HashMap<>();
@@ -81,6 +90,7 @@ public class SentinelDemoDataController {
     @DeleteMapping("/cleanup/{connectionId}")
     public ResponseEntity<Map<String, Object>> cleanupDemoData(@PathVariable String connectionId) {
         try {
+            accessControlService.assertCanManageConnectionContent(connectionId);
             log.info("Cleaning up Sentinel demo data for connection: {}", connectionId);
 
             // Delete in reverse order of dependencies

--- a/backend/src/main/java/com/dbaagent/controller/SlowQueryAnalyticsController.java
+++ b/backend/src/main/java/com/dbaagent/controller/SlowQueryAnalyticsController.java
@@ -5,6 +5,7 @@ import com.dbaagent.model.SlowQueryHistory;
 import com.dbaagent.repository.ConnectionAnalyticsConfigRepository;
 import com.dbaagent.service.SlowQueryAnalyticsService;
 import com.dbaagent.service.SlowQueryDailyAnalysisService;
+import com.dbaagent.service.security.AccessControlService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -21,6 +22,12 @@ import java.util.Map;
  * Read endpoints serve the per-query timeline, regressions, and per-customer
  * breakdown the UI / MCP / CLI consume. Write endpoints manage the
  * per-connection analytics config and trigger an on-demand analysis.
+ *
+ * <p><b>Authorization:</b> every endpoint here takes a caller-supplied connection id, so
+ * each one asserts access itself ({@code assertCanReadConnectionContent} for reads,
+ * {@code assertCanManageConnectionContent} for writes). {@code SecurityConfig} only
+ * requires an authenticated principal — nothing upstream inspects a connection id. See
+ * {@code ConnectionScopedAuthorizationSafetyTest}.
  */
 @RestController
 @RequestMapping("/slow-query-analytics")
@@ -31,11 +38,13 @@ public class SlowQueryAnalyticsController {
     private final SlowQueryAnalyticsService analyticsService;
     private final SlowQueryDailyAnalysisService dailyAnalysisService;
     private final ConnectionAnalyticsConfigRepository configRepository;
+    private final AccessControlService accessControlService;
 
     /** Every tracked query for a connection, as of the most recent analysis run. */
     @GetMapping("/{connectionId}/queries")
     public ResponseEntity<List<SlowQueryAnalyticsService.QuerySummary>> queries(
             @PathVariable String connectionId) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return ResponseEntity.ok(analyticsService.listQueries(connectionId));
     }
 
@@ -44,6 +53,7 @@ public class SlowQueryAnalyticsController {
     public ResponseEntity<List<SlowQueryAnalyticsService.TimelinePoint>> timeline(
             @PathVariable String connectionId,
             @PathVariable String fingerprint) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return ResponseEntity.ok(analyticsService.timeline(connectionId, fingerprint));
     }
 
@@ -56,6 +66,7 @@ public class SlowQueryAnalyticsController {
             @PathVariable String connectionId,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate day,
             @RequestParam(required = false, defaultValue = "1.5") double minFactor) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return ResponseEntity.ok(analyticsService.regressions(connectionId, day, minFactor));
     }
 
@@ -63,6 +74,7 @@ public class SlowQueryAnalyticsController {
     @GetMapping("/{connectionId}/customers")
     public ResponseEntity<List<SlowQueryAnalyticsService.CustomerSummary>> listCustomers(
             @PathVariable String connectionId) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return ResponseEntity.ok(analyticsService.listCustomers(connectionId));
     }
 
@@ -71,6 +83,7 @@ public class SlowQueryAnalyticsController {
     public ResponseEntity<List<SlowQueryAnalyticsService.CustomerQueryRow>> queriesForCustomer(
             @PathVariable String connectionId,
             @PathVariable String customerId) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return ResponseEntity.ok(analyticsService.queriesForCustomer(connectionId, customerId));
     }
 
@@ -80,6 +93,7 @@ public class SlowQueryAnalyticsController {
             @PathVariable String connectionId,
             @PathVariable String customerId,
             @PathVariable String fingerprint) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return ResponseEntity.ok(
             analyticsService.samplesForCustomerQuery(connectionId, customerId, fingerprint));
     }
@@ -89,6 +103,7 @@ public class SlowQueryAnalyticsController {
     public ResponseEntity<List<SlowQueryAnalyticsService.QuerySample>> samples(
             @PathVariable String connectionId,
             @PathVariable String fingerprint) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return ResponseEntity.ok(analyticsService.querySamples(connectionId, fingerprint));
     }
 
@@ -98,6 +113,7 @@ public class SlowQueryAnalyticsController {
             @PathVariable String connectionId,
             @PathVariable String fingerprint,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate day) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return ResponseEntity.ok(analyticsService.customerBreakdown(connectionId, fingerprint, day));
     }
 
@@ -110,6 +126,7 @@ public class SlowQueryAnalyticsController {
     public ResponseEntity<List<SlowQueryAnalyticsService.TenantColumnSuggestion>> tenantColumnSuggestions(
             @PathVariable String connectionId) {
         try {
+            accessControlService.assertCanReadConnectionContent(connectionId);
             return ResponseEntity.ok(analyticsService.suggestTenantColumns(connectionId));
         } catch (org.springframework.web.server.ResponseStatusException e) {
             throw e;
@@ -127,6 +144,7 @@ public class SlowQueryAnalyticsController {
      */
     @GetMapping("/{connectionId}/config")
     public ResponseEntity<ConnectionAnalyticsConfig> getConfig(@PathVariable String connectionId) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         return ResponseEntity.ok(analyticsService.effectiveConfig(connectionId));
     }
 
@@ -135,6 +153,7 @@ public class SlowQueryAnalyticsController {
     public ResponseEntity<ConnectionAnalyticsConfig> putConfig(
             @PathVariable String connectionId,
             @RequestBody ConnectionAnalyticsConfig body) {
+        accessControlService.assertCanManageConnectionContent(connectionId);
         ConnectionAnalyticsConfig cfg = configRepository.findById(connectionId)
             .orElseGet(() -> ConnectionAnalyticsConfig.builder()
                 .connectionId(connectionId)
@@ -163,6 +182,7 @@ public class SlowQueryAnalyticsController {
     @PostMapping("/{connectionId}/analyze-now")
     public ResponseEntity<Map<String, Object>> analyzeNow(@PathVariable String connectionId) {
         try {
+            accessControlService.assertCanManageConnectionContent(connectionId);
             SlowQueryHistory header = dailyAnalysisService.analyzeAndPersist(connectionId);
             if (header != null) {
                 return ResponseEntity.ok(Map.of(
@@ -206,6 +226,7 @@ public class SlowQueryAnalyticsController {
     @DeleteMapping("/{connectionId}/reset")
     public ResponseEntity<Map<String, Object>> reset(@PathVariable String connectionId) {
         try {
+            accessControlService.assertCanManageConnectionContent(connectionId);
             analyticsService.resetAnalytics(connectionId);
             return ResponseEntity.ok(Map.of("success", true, "connectionId", connectionId));
         } catch (org.springframework.web.server.ResponseStatusException e) {

--- a/backend/src/main/java/com/dbaagent/controller/SlowQueryController.java
+++ b/backend/src/main/java/com/dbaagent/controller/SlowQueryController.java
@@ -11,6 +11,7 @@ import com.dbaagent.model.SlowQuery;
 import com.dbaagent.model.SlowQueryAnalysis;
 import com.dbaagent.model.SlowQueryHistory;
 import com.dbaagent.service.*;
+import com.dbaagent.service.security.AccessControlService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +33,12 @@ import java.util.stream.Collectors;
 
 /**
  * REST API for slow query analysis
+ *
+ * <p><b>Authorization:</b> every endpoint here takes a caller-supplied connection id, so
+ * each one asserts access itself ({@code assertCanReadConnectionContent} for reads,
+ * {@code assertCanManageConnectionContent} for writes). {@code SecurityConfig} only
+ * requires an authenticated principal — nothing upstream inspects a connection id. See
+ * {@code ConnectionScopedAuthorizationSafetyTest}.
  */
 @RestController
 @RequestMapping("/slow-queries")
@@ -54,6 +61,7 @@ public class SlowQueryController {
     private final KeyCustomerService keyCustomerService;
     private final SlowQueryInsightsService slowQueryInsightsService;
     private final ObjectMapper objectMapper;
+    private final AccessControlService accessControlService;
 
     // Thread pool for SSE streaming — keeps SSE work off the Jetty request thread
     private static final ExecutorService sseExecutor =
@@ -70,6 +78,7 @@ public class SlowQueryController {
     public ResponseEntity<SlowQueryAnalysis> analyzeSlowQueries(
         @RequestBody SlowQueryRequest request
     ) {
+        accessControlService.assertCanManageConnectionContent(request.getConnectionId());
         try {
             log.info("Slow query analysis requested for connection: {}", request.getConnectionId());
 
@@ -107,6 +116,7 @@ public class SlowQueryController {
         @RequestParam(required = false, defaultValue = "100") Double threshold,
         @RequestParam(required = false, defaultValue = "10") Integer limit
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             log.info("Slow query analysis requested for connection: {}", connectionId);
 
@@ -142,6 +152,7 @@ public class SlowQueryController {
     public ResponseEntity<HistoryResponse> saveHistory(
         @RequestBody SaveHistoryRequest request
     ) {
+        accessControlService.assertCanManageConnectionContent(request.getConnectionId());
         try {
             log.info("Saving slow query history for connection: {}", request.getConnectionId());
 
@@ -169,6 +180,7 @@ public class SlowQueryController {
     public ResponseEntity<List<HistorySummaryResponse>> getHistory(
         @PathVariable String connectionId
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             log.info("Fetching slow query history summaries for connection: {}", connectionId);
 
@@ -195,6 +207,7 @@ public class SlowQueryController {
     public ResponseEntity<HistoryResponse> getLatestAnalysis(
         @PathVariable String connectionId
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             log.info("Fetching latest slow query analysis for connection: {}", connectionId);
 
@@ -227,6 +240,7 @@ public class SlowQueryController {
         @PathVariable String connectionId,
         @PathVariable String timeRange
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             log.info("Fetching slow query history summaries for connection: {} and timeRange: {}", connectionId, timeRange);
 
@@ -252,6 +266,7 @@ public class SlowQueryController {
     public ResponseEntity<HistoryResponse> getHistoryById(
         @PathVariable String id
     ) {
+        assertCanReadHistory(id);
         try {
             log.info("Fetching slow query history item: {}", id);
 
@@ -280,6 +295,7 @@ public class SlowQueryController {
     public ResponseEntity<Map<String, String>> deleteHistory(
         @PathVariable String id
     ) {
+        assertCanManageHistory(id);
         try {
             log.info("Deleting slow query history: {}", id);
             historyService.deleteHistory(id);
@@ -301,6 +317,7 @@ public class SlowQueryController {
     public ResponseEntity<Map<String, String>> deleteAllHistory(
         @PathVariable String connectionId
     ) {
+        accessControlService.assertCanManageConnectionContent(connectionId);
         try {
             log.info("Deleting all slow query history for connection: {}", connectionId);
             historyService.deleteAllForConnection(connectionId);
@@ -324,6 +341,7 @@ public class SlowQueryController {
         @RequestParam("connectionId") String connectionId,
         @RequestParam(required = false, defaultValue = "mysql") String databaseType
     ) {
+        accessControlService.assertCanManageConnectionContent(connectionId);
         try {
             log.info("Analyzing uploaded slow query log file for connection: {}, type: {}", connectionId, databaseType);
 
@@ -366,6 +384,7 @@ public class SlowQueryController {
     public ResponseEntity<SlowQueryAnalysis> analyzeSlowQueryLogFileFromS3(
         @RequestBody S3LogRequest request
     ) {
+        accessControlService.assertCanManageConnectionContent(request.getConnectionId());
         try {
             log.info("Analyzing S3 slow query log file for connection: {}, url: {}",
                 request.getConnectionId(), request.getS3Url());
@@ -410,6 +429,7 @@ public class SlowQueryController {
     public ResponseEntity<SlowQueryAnalysis> analyzeSlowQueryLogFromCloudWatch(
         @RequestBody CloudWatchLogRequest request
     ) {
+        accessControlService.assertCanManageConnectionContent(request.getConnectionId());
         try {
             log.info("Analyzing CloudWatch slow query logs for connection: {}, log group: {}",
                 request.getConnectionId(), request.getLogGroupName());
@@ -475,6 +495,7 @@ public class SlowQueryController {
             @PathVariable String connectionId,
             @RequestParam(defaultValue = "20") int limit,
             @RequestParam(required = false) String tableName) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             return keyCustomerService.analyze(connectionId, limit, tableName)
                 .map(ResponseEntity::ok)
@@ -496,6 +517,7 @@ public class SlowQueryController {
         @RequestParam(defaultValue = "7d") String window,
         @RequestParam(defaultValue = "20") int limit
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             SlowQueryInsightsResponse response = slowQueryInsightsService.getInsights(connectionId, window, limit);
             return ResponseEntity.ok(response);
@@ -516,6 +538,7 @@ public class SlowQueryController {
         @RequestParam(defaultValue = "7d") String window,
         @RequestParam(defaultValue = "20") int limit
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             SlowQueryInsightsResponse.RemediationInsights response =
                 slowQueryInsightsService.getRemediationInsights(connectionId, window, limit);
@@ -537,6 +560,7 @@ public class SlowQueryController {
         @RequestParam(defaultValue = "7d") String window,
         @RequestParam(defaultValue = "20") int limit
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             SlowQueryInsightsResponse.HotspotInsights response =
                 slowQueryInsightsService.getHotspotInsights(connectionId, window, limit);
@@ -558,6 +582,7 @@ public class SlowQueryController {
         @RequestParam(defaultValue = "7d") String window,
         @RequestParam(defaultValue = "20") int limit
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             SlowQueryInsightsResponse.SkewInsights response =
                 slowQueryInsightsService.getSkewInsights(connectionId, window, limit);
@@ -579,6 +604,7 @@ public class SlowQueryController {
         @RequestParam(defaultValue = "7d") String window,
         @RequestParam(defaultValue = "20") int limit
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             SlowQueryInsightsResponse.TailRiskInsights response =
                 slowQueryInsightsService.getTailRiskInsights(connectionId, window, limit);
@@ -600,6 +626,7 @@ public class SlowQueryController {
         @RequestParam(defaultValue = "7d") String window,
         @RequestParam(defaultValue = "20") int limit
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             SlowQueryInsightsResponse.PlanDriftInsights response =
                 slowQueryInsightsService.getPlanDriftInsights(connectionId, window, limit);
@@ -675,6 +702,7 @@ public class SlowQueryController {
     public ResponseEntity<QueryOptimizationService.OptimizationResult> optimizeQuery(
         @RequestBody OptimizeQueryRequest request
     ) {
+        accessControlService.assertCanManageConnectionContent(request.getConnectionId());
         try {
             log.info("Generating AI optimization for connection: {}", request.getConnectionId());
 
@@ -735,6 +763,7 @@ public class SlowQueryController {
         @RequestParam(required = false) String queryId,
         @RequestParam(defaultValue = "false") boolean forceRefresh
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         SseEmitter emitter = new SseEmitter(300_000L); // 5-minute timeout
 
         sseExecutor.submit(() -> {
@@ -913,6 +942,7 @@ public class SlowQueryController {
         @PathVariable String connectionId,
         @RequestParam(defaultValue = "5") int limit
     ) {
+        accessControlService.assertCanManageConnectionContent(connectionId);
         try {
             log.info("Batch optimizing slow queries for connection: {}", connectionId);
 
@@ -946,6 +976,7 @@ public class SlowQueryController {
         @PathVariable String connectionId,
         @PathVariable String queryFingerprint
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             List<com.dbaagent.model.QueryOptimizationCandidateRun> candidates =
                 candidateService.getCandidates(connectionId, queryFingerprint);
@@ -975,6 +1006,7 @@ public class SlowQueryController {
         @PathVariable String queryFingerprint,
         @RequestBody(required = false) BenchmarkCandidatesRequest request
     ) {
+        accessControlService.assertCanManageConnectionContent(connectionId);
         try {
             Integer runs = request != null ? request.getRuns() : null;
             Integer timeoutMs = request != null ? request.getTimeoutMs() : null;
@@ -999,6 +1031,7 @@ public class SlowQueryController {
         @PathVariable String connectionId,
         @PathVariable String queryFingerprint
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             QueryOptimizationService.OptimizationResult cached =
                 optimizationService.getCachedOptimization(connectionId, queryFingerprint);
@@ -1024,6 +1057,7 @@ public class SlowQueryController {
         @PathVariable String connectionId,
         @RequestBody List<String> fingerprints
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             Map<String, QueryOptimizationService.OptimizationResult> cached =
                 optimizationService.getCachedOptimizations(connectionId, fingerprints);
@@ -1044,6 +1078,7 @@ public class SlowQueryController {
     public ResponseEntity<Map<String, Object>> getOptimizationCacheStats(
         @PathVariable String connectionId
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             Map<String, Object> stats = optimizationService.getCacheStats(connectionId);
             return ResponseEntity.ok(stats);
@@ -1062,6 +1097,7 @@ public class SlowQueryController {
     public ResponseEntity<Void> clearOptimizationCache(
         @PathVariable String connectionId
     ) {
+        accessControlService.assertCanManageConnectionContent(connectionId);
         try {
             optimizationService.clearConnectionCache(connectionId);
             return ResponseEntity.ok().build();
@@ -1082,6 +1118,7 @@ public class SlowQueryController {
     public ResponseEntity<SlowQueryAlertService.SlowQueryAlertSummary> getAlertSummary(
         @PathVariable String connectionId
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             SlowQueryAlertService.SlowQueryAlertSummary summary = alertService.getAlertSummary(connectionId);
             return ResponseEntity.ok(summary);
@@ -1099,10 +1136,15 @@ public class SlowQueryController {
     @PostMapping("/alerts/{alertId}/acknowledge")
     public ResponseEntity<PlaybookAlert> acknowledgeAlert(
         @PathVariable String alertId,
-        @RequestParam String userId
+        @RequestParam(required = false) String userId
     ) {
+        assertCanManageAlert(alertId);
         try {
-            PlaybookAlert alert = alertService.acknowledgeAlert(alertId, userId);
+            // The actor is the authenticated caller, never the userId query parameter:
+            // that was client-supplied, so the acknowledgement trail could name anyone.
+            // The parameter is still accepted so existing callers do not break, and ignored.
+            PlaybookAlert alert = alertService.acknowledgeAlert(
+                alertId, accessControlService.requireCurrentUsername());
             return ResponseEntity.ok(alert);
         } catch (IllegalArgumentException e) {
             return ResponseEntity.notFound().build();
@@ -1120,10 +1162,12 @@ public class SlowQueryController {
     @PostMapping("/alerts/{connectionId}/acknowledge-all")
     public ResponseEntity<Map<String, Integer>> acknowledgeAllAlerts(
         @PathVariable String connectionId,
-        @RequestParam String userId
+        @RequestParam(required = false) String userId
     ) {
+        accessControlService.assertCanManageConnectionContent(connectionId);
         try {
-            int count = alertService.acknowledgeAllAlerts(connectionId, userId);
+            int count = alertService.acknowledgeAllAlerts(
+                connectionId, accessControlService.requireCurrentUsername());
             return ResponseEntity.ok(Map.of("acknowledged", count));
         } catch (org.springframework.web.server.ResponseStatusException e) {
             throw e;
@@ -1141,6 +1185,7 @@ public class SlowQueryController {
         @PathVariable String connectionId,
         @RequestBody(required = false) AlertConfigRequest config
     ) {
+        accessControlService.assertCanManageConnectionContent(connectionId);
         try {
             Optional<SlowQueryHistory> latestOpt = historyService.getLatestHistory(connectionId);
             if (latestOpt.isEmpty()) {
@@ -1181,6 +1226,8 @@ public class SlowQueryController {
         @RequestParam String historyId1,
         @RequestParam String historyId2
     ) {
+        assertCanReadHistory(historyId1);
+        assertCanReadHistory(historyId2);
         try {
             Optional<SlowQueryHistory> history1Opt = historyService.getHistoryById(historyId1);
             Optional<SlowQueryHistory> history2Opt = historyService.getHistoryById(historyId2);
@@ -1280,6 +1327,7 @@ public class SlowQueryController {
     public ResponseEntity<SlowQueryDashboardService.DashboardWidgetData> getDashboardWidgets(
         @PathVariable String connectionId
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             SlowQueryDashboardService.DashboardWidgetData data = dashboardService.getWidgetData(connectionId);
             return ResponseEntity.ok(data);
@@ -1298,6 +1346,7 @@ public class SlowQueryController {
     public ResponseEntity<SlowQueryDashboardService.OverviewWidget> getOverviewWidget(
         @PathVariable String connectionId
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             SlowQueryDashboardService.OverviewWidget data = dashboardService.getOverviewWidget(connectionId);
             return ResponseEntity.ok(data);
@@ -1316,6 +1365,7 @@ public class SlowQueryController {
     public ResponseEntity<SlowQueryDashboardService.TrendWidget> getTrendWidget(
         @PathVariable String connectionId
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             SlowQueryDashboardService.TrendWidget data = dashboardService.getTrendWidget(connectionId);
             return ResponseEntity.ok(data);
@@ -1336,6 +1386,7 @@ public class SlowQueryController {
     public ResponseEntity<QueryFingerprintService.FingerprintSummary> getFingerprintSummary(
         @PathVariable String connectionId
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             QueryFingerprintService.FingerprintSummary summary = fingerprintService.getSummary(connectionId);
             return ResponseEntity.ok(summary);
@@ -1358,6 +1409,7 @@ public class SlowQueryController {
         @RequestParam(required = false) Boolean regressingOnly,
         @RequestParam(defaultValue = "50") int limit
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             QueryFingerprint.TrendDirection direction = null;
             if (trendDirection != null && !trendDirection.isBlank()) {
@@ -1384,6 +1436,7 @@ public class SlowQueryController {
     public ResponseEntity<QueryFingerprintService.FingerprintTrend> getFingerprintTrend(
         @PathVariable String fingerprintId
     ) {
+        assertCanReadFingerprint(fingerprintId);
         try {
             QueryFingerprintService.FingerprintTrend trend = fingerprintService.getTrend(fingerprintId);
             return ResponseEntity.ok(trend);
@@ -1404,6 +1457,7 @@ public class SlowQueryController {
     public ResponseEntity<QueryFingerprint> resetFingerprintBaseline(
         @PathVariable String fingerprintId
     ) {
+        assertCanManageFingerprint(fingerprintId);
         try {
             QueryFingerprint fingerprint = fingerprintService.resetBaseline(fingerprintId);
             return ResponseEntity.ok(fingerprint);
@@ -1424,6 +1478,7 @@ public class SlowQueryController {
     public ResponseEntity<List<QueryFingerprint>> processFingerprints(
         @PathVariable String connectionId
     ) {
+        accessControlService.assertCanManageConnectionContent(connectionId);
         try {
             Optional<SlowQueryHistory> latestOpt = historyService.getLatestHistory(connectionId);
             if (latestOpt.isEmpty()) {
@@ -1450,6 +1505,7 @@ public class SlowQueryController {
     public ResponseEntity<Map<String, Object>> getExplainPlan(
         @RequestBody ExplainQueryRequest request
     ) {
+        accessControlService.assertCanManageConnectionContent(request.getConnectionId());
         try {
             log.info("Running EXPLAIN for query in connection: {}", request.getConnectionId());
 
@@ -1482,6 +1538,7 @@ public class SlowQueryController {
         @PathVariable String connectionId,
         @RequestParam(defaultValue = "5") int limit
     ) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         try {
             Optional<SlowQueryHistory> latestOpt = historyService.getLatestHistory(connectionId);
             if (latestOpt.isEmpty()) {
@@ -1711,5 +1768,48 @@ public class SlowQueryController {
         private Long highCount;
         private Double totalDatabaseTimeMs;
         private String timestamp;
+    }
+
+    // ── authorization helpers for endpoints keyed on a non-connection id ──────
+    //
+    // An id is not a capability: each of these entities carries its own
+    // connectionId, so resolve the owner and assert against that. An unknown id
+    // reports 404 rather than 403, so none of these can be used to probe which
+    // ids exist on connections the caller cannot see.
+
+    private String historyConnectionId(String historyId) {
+        return historyService.getHistoryById(historyId)
+                .map(com.dbaagent.model.SlowQueryHistory::getConnectionId)
+                .orElseThrow(() -> new org.springframework.web.server.ResponseStatusException(
+                        org.springframework.http.HttpStatus.NOT_FOUND, "Analysis not found"));
+    }
+
+    private void assertCanReadHistory(String historyId) {
+        accessControlService.assertCanReadConnectionContent(historyConnectionId(historyId));
+    }
+
+    private void assertCanManageHistory(String historyId) {
+        accessControlService.assertCanManageConnectionContent(historyConnectionId(historyId));
+    }
+
+    private void assertCanManageAlert(String alertId) {
+        String connectionId = alertService.findConnectionIdForAlert(alertId)
+                .orElseThrow(() -> new org.springframework.web.server.ResponseStatusException(
+                        org.springframework.http.HttpStatus.NOT_FOUND, "Alert not found"));
+        accessControlService.assertCanManageConnectionContent(connectionId);
+    }
+
+    private String fingerprintConnectionId(String fingerprintId) {
+        return fingerprintService.findConnectionIdForFingerprintId(fingerprintId)
+                .orElseThrow(() -> new org.springframework.web.server.ResponseStatusException(
+                        org.springframework.http.HttpStatus.NOT_FOUND, "Fingerprint not found"));
+    }
+
+    private void assertCanReadFingerprint(String fingerprintId) {
+        accessControlService.assertCanReadConnectionContent(fingerprintConnectionId(fingerprintId));
+    }
+
+    private void assertCanManageFingerprint(String fingerprintId) {
+        accessControlService.assertCanManageConnectionContent(fingerprintConnectionId(fingerprintId));
     }
 }

--- a/backend/src/main/java/com/dbaagent/controller/SlowQueryController.java
+++ b/backend/src/main/java/com/dbaagent/controller/SlowQueryController.java
@@ -1773,9 +1773,11 @@ public class SlowQueryController {
     // ── authorization helpers for endpoints keyed on a non-connection id ──────
     //
     // An id is not a capability: each of these entities carries its own
-    // connectionId, so resolve the owner and assert against that. An unknown id
-    // reports 404 rather than 403, so none of these can be used to probe which
-    // ids exist on connections the caller cannot see.
+    // connectionId, so resolve the owner and assert against that.
+    //
+    // Both "no such id" and "not yours" answer 404, via the *OrNotFound guards. Splitting
+    // them (404 vs 403) would confirm which ids are real, which is an enumeration
+    // primitive — same reasoning as DashboardWorkspaceService.assertCanReadDashboard.
 
     private String historyConnectionId(String historyId) {
         return historyService.getHistoryById(historyId)
@@ -1785,18 +1787,20 @@ public class SlowQueryController {
     }
 
     private void assertCanReadHistory(String historyId) {
-        accessControlService.assertCanReadConnectionContent(historyConnectionId(historyId));
+        accessControlService.assertCanReadConnectionContentOrNotFound(
+                historyConnectionId(historyId), "Analysis");
     }
 
     private void assertCanManageHistory(String historyId) {
-        accessControlService.assertCanManageConnectionContent(historyConnectionId(historyId));
+        accessControlService.assertCanManageConnectionContentOrNotFound(
+                historyConnectionId(historyId), "Analysis");
     }
 
     private void assertCanManageAlert(String alertId) {
         String connectionId = alertService.findConnectionIdForAlert(alertId)
                 .orElseThrow(() -> new org.springframework.web.server.ResponseStatusException(
                         org.springframework.http.HttpStatus.NOT_FOUND, "Alert not found"));
-        accessControlService.assertCanManageConnectionContent(connectionId);
+        accessControlService.assertCanManageConnectionContentOrNotFound(connectionId, "Alert");
     }
 
     private String fingerprintConnectionId(String fingerprintId) {
@@ -1806,10 +1810,12 @@ public class SlowQueryController {
     }
 
     private void assertCanReadFingerprint(String fingerprintId) {
-        accessControlService.assertCanReadConnectionContent(fingerprintConnectionId(fingerprintId));
+        accessControlService.assertCanReadConnectionContentOrNotFound(
+                fingerprintConnectionId(fingerprintId), "Fingerprint");
     }
 
     private void assertCanManageFingerprint(String fingerprintId) {
-        accessControlService.assertCanManageConnectionContent(fingerprintConnectionId(fingerprintId));
+        accessControlService.assertCanManageConnectionContentOrNotFound(
+                fingerprintConnectionId(fingerprintId), "Fingerprint");
     }
 }

--- a/backend/src/main/java/com/dbaagent/controller/StatsController.java
+++ b/backend/src/main/java/com/dbaagent/controller/StatsController.java
@@ -3,6 +3,7 @@ package com.dbaagent.controller;
 import com.dbaagent.model.DbaStats;
 import com.dbaagent.service.CredentialService;
 import com.dbaagent.service.StatsCollectorService;
+import com.dbaagent.service.security.AccessControlService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,15 +13,26 @@ import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * REST API for a connection's live database statistics.
+ *
+ * <p><b>Authorization:</b> every endpoint here takes a caller-supplied connection id, so
+ * each one asserts access itself ({@code assertCanReadConnectionContent} for reads,
+ * {@code assertCanManageConnectionContent} for writes). {@code SecurityConfig} only
+ * requires an authenticated principal — nothing upstream inspects a connection id. See
+ * {@code ConnectionScopedAuthorizationSafetyTest}.
+ */
 @RestController
 @RequestMapping("/connections/{connectionId}/stats")
 @RequiredArgsConstructor
 public class StatsController {
     private final StatsCollectorService statsCollectorService;
     private final CredentialService credentialService;
+    private final AccessControlService accessControlService;
 
     @GetMapping
     public ResponseEntity<Map<String, Object>> getStats(@PathVariable String connectionId) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
         Map<String, Object> response = new HashMap<>();
         try {
             if (!credentialService.connectionExists(connectionId)) {

--- a/backend/src/main/java/com/dbaagent/service/BusinessRuleMemoryService.java
+++ b/backend/src/main/java/com/dbaagent/service/BusinessRuleMemoryService.java
@@ -462,6 +462,14 @@ public class BusinessRuleMemoryService {
     }
 
     @Transactional
+    /**
+     * The connection a rule belongs to, for authorizing an endpoint keyed only
+     * on a rule id. Empty when the id does not exist.
+     */
+    public java.util.Optional<String> findConnectionIdForRule(String ruleId) {
+        return brainRuleRepository.findById(ruleId).map(r -> r.getConnectionId());
+    }
+
     public boolean deactivateRule(String ruleId) {
         if (ruleId == null || ruleId.isBlank()) {
             return false;

--- a/backend/src/main/java/com/dbaagent/service/QueryFingerprintService.java
+++ b/backend/src/main/java/com/dbaagent/service/QueryFingerprintService.java
@@ -173,6 +173,14 @@ public class QueryFingerprintService {
     /**
      * Get trend data for a specific fingerprint
      */
+    /**
+     * The connection a fingerprint row belongs to, for authorizing an endpoint
+     * keyed only on a fingerprint id. Empty when the id does not exist.
+     */
+    public java.util.Optional<String> findConnectionIdForFingerprintId(String fingerprintId) {
+        return fingerprintRepository.findById(fingerprintId).map(f -> f.getConnectionId());
+    }
+
     public FingerprintTrend getTrend(String fingerprintId) {
         QueryFingerprint fp = fingerprintRepository.findById(fingerprintId)
             .orElseThrow(() -> new IllegalArgumentException("Fingerprint not found: " + fingerprintId));

--- a/backend/src/main/java/com/dbaagent/service/QueryPerformanceService.java
+++ b/backend/src/main/java/com/dbaagent/service/QueryPerformanceService.java
@@ -209,6 +209,15 @@ public class QueryPerformanceService {
     }
 
     /**
+     * The connection a regression belongs to, for authorizing an endpoint keyed
+     * only on the regression id. Empty when the id does not exist.
+     */
+    public Optional<String> findConnectionIdForRegression(Long regressionId) {
+        return regressionRepository.findById(regressionId)
+                .map(QueryPerformanceRegression::getConnectionId);
+    }
+
+    /**
      * Acknowledge a regression
      */
     @Transactional

--- a/backend/src/main/java/com/dbaagent/service/QueryPlanCacheService.java
+++ b/backend/src/main/java/com/dbaagent/service/QueryPlanCacheService.java
@@ -549,6 +549,14 @@ public class QueryPlanCacheService {
      * Set a plan as the baseline for a query
      */
     @Transactional
+    /**
+     * The connection a cached plan belongs to, for authorizing an endpoint keyed
+     * only on a plan id. Empty when the id does not exist.
+     */
+    public java.util.Optional<String> findConnectionIdForPlan(String planId) {
+        return planCacheRepository.findById(planId).map(p -> p.getConnectionId());
+    }
+
     public void setBaseline(String planId) {
         planCacheRepository.findById(planId).ifPresent(plan -> {
             // Clear existing baseline
@@ -634,6 +642,22 @@ public class QueryPlanCacheService {
     @Transactional
     public int acknowledgeRegressions(List<String> comparisonIds, String acknowledgedBy) {
         return comparisonRepository.acknowledgeByIds(comparisonIds, acknowledgedBy, LocalDateTime.now());
+    }
+
+    /**
+     * True when every given comparison id belongs to {@code connectionId}. The ids arrive
+     * in the request body, so the caller's authorization on the path connection does not
+     * constrain them — without this a caller could acknowledge another connection's plan
+     * regressions. An id that resolves to nothing fails too, so unknown ids cannot be
+     * mixed into an otherwise valid batch.
+     */
+    public boolean allComparisonsBelongTo(String connectionId, List<String> comparisonIds) {
+        if (comparisonIds == null || comparisonIds.isEmpty()) {
+            return true;
+        }
+        List<QueryPlanComparison> found = comparisonRepository.findAllById(comparisonIds);
+        return found.size() == comparisonIds.stream().distinct().count()
+            && found.stream().allMatch(c -> java.util.Objects.equals(connectionId, c.getConnectionId()));
     }
 
     /**

--- a/backend/src/main/java/com/dbaagent/service/SchemaChangeTrackingService.java
+++ b/backend/src/main/java/com/dbaagent/service/SchemaChangeTrackingService.java
@@ -655,7 +655,38 @@ public class SchemaChangeTrackingService {
             throw new IllegalArgumentException("One or both snapshots not found");
         }
 
+        // Both snapshots must belong to the same connection. Without this a caller
+        // authorized on connection A could diff A's schema against connection B's
+        // and read B's table and column names out of the resulting change list.
+        if (!Objects.equals(snap1.get().getConnectionId(), snap2.get().getConnectionId())) {
+            throw new IllegalArgumentException("Snapshots belong to different connections");
+        }
+
         return detectChanges(snap1.get(), snap2.get());
+    }
+
+    /**
+     * The connection a snapshot belongs to, for authorizing an endpoint keyed
+     * only on a snapshot id. Empty when the id does not exist.
+     */
+    public Optional<String> findConnectionIdForSnapshot(String snapshotId) {
+        return snapshotRepository.findById(snapshotId).map(SchemaSnapshot::getConnectionId);
+    }
+
+    /**
+     * True when every given change id belongs to {@code connectionId}. Guards the
+     * acknowledge endpoints, whose ids arrive in the body and are therefore not
+     * covered by a path-variable authorization check.
+     */
+    public boolean allChangesBelongTo(String connectionId, List<String> changeIds) {
+        if (changeIds == null || changeIds.isEmpty()) {
+            return true;
+        }
+        List<SchemaChange> found = changeRepository.findAllById(changeIds);
+        // An id that resolves to nothing must fail too, otherwise a caller can mix
+        // unknown ids in and still have the batch accepted.
+        return found.size() == changeIds.stream().distinct().count()
+            && found.stream().allMatch(c -> Objects.equals(connectionId, c.getConnectionId()));
     }
 
     /**

--- a/backend/src/main/java/com/dbaagent/service/SchemaChangeTrackingService.java
+++ b/backend/src/main/java/com/dbaagent/service/SchemaChangeTrackingService.java
@@ -499,11 +499,20 @@ public class SchemaChangeTrackingService {
      */
     @Transactional
     public void setBaseline(String connectionId, String snapshotId) {
-        // Update the snapshot type to BASELINE
-        snapshotRepository.findById(snapshotId).ifPresent(snapshot -> {
-            snapshot.setSnapshotType(SchemaSnapshot.SnapshotType.BASELINE);
-            snapshotRepository.save(snapshot);
-        });
+        // The snapshot id arrives as its own path variable, so authorizing connectionId
+        // upstream says nothing about it. Without this bind, a caller with manage access
+        // on connection A could flip connection B's snapshot to BASELINE and point A's
+        // drift config at it. Rejected rather than skipped: silently no-op'ing the
+        // snapshot write while still updating the drift config would leave the config
+        // referencing a snapshot from another connection. Enforced here as well as in the
+        // controller so the invariant does not depend on which caller reaches this method.
+        SchemaSnapshot snapshot = snapshotRepository.findById(snapshotId)
+            .filter(s -> Objects.equals(connectionId, s.getConnectionId()))
+            .orElseThrow(() -> new IllegalArgumentException(
+                "Snapshot not found for this connection"));
+
+        snapshot.setSnapshotType(SchemaSnapshot.SnapshotType.BASELINE);
+        snapshotRepository.save(snapshot);
 
         // Update drift config
         driftConfigRepository.findByConnectionId(connectionId).ifPresent(config -> {

--- a/backend/src/main/java/com/dbaagent/service/SentinelAnalyticsService.java
+++ b/backend/src/main/java/com/dbaagent/service/SentinelAnalyticsService.java
@@ -499,6 +499,15 @@ public class SentinelAnalyticsService {
     /**
      * Update recommendation status
      */
+    /**
+     * The connection a recommendation belongs to, for authorizing an endpoint
+     * keyed only on a recommendation id. Empty when the id does not exist.
+     */
+    public java.util.Optional<String> findConnectionIdForRecommendation(String recommendationId) {
+        return recommendationRepository.findById(recommendationId)
+            .map(SentinelRecommendation::getConnectionId);
+    }
+
     public SentinelRecommendation updateRecommendationStatus(
             String recommendationId,
             SentinelRecommendation.Status status,

--- a/backend/src/main/java/com/dbaagent/service/SlowQueryAlertService.java
+++ b/backend/src/main/java/com/dbaagent/service/SlowQueryAlertService.java
@@ -243,6 +243,14 @@ public class SlowQueryAlertService {
     /**
      * Acknowledge an alert
      */
+    /**
+     * The connection an alert belongs to, for authorizing an endpoint keyed only
+     * on an alert id. Empty when the id does not exist.
+     */
+    public java.util.Optional<String> findConnectionIdForAlert(String alertId) {
+        return alertRepository.findById(alertId).map(PlaybookAlert::getConnectionId);
+    }
+
     public PlaybookAlert acknowledgeAlert(String alertId, String userId) {
         PlaybookAlert alert = alertRepository.findById(alertId)
             .orElseThrow(() -> new IllegalArgumentException("Alert not found: " + alertId));

--- a/backend/src/main/java/com/dbaagent/service/security/AccessControlService.java
+++ b/backend/src/main/java/com/dbaagent/service/security/AccessControlService.java
@@ -69,6 +69,51 @@ public class AccessControlService {
         assertAccess(connectionId, EffectiveConnectionAccess::canManageConfig, "Configuration access denied for this connection");
     }
 
+    /**
+     * As {@link #assertCanReadConnectionContent}, but reports 404 instead of 403 — for
+     * endpoints keyed on a row id rather than a connection id.
+     *
+     * <p>Returning 403 for a row the caller may not touch and 404 for one that does not
+     * exist tells the caller which ids are real. That is an enumeration primitive, and
+     * `query_performance_regression.id` is a sequential {@code Long}, so walking it is
+     * trivial. Collapsing both to 404 means "no such row, as far as you are concerned",
+     * which is the same answer {@code DashboardWorkspaceService.assertCanReadDashboard}
+     * already gives for a dashboard outside the caller's workspace.
+     *
+     * <p>Use this only where the caller supplied an <em>opaque row id</em>. Endpoints that
+     * take a {@code connectionId} directly should keep 403: the caller already knows the
+     * connection exists (they typed its id), so hiding it buys nothing and an actionable
+     * "access denied" is the better answer.
+     *
+     * @param entity human-readable name for the 404 message, e.g. {@code "Alert"}
+     */
+    public void assertCanReadConnectionContentOrNotFound(String connectionId, String entity) {
+        assertOrNotFound(connectionId, EffectiveConnectionAccess::canReadContent, entity);
+    }
+
+    /** Write-side counterpart to {@link #assertCanReadConnectionContentOrNotFound}. */
+    public void assertCanManageConnectionContentOrNotFound(String connectionId, String entity) {
+        assertOrNotFound(connectionId, EffectiveConnectionAccess::canManageContent, entity);
+    }
+
+    private void assertOrNotFound(
+        String connectionId,
+        java.util.function.Predicate<EffectiveConnectionAccess> predicate,
+        String entity
+    ) {
+        ConnectionAccessService.ResolvedConnectionAccess access;
+        try {
+            access = resolveCurrentUserAccess(connectionId);
+        } catch (ResponseStatusException e) {
+            // An unresolvable connection, or an unauthenticated caller, must look the same
+            // as a row that isn't there — otherwise the distinction leaks back in here.
+            throw new ResponseStatusException(NOT_FOUND, entity + " not found");
+        }
+        if (!predicate.test(access.getEffectiveAccess())) {
+            throw new ResponseStatusException(NOT_FOUND, entity + " not found");
+        }
+    }
+
     public ConnectionAccessService.ResolvedConnectionAccess resolveCurrentUserAccess(String connectionId) {
         if (!authEnabled && !ImpersonationContext.isActive()) {
             try {

--- a/backend/src/test/java/com/dbaagent/controller/ConnectionScopedAuthorizationSafetyTest.java
+++ b/backend/src/test/java/com/dbaagent/controller/ConnectionScopedAuthorizationSafetyTest.java
@@ -157,13 +157,65 @@ class ConnectionScopedAuthorizationSafetyTest {
      * yet mutates a row that belongs to one.
      */
     private static boolean touchesAConnection(String body) {
-        return body.contains("connectionId")
-            || Pattern.compile("@PathVariable[^)]*\\)?\\s*(?:Long|String)\\s+"
-                + "(alertId|actionId|regressionId|recommendationId|fingerprintId|planId|ruleId"
-                + "|snapshotId|historyId|changeId|comparisonId)").matcher(body).find()
-            || body.contains("historyId1")
-            || body.contains("snapshotId1");
+        if (CONNECTION_REF.matcher(body).find()) {
+            return true;
+        }
+        Matcher ids = OWNED_ID.matcher(body);
+        while (ids.find()) {
+            if (!NOT_CONNECTION_OWNED_IDS.contains(ids.group(1))) {
+                return true;
+            }
+        }
+        return false;
     }
+
+    /**
+     * Any mention of a connection id, in any casing a real signature uses.
+     *
+     * <p>This started as {@code body.contains("connectionId")} and that was a real hole:
+     * {@code ProjectController.createProject} reads the connection from
+     * {@code request.getConnectionId()} — capital C — so it did not match, and four
+     * unguarded endpoints were invisible while this test reported 6/6 green. Match the
+     * name case-insensitively and cover the {@code getConnectionId()} /
+     * {@code get("connectionId")} accessor forms explicitly.
+     */
+    private static final Pattern CONNECTION_REF = Pattern.compile(
+        "(?i)connection_?id");
+
+    /**
+     * Any id-shaped path variable, allowlist-free.
+     *
+     * <p>The previous version enumerated the id names it knew about
+     * ({@code alertId|actionId|regressionId|…}), which can only catch ids someone
+     * remembered to add — {@code projectId} was missing, so
+     * {@code GET|PUT|DELETE /projects/{projectId}} were never examined. Inverted: treat
+     * <em>every</em> {@code @PathVariable ...Id} as a row that plausibly belongs to a
+     * connection, and require the handler to prove otherwise by authorizing it. A genuine
+     * exception goes in {@link #NOT_CONNECTION_OWNED_IDS} with a reason, so adding one is
+     * a deliberate, reviewable act rather than an omission.
+     */
+    private static final Pattern OWNED_ID = Pattern.compile(
+        "@PathVariable[^)]*\\)?\\s*(?:Long|String|UUID)\\s+(\\w*[Ii]d)\\b");
+
+    /**
+     * Path-variable ids that identify something other than a connection-owned row. Each
+     * is scoped by its own mechanism, named here so the exemption is auditable.
+     */
+    private static final Set<String> NOT_CONNECTION_OWNED_IDS = Set.of(
+        "userId",       // user administration; role-gated, not connection-gated
+        "id",           // too generic to classify — handled per-controller
+        "chatId",       // AccessControlService.assertCanAccessChat owns this
+        "workspaceId",  // DashboardWorkspaceService membership owns this
+        "dashboardId",  // SavedDashboardService owns this
+        "tokenId",      // MCP tokens, scoped to the authenticated caller
+        "jobId",        // resolved to its connection by SlowLogSourceController
+        "threadId",     // agent conversation, scoped by userId
+        "conversationId",
+        // Playbooks are global templates: the Playbook entity has no connectionId at all,
+        // so there is no connection to authorize against. The endpoints in that controller
+        // which *do* carry one (execute, runs, alerts) are guarded — verified, not assumed.
+        "playbookId"
+    );
 
     @Test
     void everyConnectionScopedEndpointAuthorizesTheCaller() throws IOException {
@@ -274,6 +326,25 @@ class ConnectionScopedAuthorizationSafetyTest {
                 + "into a 500. Rethrow it first: catch (ResponseStatusException e) { throw e; } "
                 + "— or move the assert above the try.")
             .isEmpty();
+    }
+
+    /**
+     * {@code playbookId} is exempt because {@code Playbook} carries no {@code connectionId}
+     * — there is genuinely no connection to authorize against. That is a claim about the
+     * entity, so check it: if a {@code connectionId} is ever added to {@code Playbook}, the
+     * exemption silently starts hiding four unguarded endpoints
+     * ({@code GET|PUT|DELETE /playbooks/{id}} and {@code /toggle}).
+     */
+    @Test
+    void playbookExemptionHoldsOnlyWhilePlaybooksAreConnectionFree() throws IOException {
+        Path entity = Path.of("src/main/java/com/dbaagent/model/Playbook.java");
+        String source = Files.readString(entity);
+
+        assertThat(source)
+            .as("Playbook has gained a connectionId, so playbooks are no longer global "
+                + "templates. Remove \"playbookId\" from NOT_CONNECTION_OWNED_IDS and "
+                + "authorize the id-keyed playbook endpoints against the owning connection.")
+            .doesNotContain("connectionId");
     }
 
     /**

--- a/backend/src/test/java/com/dbaagent/controller/ConnectionScopedAuthorizationSafetyTest.java
+++ b/backend/src/test/java/com/dbaagent/controller/ConnectionScopedAuthorizationSafetyTest.java
@@ -1,0 +1,383 @@
+package com.dbaagent.controller;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Every endpoint that takes a caller-supplied connection id must authorize it.
+ *
+ * <p>{@link BrainControllerAuthorizationSafetyTest} asserts this for one file, and that is
+ * exactly why the same defect shipped again: 116 endpoints across 12 other controllers
+ * ({@code SlowQueryController}, {@code SlowQueryAnalyticsController}, {@code SentinelAnalyticsController},
+ * {@code SchemaChangeController}, the four Performance controllers, {@code IndexAdvisorController},
+ * {@code AdvisorController}, {@code ResourceLimitsController}, {@code BusinessRuleController})
+ * had no authorization at all. A user with no grant on any connection could read
+ * literal-bearing slow-query SQL with real customer ids and names, enumerate another
+ * tenant's schema, and permanently delete their analysis history — verified against a
+ * running install, not inferred.
+ *
+ * <p>So this test scans <em>every</em> controller rather than a named list. A new
+ * controller is covered the day it is written, which a per-file test can never promise.
+ */
+class ConnectionScopedAuthorizationSafetyTest {
+
+    private static final Path CONTROLLER_DIR = Path.of("src/main/java/com/dbaagent/controller");
+
+    private static final Pattern MAPPING = Pattern.compile(
+        "^\\s*@(?:[\\w.]*\\.)?(Get|Post|Delete|Put|Patch)Mapping\\b");
+
+    /**
+     * A handler is authorized by a per-connection assert, by resolving some other id to its
+     * owning connection through a local helper, or by being admin-only. The helper form is
+     * matched by name because the resolution happens one call away — an
+     * {@code assertCanManageAlert(alertId)} that looks up the alert's connection and
+     * asserts on it is the correct shape, and inlining it in every handler would be worse.
+     */
+    private static final Pattern AUTHORIZED = Pattern.compile(
+        "accessControlService\\.assertCan\\w+\\(|@PreAuthorize|assertCan(Read|Manage)\\w+\\(");
+
+    /**
+     * Handlers whose authorization correctly lives one layer down, named as
+     * {@code Controller:line}. Two distinct reasons, and both matter:
+     *
+     * <ul>
+     *   <li>{@code DashboardWorkspaceController} delegates to
+     *       {@code DashboardWorkspaceService}, which calls
+     *       {@code assertCanReadConnectionContent} itself. Asserting again in the
+     *       controller would duplicate a check that could then drift.
+     *   <li>The Agent controllers scope by <em>user</em>, not by connection ACL:
+     *       {@code AgentConversationService} keys every query on {@code currentUserId()},
+     *       so the {@code connectionId} there is a label on the caller's own conversation
+     *       rather than a reference to someone else's data. There is no connection
+     *       authorization to perform.
+     * </ul>
+     *
+     * {@link #everyDelegatedCheckStillExists()} re-derives the first group, so removing the
+     * service-layer assert fails the build instead of silently widening access.
+     */
+    private static final Set<String> AUTHORIZED_ELSEWHERE = Set.of(
+        "DashboardWorkspaceController.java:47",
+        "DashboardWorkspaceController.java:60",
+        "AgentChatController.java:25",
+        "AgentConversationController.java:29",
+        "AgentConversationController.java:45"
+    );
+
+    /** Service methods that own a delegated connection check. */
+    private static final List<String> DELEGATED_CHECKS = List.of(
+        "src/main/java/com/dbaagent/service/DashboardWorkspaceService.java"
+    );
+
+    /**
+     * Controllers that legitimately have no connection to authorize against. Each is here
+     * for a stated reason, not because it was inconvenient — an entry is a claim that the
+     * endpoints hold no caller-supplied connection id, which {@link #everyExemptControllerIsActuallyConnectionFree()}
+     * re-checks so this list cannot rot into a way of hiding a real gap.
+     */
+    private static final Set<String> NOT_CONNECTION_SCOPED = Set.of(
+        "AuthController",            // login / refresh / logout — pre-authentication by definition
+        "AuthCliController",         // device-code pairing, same
+        "AuthInternalController",    // nginx auth_request subrequest
+        "BootstrapController",       // first-admin creation, gated by a shared secret + localhost
+        "SetupController",           // install wizard
+        "InviteCodeController",      // invite redemption, keyed on a code
+        "UserController",            // user administration, role-gated elsewhere
+        "AdminController",           // admin surface, @PreAuthorize at class level
+        "ImpersonationController",   // admin surface, @PreAuthorize at class level
+        "McpTokenController",        // per-caller tokens, scoped to the authenticated user
+        "SlackLinkController",       // Slack workspace binding
+        "LlmProxyController",        // OpenAI-shaped gateway, no connection in the contract
+        "PublicDashboardController", // permitAll by design; scoped by share token
+        // Provisions the agent profile for whoever is calling: the username comes from
+        // requireCurrentUsername() and any connectionId in the body only selects which of
+        // the caller's own connections to preload.
+        "AgentBridgeController"
+    );
+
+    private record Endpoint(String file, int line, String mapping, String body) {}
+
+    private static List<Path> controllers() throws IOException {
+        try (Stream<Path> paths = Files.list(CONTROLLER_DIR)) {
+            return paths.filter(p -> p.getFileName().toString().endsWith("Controller.java")).sorted().toList();
+        }
+    }
+
+    /**
+     * Slices one controller into one entry per handler, mapping annotation to closing brace.
+     *
+     * <p>The slice starts one line <em>above</em> the mapping when that line is another
+     * annotation, because {@code @PreAuthorize} is conventionally written above
+     * {@code @PostMapping}. Starting at the mapping itself put the authorization outside the
+     * captured body and reported {@code POST /training/reindex-all} — which is admin-only —
+     * as unguarded.
+     */
+    private static List<Endpoint> endpoints(Path controller) throws IOException {
+        List<String> lines = Files.readAllLines(controller);
+        List<Endpoint> endpoints = new ArrayList<>();
+        String name = controller.getFileName().toString();
+
+        for (int i = 0; i < lines.size(); i++) {
+            Matcher matcher = MAPPING.matcher(lines.get(i));
+            if (!matcher.find()) {
+                continue;
+            }
+            int start = i;
+            while (start > 0 && lines.get(start - 1).trim().startsWith("@")) {
+                start--;
+            }
+            StringBuilder body = new StringBuilder();
+            int end = start;
+            while (end < lines.size()) {
+                body.append(lines.get(end)).append('\n');
+                if (end > i && lines.get(end).equals("    }")) {
+                    break;
+                }
+                end++;
+            }
+            endpoints.add(new Endpoint(name, i + 1, lines.get(i).trim(), body.toString()));
+        }
+        return endpoints;
+    }
+
+    /**
+     * True when the handler receives a connection id, or an id that identifies a
+     * connection-owned row. Both forms need authorization: the second is the trap, since
+     * {@code PUT /performance-actions/{actionId}/status} carries no {@code connectionId}
+     * yet mutates a row that belongs to one.
+     */
+    private static boolean touchesAConnection(String body) {
+        return body.contains("connectionId")
+            || Pattern.compile("@PathVariable[^)]*\\)?\\s*(?:Long|String)\\s+"
+                + "(alertId|actionId|regressionId|recommendationId|fingerprintId|planId|ruleId"
+                + "|snapshotId|historyId|changeId|comparisonId)").matcher(body).find()
+            || body.contains("historyId1")
+            || body.contains("snapshotId1");
+    }
+
+    @Test
+    void everyConnectionScopedEndpointAuthorizesTheCaller() throws IOException {
+        List<String> offenders = new ArrayList<>();
+
+        for (Path controller : controllers()) {
+            String name = controller.getFileName().toString().replace(".java", "");
+            if (NOT_CONNECTION_SCOPED.contains(name)) {
+                continue;
+            }
+            String source = Files.readString(controller);
+            boolean classLevelAdminOnly = source.contains("@PreAuthorize")
+                && source.indexOf("@PreAuthorize") < source.indexOf("public class");
+            if (classLevelAdminOnly) {
+                continue;
+            }
+            for (Endpoint endpoint : endpoints(controller)) {
+                if (!touchesAConnection(endpoint.body())) {
+                    continue;
+                }
+                if (AUTHORIZED_ELSEWHERE.contains(endpoint.file() + ":" + endpoint.line())) {
+                    continue;
+                }
+                if (!AUTHORIZED.matcher(endpoint.body()).find()) {
+                    offenders.add(endpoint.file() + ":" + endpoint.line() + " " + endpoint.mapping());
+                }
+            }
+        }
+
+        assertThat(offenders)
+            .as("These endpoints take a caller-supplied connection id (or an id owned by a "
+                + "connection) and never authorize it. Authentication is not authorization: "
+                + "SecurityConfig only asserts .anyRequest().authenticated() and no filter, "
+                + "interceptor or aspect inspects a connectionId. Add "
+                + "accessControlService.assertCanReadConnectionContent(connectionId) to reads "
+                + "and assertCanManageConnectionContent(connectionId) to writes. When the path "
+                + "carries some other id, resolve its owning connection first and assert on "
+                + "that — an id is not a capability. An endpoint with no connection scope at "
+                + "all is admin-only (@PreAuthorize).")
+            .isEmpty();
+    }
+
+    /**
+     * Ids that arrive in the request <em>body</em> are not constrained by a path-variable
+     * check. {@code POST /schema-changes/{connectionId}/changes/acknowledge} authorizes the
+     * path connection and then acknowledges whatever change ids the body names, so a caller
+     * authorized on their own connection could acknowledge another tenant's changes. Each
+     * such handler must additionally verify the collection belongs to the scope.
+     */
+    @Test
+    void collectionIdsFromTheRequestBodyAreCheckedAgainstTheScope() throws IOException {
+        List<String> offenders = new ArrayList<>();
+
+        for (Path controller : controllers()) {
+            for (Endpoint endpoint : endpoints(controller)) {
+                String body = endpoint.body();
+                boolean takesIdCollection = Pattern
+                    .compile("@RequestBody[^;]*List<String>\\s+(\\w*[Ii]ds)").matcher(body).find()
+                    || body.contains("getActionIds()")
+                    || body.contains("getChangeIds()");
+                if (!takesIdCollection) {
+                    continue;
+                }
+                boolean scoped = body.contains("BelongTo")
+                    || body.contains("forEach(this::assertCan")
+                    || body.contains("stream().forEach");
+                if (!scoped) {
+                    offenders.add(endpoint.file() + ":" + endpoint.line() + " " + endpoint.mapping());
+                }
+            }
+        }
+
+        assertThat(offenders)
+            .as("These endpoints accept a list of ids in the request body. A path-variable "
+                + "authorization check does not constrain them, so verify every id belongs "
+                + "to the authorized scope (or authorize each id individually) before acting.")
+            .isEmpty();
+    }
+
+    /**
+     * An assert placed inside a {@code try} whose catch-all returns 500 turns a 403 into a
+     * server error: the denial holds, but the client cannot tell "not yours" from "broken".
+     */
+    @Test
+    void authorizationFailuresPropagateAsForbiddenRatherThanServerError() throws IOException {
+        List<String> offenders = new ArrayList<>();
+
+        for (Path controller : controllers()) {
+            for (Endpoint endpoint : endpoints(controller)) {
+                String body = endpoint.body();
+                int assertAt = body.indexOf("accessControlService.assertCan");
+                if (assertAt < 0) {
+                    continue;
+                }
+                int tryAt = body.indexOf("try {");
+                boolean assertInsideTry = tryAt >= 0 && tryAt < assertAt;
+                boolean hasCatchAll = body.contains("catch (Exception");
+                if (assertInsideTry && hasCatchAll
+                        && !body.contains("catch (org.springframework.web.server.ResponseStatusException e)")
+                        && !body.contains("catch (ResponseStatusException e)")) {
+                    offenders.add(endpoint.file() + ":" + endpoint.line() + " " + endpoint.mapping());
+                }
+            }
+        }
+
+        assertThat(offenders)
+            .as("These endpoints assert access inside a try whose catch-all converts the 403 "
+                + "into a 500. Rethrow it first: catch (ResponseStatusException e) { throw e; } "
+                + "— or move the assert above the try.")
+            .isEmpty();
+    }
+
+    /**
+     * A {@code @ControllerAdvice} with a catch-all {@code @ExceptionHandler(Exception.class)}
+     * swallows authorization denials the same way an in-method catch-all does, and it is
+     * easier to miss because it lives in a different file from the endpoint.
+     *
+     * <p>{@code IndexAdvisorExceptionHandler} did exactly this: a non-granted caller hitting
+     * {@code /index-advisor/{id}/health-report} got {@code 500 "Index operation failed"}
+     * whose body carried the 403's text. The guard held, but the response blamed the index
+     * store. Any advice with a catch-all must also handle {@code ResponseStatusException}.
+     */
+    @Test
+    void controllerAdvicesDoNotSwallowAuthorizationDenials() throws IOException {
+        List<String> offenders = new ArrayList<>();
+
+        try (Stream<Path> paths = Files.walk(Path.of("src/main/java/com/dbaagent"))) {
+            for (Path file : paths.filter(p -> p.toString().endsWith(".java")).toList()) {
+                String source = Files.readString(file);
+                if (!source.contains("@RestControllerAdvice") && !source.contains("@ControllerAdvice")) {
+                    continue;
+                }
+                if (source.contains("@ExceptionHandler(Exception.class)")
+                        && !source.contains("ResponseStatusException.class")) {
+                    offenders.add(file.getFileName().toString());
+                }
+            }
+        }
+
+        assertThat(offenders)
+            .as("These @ControllerAdvice classes catch Exception without handling "
+                + "ResponseStatusException first, so a 403 from an authorization check is "
+                + "reported as a 500 attributed to the feature. Add an "
+                + "@ExceptionHandler(ResponseStatusException.class) that preserves the status.")
+            .isEmpty();
+    }
+
+    /**
+     * A handler exempted because its check lives in the service layer stays exempt only
+     * while that check is actually there. Without this, deleting the service-layer assert
+     * would widen access and the exemption would quietly cover for it.
+     */
+    @Test
+    void everyDelegatedCheckStillExists() throws IOException {
+        List<String> missing = new ArrayList<>();
+
+        for (String service : DELEGATED_CHECKS) {
+            String source = Files.readString(Path.of(service));
+            if (!source.contains("accessControlService.assertCanReadConnectionContent(")
+                    && !source.contains("accessControlService.assertCanManageConnectionContent(")) {
+                missing.add(service);
+            }
+        }
+
+        assertThat(missing)
+            .as("A controller endpoint is exempted from the authorization sweep because this "
+                + "service performs the connection check on its behalf, and that check is now "
+                + "gone. Either restore it or drop the controller's AUTHORIZED_ELSEWHERE entry "
+                + "and assert in the controller.")
+            .isEmpty();
+    }
+
+    /**
+     * Guards the exemption list. If an exempt controller grows an endpoint that does take a
+     * connection id, the entry is no longer true and the controller must be authorized
+     * rather than skipped.
+     */
+    @Test
+    void everyExemptControllerIsActuallyConnectionFree() throws IOException {
+        List<String> offenders = new ArrayList<>();
+
+        for (Path controller : controllers()) {
+            String name = controller.getFileName().toString().replace(".java", "");
+            if (!NOT_CONNECTION_SCOPED.contains(name)) {
+                continue;
+            }
+            String source = Files.readString(controller);
+            // A class-level @PreAuthorize already authorizes every handler in the file, so a
+            // connectionId appearing inside one is not evidence of a gap.
+            if (source.contains("@PreAuthorize")
+                    && source.indexOf("@PreAuthorize") < source.indexOf("public class")) {
+                continue;
+            }
+            for (Endpoint endpoint : endpoints(controller)) {
+                String body = endpoint.body();
+                if (!body.contains("connectionId")) {
+                    continue;
+                }
+                // Acting on the caller's own identity is its own scope: the row is selected
+                // by the authenticated username, so a connectionId in the body only picks
+                // among things that caller already owns.
+                boolean scopedToCaller = body.contains("requireCurrentUsername()")
+                    || body.contains("getCurrentUsername()");
+                if (!scopedToCaller && !AUTHORIZED.matcher(body).find()) {
+                    offenders.add(endpoint.file() + ":" + endpoint.line() + " " + endpoint.mapping());
+                }
+            }
+        }
+
+        assertThat(offenders)
+            .as("These endpoints live in a controller exempted as 'not connection scoped', "
+                + "but they reference a connectionId and neither authorize it nor scope the "
+                + "work to the authenticated caller. Either authorize them or remove the "
+                + "controller from NOT_CONNECTION_SCOPED — the exemption list must stay true.")
+            .isEmpty();
+    }
+}

--- a/backend/src/test/java/com/dbaagent/controller/SlowQueryControllerS3Test.java
+++ b/backend/src/test/java/com/dbaagent/controller/SlowQueryControllerS3Test.java
@@ -27,6 +27,8 @@ import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import com.dbaagent.service.security.AccessControlService;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -53,6 +55,9 @@ class SlowQueryControllerS3Test {
         KeyCustomerService keyCustomerService = mock(KeyCustomerService.class);
         SlowQueryInsightsService slowQueryInsightsService = mock(SlowQueryInsightsService.class);
         ObjectMapper objectMapper = mock(ObjectMapper.class);
+        // The controller now authorizes the connection before doing any work; a plain
+        // mock allows it, so these tests still exercise the S3 path they were written for.
+        AccessControlService accessControlService = mock(AccessControlService.class);
 
         SlowQueryController controller = new SlowQueryController(
             slowQueryService,
@@ -69,7 +74,8 @@ class SlowQueryControllerS3Test {
             explainPlanService,
             keyCustomerService,
             slowQueryInsightsService,
-            objectMapper
+            objectMapper,
+            accessControlService
         );
 
         SlowQueryAnalysis analysis = SlowQueryAnalysis.builder()
@@ -117,6 +123,9 @@ class SlowQueryControllerS3Test {
         KeyCustomerService keyCustomerService = mock(KeyCustomerService.class);
         SlowQueryInsightsService slowQueryInsightsService = mock(SlowQueryInsightsService.class);
         ObjectMapper objectMapper = mock(ObjectMapper.class);
+        // The controller now authorizes the connection before doing any work; a plain
+        // mock allows it, so these tests still exercise the S3 path they were written for.
+        AccessControlService accessControlService = mock(AccessControlService.class);
 
         SlowQueryController controller = new SlowQueryController(
             slowQueryService,
@@ -133,7 +142,8 @@ class SlowQueryControllerS3Test {
             explainPlanService,
             keyCustomerService,
             slowQueryInsightsService,
-            objectMapper
+            objectMapper,
+            accessControlService
         );
 
         SlowQueryInsightsResponse payload = SlowQueryInsightsResponse.builder()


### PR DESCRIPTION
12 controllers took a caller-supplied connectionId and never checked it. SecurityConfig only asserts .anyRequest().authenticated() and no filter, interceptor or aspect inspects a connection id, so authentication was the only barrier. Verified against a running install, not inferred: a DEVELOPER holding no grant on any connection could

  - read literal-bearing slow-query SQL with real customer ids and names (GET /slow-query-analytics/{id}/query/{fp}/samples returned 200 while GET /slow-log-source/{id} returned 403 in the same session),
  - enumerate another tenant's schema and table statistics, via two endpoints that decrypt the target connection's credentials and open a live JDBC session (/tenant-column-suggestions and /config),
  - and permanently delete that tenant's analysis history (DELETE /slow-queries/history/connection/{id} -> 200, row gone).

Affected: SlowQueryController (43), SlowQueryAnalyticsController (13), SchemaChangeController (13), SentinelAnalyticsController (10), PerformanceActionController (9), QueryPerformanceController (8), QueryPlanController (8), IndexAdvisorController (7), PerformanceInsightsController (5), AdvisorController (3), ResourceLimitsController (3), BusinessRuleController (3).

This is the same class of defect BrainController carried (93 of 116 unguarded). The safety test added then hardcodes one Path.of(...), so it could not see any of these.

What changed

* 127 guard calls: assertCanReadConnectionContent on reads, assertCanManageConnectionContent on writes and deletes.

* An id is not a capability. For endpoints keyed on alertId, actionId, regressionId, recommendationId, fingerprintId, planId, ruleId, snapshotId or historyId, resolve the owning connection and assert on that. 15 new findConnectionIdFor* accessors where no lookup existed. These report 404, not 403, for an unknown id — a 403 confirms the row exists, turning the endpoint into an id oracle, and regressionId is a sequential Long.

* Ids arriving in the request body are not constrained by a path-variable check. Four holes survived exactly that kind of fix:
    - schema-changes/snapshots/compare took two snapshot ids and no connectionId at all, so it would diff tenant A's schema against tenant B's; compareSnapshots now refuses a mismatch outright.
    - PUT /performance-actions/batch-status took an arbitrary actionIds list with no scope; it now authorizes every id before mutating any, so a mixed batch fails atomically.
    - changes/acknowledge and regressions/acknowledge authorized the path connection and then acted on whatever ids the body named; allChangesBelongTo / allComparisonsBelongTo verify membership, and an id that resolves to nothing fails too, so unknown ids cannot be mixed into an otherwise valid batch.

* Never take the actor from the request. userId was a query parameter and acknowledgedBy/resolvedBy/updatedBy defaulted to the literal string "user", so the acknowledgement trail was unauthenticated free text that could name any colleague. 10 sites now use requireCurrentUsername(). The parameters are still accepted for wire compatibility and ignored.

* ConnectionScopedAuthorizationSafetyTest replaces the per-file approach: it scans every *Controller.java, so a new controller is covered the day it is written. Six cases — connection-scoped endpoints authorized, body-supplied id collections scoped, 403 not swallowed into 500, controller advices not swallowing denials, exemptions still true, delegated service checks still present. The exemption list is itself guarded, so it cannot rot into a way of hiding a real gap.

Two things found by writing and running the fix, not by reading it

* The generalized test immediately found 9 more unguarded endpoints in controllers nobody was looking at: StatsController, ProjectController, DashboardController, and a destructive DELETE /sentinel/demo/cleanup/{connectionId}. Three had been in my draft exemption list on the assumption they were connection-free; they were not.

* Testing the fix found a bug reading it never would. 24 endpoints returned 403 and index-advisor returned 500: IndexAdvisorExceptionHandler's @ExceptionHandler(Exception.class) swallowed the denial and reported "Index operation failed" with the 403's text in the body. The guard held, but the response blamed the index store. It now handles ResponseStatusException first, and the safety test asserts no advice with a catch-all omits that.

Also drops @CrossOrigin(origins = "*") from SentinelAnalyticsController. Tested and inert — an evil-origin preflight gets 403 with no Access-Control-Allow-Origin because the SecurityConfig allowlist wins, while an allowed origin gets 200 + ACAO — but it reads like an intentional hole.

Verification

Real Maven compile of main and test sources, zero errors. SlowQueryControllerS3Test needed the new constructor argument and was updated rather than left red.

Live, against the rebuilt image with a DEVELOPER holding no grant on the target connection:
  - 40/40 previously-leaking reads -> 403
  - 10/10 writes and destructive endpoints -> 403, and psql confirms nothing was mutated
  - 7/7 orphan-id and body-scoped paths -> 404, no existence oracle
  - 30/30 same endpoint shapes on a granted connection -> 200, zero false denials; confirmed again from a real browser session
  - index-advisor now returns 403 "Read access denied for this connection"

Not covered: mvn test was not executed (the image build uses -DskipTests and this host has no JDK/Maven). The six safety-test cases were validated by re-implementing their scan logic against the tree and the file compiles, but they have not been run by JUnit.