### PR TITLE
ci(desktop): fix unsigned macOS builds and Linux Electron sandbox

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -46,21 +46,42 @@ jobs:
       - name: Self-test the SSH tunnel transport
         # Runs a real SSH server in-process, so it needs a display-free Electron.
         # xvfb is only required on Linux; the other runners have a window server.
+        #
+        # ELECTRON_DISABLE_SANDBOX: GitHub-hosted Linux runners ship Electron's
+        # chrome-sandbox without root:4755, so Chromium aborts with SIGTRAP
+        # before the test starts ("SUID sandbox helper binary … is not
+        # configured correctly"). Verified on desktop-v1.0.0. Sandbox is
+        # irrelevant for this headless selftest.
         working-directory: desktop
+        env:
+          ELECTRON_DISABLE_SANDBOX: '1'
         run: ${{ matrix.os == 'ubuntu-latest' && 'xvfb-run --auto-servernum npm run selftest:tunnel' || 'npm run selftest:tunnel' }}
         shell: bash
 
       - name: Build installers
         working-directory: desktop
         env:
-          # Signing is skipped when these are unset; electron-builder warns and
-          # produces unsigned artifacts rather than failing the build.
-          CSC_LINK: ${{ secrets.DESKTOP_CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.DESKTOP_CSC_KEY_PASSWORD }}
+          # Keep secrets in DESKTOP_* names first. Passing an empty CSC_LINK from
+          # an unset repository secret still counts as "set" for electron-builder,
+          # which then tries to open it as a file and fails macOS with
+          # "…/desktop not a file" (observed on desktop-v1.0.0). Only export the
+          # real CSC_* / Apple vars when a signing secret is actually configured.
+          DESKTOP_CSC_LINK: ${{ secrets.DESKTOP_CSC_LINK }}
+          DESKTOP_CSC_KEY_PASSWORD: ${{ secrets.DESKTOP_CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: npx electron-builder ${{ matrix.target }} --publish never
+        run: |
+          set -euo pipefail
+          if [ -n "${DESKTOP_CSC_LINK:-}" ]; then
+            export CSC_LINK="$DESKTOP_CSC_LINK"
+            export CSC_KEY_PASSWORD="${DESKTOP_CSC_KEY_PASSWORD:-}"
+          else
+            export CSC_IDENTITY_AUTO_DISCOVERY=false
+            echo "No DESKTOP_CSC_LINK secret — building unsigned installers."
+          fi
+          npx electron-builder ${{ matrix.target }} --publish never
+        shell: bash
 
       - uses: actions/upload-artifact@v4
         with:

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -91,6 +91,13 @@ environment variables to enable it:
 - macOS: `CSC_LINK`, `CSC_KEY_PASSWORD`, plus `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID` for notarisation.
 - Windows: `CSC_LINK`, `CSC_KEY_PASSWORD` (or an Azure Trusted Signing config).
 
+CI (`.github/workflows/desktop-release.yml`) builds **unsigned** installers unless
+the repository secret `DESKTOP_CSC_LINK` is set. An empty `CSC_LINK` still counts
+as configured for electron-builder and fails the macOS job — the workflow only
+exports `CSC_*` when that secret is non-empty, and otherwise sets
+`CSC_IDENTITY_AUTO_DISCOVERY=false`. Linux selftests set `ELECTRON_DISABLE_SANDBOX=1`
+because hosted runners lack a correctly permissioned `chrome-sandbox`.
+
 **Auto-update** is opt-in. `package.json` sets `"publish": null`, so no update
 feed is baked in and the updater no-ops. To enable it, either set a `publish`
 target (GitHub Releases, S3, generic) before building, or point


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the `desktop-v1.0.0` CI failures that blocked publishing DeepSQL Desktop installers. After this lands, re-tag / re-run `desktop-release` so `/download` has assets.

## Root causes (from failed run)

| Platform | Failure |
|----------|---------|
| Linux | Tunnel selftest: Electron aborts — `chrome-sandbox` lacks root:4755 on hosted runners |
| macOS | `electron-builder` treated empty `CSC_LINK` (unset secret → empty string) as a file path → `…/desktop not a file` |
| Windows | Cancelled after sibling failures; never reached builder |

## Changes

- Selftest: `ELECTRON_DISABLE_SANDBOX=1` (sandbox irrelevant for headless CI)
- Build: only export `CSC_*` when `DESKTOP_CSC_LINK` is non-empty; otherwise `CSC_IDENTITY_AUTO_DISCOVERY=false` for unsigned installers
- `desktop/README.md`: document the CI behavior

## After merge

```bash
# Option A — new patch tag from main
git checkout main && git pull
git tag -a desktop-v1.0.1 -m "DeepSQL Desktop v1.0.1"
git push origin desktop-v1.0.1

# Option B — re-run workflow_dispatch on main, then attach assets manually
```

Then confirm the `desktop-v*` GitHub Release has dmg/zip/exe/AppImage/deb and `/download` lists them.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: desktop-release succeeds on macOS + Linux + Windows
- [ ] Release assets appear; `/download` no longer shows empty state

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ce91e70-c67b-48c6-84b3-05bb9d06231a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ce91e70-c67b-48c6-84b3-05bb9d06231a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

