### PR TITLE
fix(desktop): unblock Linux deb/rpm CI and Windows selftest hang

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -58,6 +58,12 @@ jobs:
         run: ${{ matrix.os == 'ubuntu-latest' && 'xvfb-run --auto-servernum npm run selftest:tunnel' || 'npm run selftest:tunnel' }}
         shell: bash
 
+      - name: Install Linux packaging tools
+        if: matrix.os == 'ubuntu-latest'
+        # electron-builder's rpm target shells out to rpmbuild; ubuntu-latest
+        # runners do not ship it by default.
+        run: sudo apt-get update && sudo apt-get install -y rpm
+
       - name: Build installers
         working-directory: desktop
         env:

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,6 +1,6 @@
 # DeepSQL Desktop
 
-**Version 1.0.0** — first public Desktop cut (ships with DeepSQL product `v1.3.0`).
+**Version 1.0.2** — first public Desktop cut (ships with DeepSQL product `v1.3.0`).
 
 A cross-platform desktop client for a self-hosted DeepSQL server. It connects to
 the VM (or bare metal) running the DeepSQL stack either **directly over TLS** or

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,9 +1,15 @@
 {
   "name": "deepsql-desktop",
   "productName": "DeepSQL",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "private": true,
   "description": "DeepSQL desktop client \u2014 connect to a self-hosted DeepSQL VM over TLS or an SSH tunnel.",
+  "homepage": "https://github.com/DeepSQLAI/deepsql",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/DeepSQLAI/deepsql.git",
+    "directory": "desktop"
+  },
   "license": "Apache-2.0",
   "author": {
     "name": "DeepSQL",

--- a/desktop/scripts/tunnel-selftest.js
+++ b/desktop/scripts/tunnel-selftest.js
@@ -224,13 +224,23 @@ app.whenReady().then(async () => {
   check('missing key file is reported clearly', keyError?.code === 'key-unreadable', keyError?.code);
 
   // ── 5. Teardown ────────────────────────────────────────────────────────
-  sshServer.close();
-  upstream.close();
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  await closeServer(sshServer);
+  await closeServer(upstream);
+  try {
+    // Windows can still have Electron file handles open on userData when we
+    // rmSync synchronously; retry briefly so CI doesn't hang after the checks
+    // pass (observed as ENOTEMPTY + no exit on windows-latest).
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+  } catch (err) {
+    process.stderr.write(`WARN: temp cleanup: ${err.message}\n`);
+  }
 
   const failed = results.filter((r) => !r.ok).length;
   process.stdout.write(`\n${results.length - failed}/${results.length} checks passed\n`);
   app.exit(failed === 0 ? 0 : 1);
+}).catch((err) => {
+  process.stderr.write(`${err?.stack || err}\n`);
+  app.exit(1);
 });
 
 function makeProfile({ keyPath, sshPort, upstreamPort }) {
@@ -288,6 +298,16 @@ function listen(server, port, host) {
   return new Promise((resolve, reject) => {
     server.once('error', reject);
     server.listen(port, host, () => resolve());
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolve) => {
+    if (!server || !server.listening) {
+      resolve();
+      return;
+    }
+    server.close(() => resolve());
   });
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`desktop-v1.0.1` workflow run [33196314686](https://github.com/DeepSQLAI/deepsql/actions/runs/33196314686):

| Job | Result | Root cause |
|-----|--------|------------|
| **Linux** | Failed | `.deb` build: `Please specify project homepage` (electron-builder FpmTarget) |
| **Windows** | Cancelled after ~6h | `selftest:tunnel` passed but process never exited — `fs.rmSync` threw `ENOTEMPTY` on temp dir before `app.exit()` |
| **macOS** | Success | — |
| **Release attach** | Skipped | Blocked by Linux failure |

## Fix

1. **`desktop/package.json`** — add `homepage` + `repository` (required for `.deb`/`.rpm` metadata); bump to **1.0.2**
2. **`desktop/scripts/tunnel-selftest.js`** — await server close, retry temp cleanup, `.catch()` → `app.exit(1)` so CI never hangs
3. **`.github/workflows/desktop-release.yml`** — `apt-get install rpm` on ubuntu-latest (needed for `.rpm` target)

## Verification

Local (Linux runner equivalent):

- `npm test` — 4/4 pass
- `xvfb-run npm run selftest:tunnel` — 14/14 checks, clean exit
- `electron-builder --linux` — AppImage + deb (amd64/arm64) + rpm built for v1.0.2

## After merge

Push tag to trigger installers:

```bash
git tag -a desktop-v1.0.2 -m "DeepSQL Desktop v1.0.2"
git push origin desktop-v1.0.2
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ce91e70-c67b-48c6-84b3-05bb9d06231a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ce91e70-c67b-48c6-84b3-05bb9d06231a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

