### PR TITLE
Feat/preflight migration review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,13 +439,20 @@ report in chat, but it never computes it.
   (`varchar(50)` → `varchar(100)`, which Postgres does NOT rewrite) from a genuine
   type change (which does). It reports the conservative rewrite verdict for both
   rather than risk a false SAFE.
-- **Lock strength is ranked by an explicit ordering list, not `max(mode)`.**
-  Postgres lock mode names sort alphabetically in a way that has nothing to do with
-  strength — `"ShareLock".compareTo("AccessExclusiveLock") > 0`, so a naive
-  string-max would report a statement that also takes `ShareLock` as the stronger
-  of the two, when `AccessExclusiveLock` is in fact the most exclusive mode
-  Postgres has. Any code that needs "the worst lock this statement takes" must
-  rank against Postgres's real lock hierarchy, not compare mode names.
+- **The verification test ranks lock strength by an explicit ordering list, not
+  `max(mode)` — the provider itself does not rank at all.**
+  `PostgresMigrationRiskProvider` never computes a lock mode; each rule hardcodes
+  the one it asserts (e.g. `addForeignKey` always reports `ShareRowExclusiveLock`).
+  The ranking lives only in `PostgresMigrationRiskVerificationTest`
+  (`LOCK_STRENGTH` + `strongestLock()`), which has to pick the strongest lock out
+  of however many rows a query against the real `pg_locks` returns. It needs the
+  ordering because Postgres lock mode names sort alphabetically in a way that has
+  nothing to do with strength — `"ShareLock".compareTo("AccessExclusiveLock") > 0`,
+  so a naive string-max would call `ShareLock` the stronger of the two, when
+  `AccessExclusiveLock` is in fact the most exclusive mode Postgres has. Any future
+  code that needs "the worst lock a query is holding" from `pg_locks` must rank
+  against Postgres's real lock hierarchy, not compare mode names — but that need
+  has not yet reached production code, only this test.
 - **Authorization is asserted in the service, before parsing, credential
   decryption, or session opening** (`MigrationRiskService.analyze` calls
   `accessControlService.assertCanReadConnectionContent` first). The controller is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,6 +387,77 @@ than an `assertCan*` call — the case `Endpoint Authorization Rules` describes 
 - Usage belongs to `QueryActorContextHolder` first and the security principal second, so
   under **View as** the spend is attributed to the target user, not the admin.
 
+## Pre-flight Migration Review
+
+`POST /migrations/analyze` (`MigrationRiskController` → `MigrationRiskService` →
+`DatabaseDialect.migrationRisk()`) classifies a DDL statement's blast radius —
+verdict, locks (per table), whether it rewrites the table, a coarse duration bucket,
+and a safer alternative — before anyone runs it. It is **deterministic by
+convention**, same as `IndexAdvisorService` and `ExplainPlanService`: the rule table
+and the target table's real size (`pg_class.reltuples` / `pg_total_relation_size`)
+decide the verdict; nothing here asks an LLM to judge risk. An LLM may narrate the
+report in chat, but it never computes it.
+
+- **The Postgres rule table is engine-verified, not hand-derived.** A Testcontainers
+  suite runs each rule's DDL against a real `postgres:18`, reading
+  `pg_relation_filenode` before/after to detect an actual rewrite and `pg_locks` to
+  read the actual lock mode taken — not PostgreSQL documentation summarized from
+  memory. If a rule disagrees with what the engine measured, the rule is wrong,
+  full stop.
+- **`DEFAULT now()` does NOT force a table rewrite — this is measured, not a bug.**
+  `now()` is STABLE (it returns the same value for the whole transaction), and
+  Postgres 11+ adds a column with a STABLE or constant default as a metadata-only
+  operation. Only a VOLATILE default (`random()`, `gen_random_uuid()`,
+  `clock_timestamp()`, `uuid_generate_v4()`) forces a full rewrite, because a
+  volatile function must be evaluated per row. Wrote this down after getting it
+  wrong from memory twice before the Testcontainers run corrected it.
+- **`ADD FOREIGN KEY` takes `ShareRowExclusiveLock` on the referenced table too**,
+  not just the table being altered — confirmed live: `ALTER TABLE child ADD
+  CONSTRAINT fk FOREIGN KEY (t_id) REFERENCES t(id)` returns a `locks` array with
+  two entries, `child` and `t`. This is why `MigrationRiskReport.locks` is a
+  per-table array rather than a single lock on the altered table — a statement can
+  block writes on a table it never names, and that is the finding an operator is
+  least likely to expect from reading the SQL alone.
+- **The JSqlParser 5.2 shim exists because the library cannot parse the forms this
+  tool exists to recommend.** JSqlParser has no grammar for `NOT VALID` or `CREATE
+  INDEX CONCURRENTLY` — both fail to parse outright, which would make the analyzer
+  unable to evaluate the very migration pattern (`ADD CONSTRAINT ... NOT VALID` +
+  `VALIDATE CONSTRAINT`, `CREATE INDEX CONCURRENTLY`) it recommends as the safer
+  alternative. `DdlStatementParser` pre-strips both into flags (`notValid`,
+  `concurrently`) before handing the rest to JSqlParser. Do not remove this step —
+  removing it silently turns every NOT VALID / CONCURRENTLY statement into a parse
+  failure, which fails closed (UNKNOWN) but defeats the point of the feature for
+  exactly the statements it is meant to bless as safe.
+- **Fail-closed, not best-effort.** Unparseable SQL, an ALTER with more than one
+  clause (a single `DdlFacts` cannot honestly represent two clauses' worth of risk),
+  an unrecognised default function DeepSQL cannot confirm the volatility of, and
+  MySQL (no verified rule table exists yet — `MySQLMigrationRiskProvider` always
+  returns `UNKNOWN`) all report `UNKNOWN` or `CAUTION` rather than guessing `SAFE`.
+  Verified live: `{"sql":"not sql"}` returns `verdict: UNKNOWN`, `safeToRun: false`.
+- **Known limitation: `ALTER COLUMN TYPE` over-warns.** `DdlFacts` carries no old
+  column type, only the new one, so the provider cannot tell a same-family widening
+  (`varchar(50)` → `varchar(100)`, which Postgres does NOT rewrite) from a genuine
+  type change (which does). It reports the conservative rewrite verdict for both
+  rather than risk a false SAFE.
+- **Lock strength is ranked by an explicit ordering list, not `max(mode)`.**
+  Postgres lock mode names sort alphabetically in a way that has nothing to do with
+  strength — `"ShareLock".compareTo("AccessExclusiveLock") > 0`, so a naive
+  string-max would report a statement that also takes `ShareLock` as the stronger
+  of the two, when `AccessExclusiveLock` is in fact the most exclusive mode
+  Postgres has. Any code that needs "the worst lock this statement takes" must
+  rank against Postgres's real lock hierarchy, not compare mode names.
+- **Authorization is asserted in the service, before parsing, credential
+  decryption, or session opening** (`MigrationRiskService.analyze` calls
+  `accessControlService.assertCanReadConnectionContent` first). The controller is
+  exempted from the static `ConnectionScopedAuthorizationSafetyTest` sweep
+  (`AUTHORIZED_ELSEWHERE`) on that basis, same reasoning as
+  `DashboardWorkspaceController`. Verified live, not just by the mocked unit test
+  and the static scanner: a second user with zero grants on the target connection
+  (confirmed empty in `connection_access_grant`) received a genuine `403` from
+  `POST /migrations/analyze`, with no stack trace in the logs — proof the
+  controller's `catch (ResponseStatusException e) { throw e; }` before the
+  catch-all is live and not swallowing the 403 into a 500.
+
 ## Key Rules & Patterns
 
 ### Backend Rules

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -356,6 +356,18 @@
             <version>4.2.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>1.20.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>1.20.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/src/main/java/com/dbaagent/controller/MigrationRiskController.java
+++ b/backend/src/main/java/com/dbaagent/controller/MigrationRiskController.java
@@ -1,0 +1,39 @@
+package com.dbaagent.controller;
+
+import com.dbaagent.dto.MigrationRiskReport;
+import com.dbaagent.service.migration.MigrationRiskService;
+import com.dbaagent.service.security.AccessControlService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/migrations")
+@RequiredArgsConstructor
+public class MigrationRiskController {
+
+    private final MigrationRiskService migrationRiskService;
+    private final AccessControlService accessControlService;
+
+    @PostMapping("/analyze")
+    public ResponseEntity<?> analyze(@RequestBody Map<String, String> body) {
+        String connectionId = body.get("connectionId");
+        String sql = body.get("sql");
+        if (connectionId == null || connectionId.isBlank() || sql == null || sql.isBlank()) {
+            return ResponseEntity.badRequest().body(Map.of("message", "connectionId and sql are required"));
+        }
+        try {
+            accessControlService.assertCanReadConnectionContent(connectionId);
+            MigrationRiskReport report = migrationRiskService.analyze(connectionId, sql);
+            return ResponseEntity.ok(report);
+        } catch (ResponseStatusException e) {
+            throw e;   // preserve 403/404 — a catch-all below would report it as a 500
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError()
+                    .body(Map.of("message", "Migration analysis failed: " + e.getMessage()));
+        }
+    }
+}

--- a/backend/src/main/java/com/dbaagent/controller/MigrationRiskController.java
+++ b/backend/src/main/java/com/dbaagent/controller/MigrationRiskController.java
@@ -2,7 +2,6 @@ package com.dbaagent.controller;
 
 import com.dbaagent.dto.MigrationRiskReport;
 import com.dbaagent.service.migration.MigrationRiskService;
-import com.dbaagent.service.security.AccessControlService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,7 +15,6 @@ import java.util.Map;
 public class MigrationRiskController {
 
     private final MigrationRiskService migrationRiskService;
-    private final AccessControlService accessControlService;
 
     @PostMapping("/analyze")
     public ResponseEntity<?> analyze(@RequestBody Map<String, String> body) {
@@ -26,7 +24,9 @@ public class MigrationRiskController {
             return ResponseEntity.badRequest().body(Map.of("message", "connectionId and sql are required"));
         }
         try {
-            accessControlService.assertCanReadConnectionContent(connectionId);
+            // MigrationRiskService.analyze asserts assertCanReadConnectionContent before
+            // parsing, credential decryption or session opening — see AUTHORIZED_ELSEWHERE
+            // in ConnectionScopedAuthorizationSafetyTest.
             MigrationRiskReport report = migrationRiskService.analyze(connectionId, sql);
             return ResponseEntity.ok(report);
         } catch (ResponseStatusException e) {

--- a/backend/src/main/java/com/dbaagent/dto/MigrationRiskReport.java
+++ b/backend/src/main/java/com/dbaagent/dto/MigrationRiskReport.java
@@ -1,0 +1,23 @@
+package com.dbaagent.dto;
+
+import java.util.List;
+
+public record MigrationRiskReport(
+        String dialect,
+        String verdict,            // SAFE | CAUTION | DANGER | FAILS | UNKNOWN
+        boolean safeToRun,
+        boolean dialectSupported,
+        String operation,
+        String table,
+        List<LockRef> locks,       // per table — a statement can lock tables it does not name
+        boolean rewritesTable,
+        long tableRows,
+        long tableSizeBytes,
+        String estimatedDuration,  // coarse bucket, never a number
+        String reason,
+        String saferAlternative,
+        String docsUrl,
+        String confidence) {
+
+    public record LockRef(String table, String mode, List<String> blocks) {}
+}

--- a/backend/src/main/java/com/dbaagent/dto/TableFacts.java
+++ b/backend/src/main/java/com/dbaagent/dto/TableFacts.java
@@ -1,0 +1,3 @@
+package com.dbaagent.dto;
+
+public record TableFacts(long rowEstimate, long sizeBytes, boolean empty) {}

--- a/backend/src/main/java/com/dbaagent/provider/api/DatabaseDialect.java
+++ b/backend/src/main/java/com/dbaagent/provider/api/DatabaseDialect.java
@@ -93,4 +93,10 @@ public interface DatabaseDialect {
      * @return The sampling provider
      */
     SamplingProvider sampling();
+
+    /**
+     * Get the migration risk provider for this database.
+     * @return The migration risk provider
+     */
+    MigrationRiskProvider migrationRisk();
 }

--- a/backend/src/main/java/com/dbaagent/provider/api/MigrationRiskProvider.java
+++ b/backend/src/main/java/com/dbaagent/provider/api/MigrationRiskProvider.java
@@ -1,0 +1,9 @@
+package com.dbaagent.provider.api;
+
+import com.dbaagent.dto.MigrationRiskReport;
+import com.dbaagent.dto.TableFacts;
+import com.dbaagent.service.migration.DdlFacts;
+
+public interface MigrationRiskProvider {
+    MigrationRiskReport classify(DdlFacts facts, TableFacts table);
+}

--- a/backend/src/main/java/com/dbaagent/provider/mysql/MySQLDialect.java
+++ b/backend/src/main/java/com/dbaagent/provider/mysql/MySQLDialect.java
@@ -28,6 +28,7 @@ public class MySQLDialect implements DatabaseDialect {
     private final MySQLQueryExecutionProvider queryExecutionProvider;
     private final MySQLPrivilegeCheckProvider privilegeCheckProvider;
     private final MySQLSamplingProvider samplingProvider;
+    private final MySQLMigrationRiskProvider migrationRiskProvider;
 
     @Override
     public String getCanonicalName() {
@@ -92,5 +93,10 @@ public class MySQLDialect implements DatabaseDialect {
     @Override
     public SamplingProvider sampling() {
         return samplingProvider;
+    }
+
+    @Override
+    public MigrationRiskProvider migrationRisk() {
+        return migrationRiskProvider;
     }
 }

--- a/backend/src/main/java/com/dbaagent/provider/mysql/MySQLMigrationRiskProvider.java
+++ b/backend/src/main/java/com/dbaagent/provider/mysql/MySQLMigrationRiskProvider.java
@@ -1,0 +1,28 @@
+package com.dbaagent.provider.mysql;
+
+import com.dbaagent.dto.MigrationRiskReport;
+import com.dbaagent.dto.TableFacts;
+import com.dbaagent.provider.api.MigrationRiskProvider;
+import com.dbaagent.service.migration.DdlFacts;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * MySQL migration risk is not implemented. Returning UNKNOWN is deliberate: MySQL's
+ * online-DDL matrix varies by version, storage engine and ALGORITHM/LOCK clause, and a
+ * confident wrong answer about a lock is worse than no answer.
+ */
+@Component
+public class MySQLMigrationRiskProvider implements MigrationRiskProvider {
+
+    @Override
+    public MigrationRiskReport classify(DdlFacts facts, TableFacts table) {
+        return new MigrationRiskReport("mysql", "UNKNOWN", false, false,
+                facts.operation().name(), facts.table(), List.of(), false,
+                table.rowEstimate(), table.sizeBytes(), "unknown",
+                "DeepSQL does not yet have verified MySQL DDL rules. Review this by hand.",
+                null, "https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl-operations.html",
+                "unverified");
+    }
+}

--- a/backend/src/main/java/com/dbaagent/provider/postgres/PostgresDialect.java
+++ b/backend/src/main/java/com/dbaagent/provider/postgres/PostgresDialect.java
@@ -28,6 +28,7 @@ public class PostgresDialect implements DatabaseDialect {
     private final PostgresQueryExecutionProvider queryExecutionProvider;
     private final PostgresPrivilegeCheckProvider privilegeCheckProvider;
     private final PostgresSamplingProvider samplingProvider;
+    private final PostgresMigrationRiskProvider migrationRiskProvider;
 
     @Override
     public String getCanonicalName() {
@@ -92,5 +93,10 @@ public class PostgresDialect implements DatabaseDialect {
     @Override
     public SamplingProvider sampling() {
         return samplingProvider;
+    }
+
+    @Override
+    public MigrationRiskProvider migrationRisk() {
+        return migrationRiskProvider;
     }
 }

--- a/backend/src/main/java/com/dbaagent/provider/postgres/PostgresMigrationRiskProvider.java
+++ b/backend/src/main/java/com/dbaagent/provider/postgres/PostgresMigrationRiskProvider.java
@@ -18,6 +18,8 @@ public class PostgresMigrationRiskProvider implements MigrationRiskProvider {
     private static final String INDEX_DOCS = "https://www.postgresql.org/docs/18/sql-createindex.html";
     private static final Set<String> VOLATILE_FALLBACK =
             Set.of("random", "gen_random_uuid", "clock_timestamp", "uuid_generate_v4");
+    private static final Set<String> STABLE_FALLBACK =
+            Set.of("now", "current_timestamp", "current_date", "current_time", "transaction_timestamp");
 
     private static final List<String> RW = List.of("read", "write");
     private static final List<String> W = List.of("write");
@@ -40,6 +42,10 @@ public class PostgresMigrationRiskProvider implements MigrationRiskProvider {
 
     private boolean isVolatile(String fn) {
         return fn != null && VOLATILE_FALLBACK.contains(fn.toLowerCase());
+    }
+
+    private boolean isStable(String fn) {
+        return fn != null && STABLE_FALLBACK.contains(fn.toLowerCase());
     }
 
     private String bucket(TableFacts t) {
@@ -65,6 +71,16 @@ public class PostgresMigrationRiskProvider implements MigrationRiskProvider {
                     "Add the column without a default, backfill in batches, then set the default "
                     + "for future rows.", ALTER_DOCS);
         }
+        if (f.defaultFunction() != null && !isStable(f.defaultFunction())) {
+            return report("CAUTION", false, f, t, locks, false, "unknown",
+                    "DeepSQL cannot verify the volatility of " + f.defaultFunction()
+                    + "(). A VOLATILE default would force a full table rewrite under ACCESS "
+                    + "EXCLUSIVE; a STABLE or IMMUTABLE one would not. Check "
+                    + "SELECT provolatile FROM pg_proc WHERE proname = '" + f.defaultFunction()
+                    + "' before running this.",
+                    "If the function is VOLATILE, add the column without a default, backfill in "
+                    + "batches, then set the default for future rows.", ALTER_DOCS);
+        }
         return report("SAFE", true, f, t, locks, false, "milliseconds",
                 "Adding a column with no default, a constant default, or a STABLE default "
                 + "(such as now()) is metadata-only in PostgreSQL 11+. The ACCESS EXCLUSIVE lock "
@@ -83,8 +99,9 @@ public class PostgresMigrationRiskProvider implements MigrationRiskProvider {
                 List.of(new LockRef(f.table(), "AccessExclusiveLock", RW)),
                 true, bucket(t),
                 "Changing a column type generally rewrites the whole table under ACCESS EXCLUSIVE. "
-                + "(Widening within the same type family — varchar(50) to varchar(100) — is the "
-                + "exception and does not rewrite.)",
+                + "(Some conversions, such as widening within the same type family, are known "
+                + "exceptions that PostgreSQL can skip rewriting for — but DeepSQL cannot confirm "
+                + "which case this is, so the conservative rewrite verdict is reported here.)",
                 "Add a new column, backfill in batches, swap the names, then drop the old column.",
                 ALTER_DOCS);
     }

--- a/backend/src/main/java/com/dbaagent/provider/postgres/PostgresMigrationRiskProvider.java
+++ b/backend/src/main/java/com/dbaagent/provider/postgres/PostgresMigrationRiskProvider.java
@@ -1,0 +1,177 @@
+package com.dbaagent.provider.postgres;
+
+import com.dbaagent.dto.MigrationRiskReport;
+import com.dbaagent.dto.MigrationRiskReport.LockRef;
+import com.dbaagent.dto.TableFacts;
+import com.dbaagent.provider.api.MigrationRiskProvider;
+import com.dbaagent.service.migration.DdlFacts;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Set;
+
+@Component
+public class PostgresMigrationRiskProvider implements MigrationRiskProvider {
+
+    private static final long LARGE_ROWS = 1_000_000L;
+    private static final String ALTER_DOCS = "https://www.postgresql.org/docs/18/sql-altertable.html";
+    private static final String INDEX_DOCS = "https://www.postgresql.org/docs/18/sql-createindex.html";
+    private static final Set<String> VOLATILE_FALLBACK =
+            Set.of("random", "gen_random_uuid", "clock_timestamp", "uuid_generate_v4");
+
+    private static final List<String> RW = List.of("read", "write");
+    private static final List<String> W = List.of("write");
+
+    @Override
+    public MigrationRiskReport classify(DdlFacts f, TableFacts t) {
+        return switch (f.operation()) {
+            case ADD_COLUMN -> addColumn(f, t);
+            case DROP_COLUMN -> metadataOnly(f, t, "Dropping a column is metadata-only; the data is reclaimed later by VACUUM.");
+            case RENAME_COLUMN -> metadataOnly(f, t, "Renaming is metadata-only, but it will break application code referencing the old name.");
+            case ALTER_COLUMN_TYPE -> alterType(f, t);
+            case SET_NOT_NULL -> setNotNull(f, t);
+            case ADD_CHECK -> addCheck(f, t);
+            case ADD_FOREIGN_KEY -> addForeignKey(f, t);
+            case VALIDATE_CONSTRAINT -> validateConstraint(f, t);
+            case CREATE_INDEX -> createIndex(f, t);
+            case UNKNOWN -> unknown(f, t);
+        };
+    }
+
+    private boolean isVolatile(String fn) {
+        return fn != null && VOLATILE_FALLBACK.contains(fn.toLowerCase());
+    }
+
+    private String bucket(TableFacts t) {
+        if (t.rowEstimate() >= 10_000_000L) return "minutes-to-tens-of-minutes";
+        if (t.rowEstimate() >= LARGE_ROWS) return "minutes";
+        return "seconds";
+    }
+
+    private MigrationRiskReport addColumn(DdlFacts f, TableFacts t) {
+        var locks = List.of(new LockRef(f.table(), "AccessExclusiveLock", RW));
+        if (f.notNull() && f.defaultFunction() == null && f.defaultExpression() == null && !t.empty()) {
+            return report("FAILS", false, f, t, locks, false, "milliseconds",
+                    "ADD COLUMN ... NOT NULL without a default fails on a non-empty table: "
+                    + "the existing rows contain null values.",
+                    "Add the column nullable, backfill in batches, then SET NOT NULL.", ALTER_DOCS);
+        }
+        if (isVolatile(f.defaultFunction())) {
+            boolean big = t.rowEstimate() >= LARGE_ROWS;
+            return report(big ? "DANGER" : "CAUTION", false, f, t, locks, true, bucket(t),
+                    "Default expression " + f.defaultFunction()
+                    + "() is VOLATILE, so every existing row must be written — a full table rewrite "
+                    + "under ACCESS EXCLUSIVE, blocking reads and writes for the whole operation.",
+                    "Add the column without a default, backfill in batches, then set the default "
+                    + "for future rows.", ALTER_DOCS);
+        }
+        return report("SAFE", true, f, t, locks, false, "milliseconds",
+                "Adding a column with no default, a constant default, or a STABLE default "
+                + "(such as now()) is metadata-only in PostgreSQL 11+. The ACCESS EXCLUSIVE lock "
+                + "is held only briefly.", null, ALTER_DOCS);
+    }
+
+    private MigrationRiskReport metadataOnly(DdlFacts f, TableFacts t, String why) {
+        return report("SAFE", true, f, t,
+                List.of(new LockRef(f.table(), "AccessExclusiveLock", RW)),
+                false, "milliseconds", why, null, ALTER_DOCS);
+    }
+
+    private MigrationRiskReport alterType(DdlFacts f, TableFacts t) {
+        boolean big = t.rowEstimate() >= LARGE_ROWS;
+        return report(big ? "DANGER" : "CAUTION", false, f, t,
+                List.of(new LockRef(f.table(), "AccessExclusiveLock", RW)),
+                true, bucket(t),
+                "Changing a column type generally rewrites the whole table under ACCESS EXCLUSIVE. "
+                + "(Widening within the same type family — varchar(50) to varchar(100) — is the "
+                + "exception and does not rewrite.)",
+                "Add a new column, backfill in batches, swap the names, then drop the old column.",
+                ALTER_DOCS);
+    }
+
+    private MigrationRiskReport setNotNull(DdlFacts f, TableFacts t) {
+        return report(t.rowEstimate() >= LARGE_ROWS ? "CAUTION" : "SAFE",
+                t.rowEstimate() < LARGE_ROWS, f, t,
+                List.of(new LockRef(f.table(), "AccessExclusiveLock", RW)),
+                false, bucket(t),
+                "SET NOT NULL does not rewrite the table, but it scans every row to validate, "
+                + "holding ACCESS EXCLUSIVE for the duration of the scan.",
+                "Add a NOT VALID CHECK (col IS NOT NULL) constraint, VALIDATE it under a weaker "
+                + "lock, then SET NOT NULL.", ALTER_DOCS);
+    }
+
+    private MigrationRiskReport addCheck(DdlFacts f, TableFacts t) {
+        var locks = List.of(new LockRef(f.table(), "AccessExclusiveLock", RW));
+        if (f.notValid()) {
+            return report("SAFE", true, f, t, locks, false, "milliseconds",
+                    "ADD CONSTRAINT ... NOT VALID skips the validating scan, so the ACCESS "
+                    + "EXCLUSIVE lock is held only briefly.",
+                    "Follow with VALIDATE CONSTRAINT, which runs under a weaker lock that allows "
+                    + "concurrent writes.", ALTER_DOCS);
+        }
+        return report(t.rowEstimate() >= LARGE_ROWS ? "DANGER" : "CAUTION", false, f, t, locks,
+                false, bucket(t),
+                "A validating CHECK constraint scans every row while holding ACCESS EXCLUSIVE, "
+                + "blocking reads and writes.",
+                "Add it NOT VALID first, then VALIDATE CONSTRAINT separately.", ALTER_DOCS);
+    }
+
+    private MigrationRiskReport addForeignKey(DdlFacts f, TableFacts t) {
+        var locks = f.referencedTable() == null
+                ? List.of(new LockRef(f.table(), "ShareRowExclusiveLock", W))
+                : List.of(new LockRef(f.table(), "ShareRowExclusiveLock", W),
+                          new LockRef(f.referencedTable(), "ShareRowExclusiveLock", W));
+        String bothTables = "This locks the referenced table as well as the one being altered — "
+                + "writes are blocked on a table the statement does not name.";
+        if (f.notValid()) {
+            return report("CAUTION", false, f, t, locks, false, "seconds",
+                    "NOT VALID skips the validating scan, but ShareRowExclusiveLock is still taken "
+                    + "on both tables. " + bothTables,
+                    "Follow with VALIDATE CONSTRAINT under ShareUpdateExclusiveLock.", ALTER_DOCS);
+        }
+        return report("DANGER", false, f, t, locks, false, bucket(t),
+                "Adding a validating foreign key scans the child table and blocks writes on both "
+                + "tables under ShareRowExclusiveLock. " + bothTables,
+                "Add the constraint NOT VALID, then VALIDATE CONSTRAINT separately.", ALTER_DOCS);
+    }
+
+    private MigrationRiskReport validateConstraint(DdlFacts f, TableFacts t) {
+        return report("SAFE", true, f, t,
+                List.of(new LockRef(f.table(), "ShareUpdateExclusiveLock", List.of())),
+                false, bucket(t),
+                "VALIDATE CONSTRAINT scans the table under ShareUpdateExclusiveLock, which allows "
+                + "concurrent reads and writes. This is the cheap second half of the NOT VALID pattern.",
+                null, ALTER_DOCS);
+    }
+
+    private MigrationRiskReport createIndex(DdlFacts f, TableFacts t) {
+        if (f.concurrently()) {
+            return report("SAFE", true, f, t,
+                    List.of(new LockRef(f.table(), "ShareUpdateExclusiveLock", List.of())),
+                    false, bucket(t),
+                    "CREATE INDEX CONCURRENTLY does not block reads or writes. It takes longer and "
+                    + "cannot run inside a transaction block.",
+                    "If it fails it leaves an INVALID index behind — check with \\d and drop it "
+                    + "before retrying.", INDEX_DOCS);
+        }
+        return report(t.rowEstimate() >= LARGE_ROWS ? "DANGER" : "CAUTION", false, f, t,
+                List.of(new LockRef(f.table(), "ShareLock", W)),
+                false, bucket(t),
+                "A plain CREATE INDEX blocks all writes to the table for the entire build.",
+                "Use CREATE INDEX CONCURRENTLY, which allows concurrent writes.", INDEX_DOCS);
+    }
+
+    private MigrationRiskReport unknown(DdlFacts f, TableFacts t) {
+        return report("UNKNOWN", false, f, t, List.of(), false, "unknown",
+                "This statement is not one DeepSQL has a verified rule for. Treat it as unsafe "
+                + "until reviewed by hand.", null, ALTER_DOCS);
+    }
+
+    private MigrationRiskReport report(String verdict, boolean safe, DdlFacts f, TableFacts t,
+                                       List<LockRef> locks, boolean rewrites, String duration,
+                                       String reason, String safer, String docs) {
+        return new MigrationRiskReport("postgres", verdict, safe, true, f.operation().name(),
+                f.table(), locks, rewrites, t.rowEstimate(), t.sizeBytes(), duration,
+                reason, safer, docs, "verified");
+    }
+}

--- a/backend/src/main/java/com/dbaagent/service/migration/DdlFacts.java
+++ b/backend/src/main/java/com/dbaagent/service/migration/DdlFacts.java
@@ -1,0 +1,15 @@
+package com.dbaagent.service.migration;
+
+public record DdlFacts(
+        DdlOperation operation,
+        String table,
+        String column,
+        String newColumnName,
+        String dataType,
+        String defaultExpression,
+        String defaultFunction,
+        boolean notNull,
+        boolean notValid,
+        boolean concurrently,
+        String referencedTable,
+        String rawSql) {}

--- a/backend/src/main/java/com/dbaagent/service/migration/DdlOperation.java
+++ b/backend/src/main/java/com/dbaagent/service/migration/DdlOperation.java
@@ -1,0 +1,6 @@
+package com.dbaagent.service.migration;
+
+public enum DdlOperation {
+    ADD_COLUMN, DROP_COLUMN, RENAME_COLUMN, ALTER_COLUMN_TYPE, SET_NOT_NULL,
+    ADD_CHECK, ADD_FOREIGN_KEY, VALIDATE_CONSTRAINT, CREATE_INDEX, UNKNOWN
+}

--- a/backend/src/main/java/com/dbaagent/service/migration/DdlStatementParser.java
+++ b/backend/src/main/java/com/dbaagent/service/migration/DdlStatementParser.java
@@ -15,7 +15,6 @@ import java.util.regex.Pattern;
 @Component
 public class DdlStatementParser {
 
-    private static final Pattern NOT_VALID = Pattern.compile("(?i)\\s+NOT\\s+VALID\\s*;?\\s*$");
     private static final Pattern CONCURRENTLY =
             Pattern.compile("(?i)\\bCREATE\\s+(UNIQUE\\s+)?INDEX\\s+CONCURRENTLY\\b");
     private static final Pattern DEFAULT_FN =
@@ -28,8 +27,9 @@ public class DdlStatementParser {
     public Optional<DdlFacts> parse(String sql) {
         if (sql == null || sql.isBlank()) return Optional.empty();
 
-        boolean notValid = NOT_VALID.matcher(sql).find();
-        String normalized = notValid ? NOT_VALID.matcher(sql).replaceAll("") : sql;
+        int notValidAt = notValidStart(sql);
+        boolean notValid = notValidAt >= 0;
+        String normalized = notValid ? sql.substring(0, notValidAt) : sql;
 
         boolean concurrently = CONCURRENTLY.matcher(normalized).find();
         if (concurrently) {
@@ -144,5 +144,33 @@ public class DdlStatementParser {
 
     private String strip(String s) {
         return s == null ? null : s.replace("\"", "");
+    }
+
+    private static int trimEnd(String s) {
+        int e = s.length();
+        while (e > 0) {
+            char c = s.charAt(e - 1);
+            if (c == ';' || Character.isWhitespace(c)) e--;
+            else break;
+        }
+        return e;
+    }
+
+    // A regex tail-match here (\s+NOT\s+VALID...$ via find()) is quadratic on attacker-
+    // controlled input: CodeQL flagged it, and it measured at 35s for 80KB of input.
+    // The clause can only ever be a bounded tail, so scan indices instead of the whole string.
+    private static int notValidStart(String s) {
+        int e = trimEnd(s);
+        int p = e - 5;
+        if (p < 0 || !s.regionMatches(true, p, "VALID", 0, 5)) return -1;
+        int q = p;
+        while (q > 0 && Character.isWhitespace(s.charAt(q - 1))) q--;
+        if (q == p) return -1;
+        int r = q - 3;
+        if (r < 0 || !s.regionMatches(true, r, "NOT", 0, 3)) return -1;
+        int t = r;
+        while (t > 0 && Character.isWhitespace(s.charAt(t - 1))) t--;
+        if (t == r) return -1;
+        return t;
     }
 }

--- a/backend/src/main/java/com/dbaagent/service/migration/DdlStatementParser.java
+++ b/backend/src/main/java/com/dbaagent/service/migration/DdlStatementParser.java
@@ -65,6 +65,9 @@ public class DdlStatementParser {
     private Optional<DdlFacts> fromAlter(Alter alter, String rawSql, boolean notValid) {
         List<AlterExpression> exprs = alter.getAlterExpressions();
         if (exprs == null || exprs.isEmpty()) return Optional.empty();
+        // A single DdlFacts cannot honestly represent more than one clause; refuse rather than
+        // judge the statement on the first clause alone.
+        if (exprs.size() > 1) return Optional.empty();
         AlterExpression e = exprs.get(0);
         String table = strip(alter.getTable().getName());
         String op = e.getOperation() == null ? "" : e.getOperation().name().toUpperCase(Locale.ROOT);
@@ -84,7 +87,10 @@ public class DdlStatementParser {
                 return Optional.of(new DdlFacts(DdlOperation.ADD_FOREIGN_KEY, table, null, null, null,
                         null, null, false, notValid, false, referencedTable(rawSql), rawSql));
             }
-            if (rawSql.toUpperCase(Locale.ROOT).contains("CHECK")) {
+            // A constraint clause (ADD CONSTRAINT ... CHECK / ADD CHECK) parses with a non-null
+            // Index and no column data type; a plain ADD COLUMN never sets one. Checking a whole-
+            // statement substring instead would misclassify an ordinary column named e.g. check_flag.
+            if (e.getIndex() != null) {
                 return Optional.of(new DdlFacts(DdlOperation.ADD_CHECK, table, null, null, null,
                         null, null, false, notValid, false, null, rawSql));
             }

--- a/backend/src/main/java/com/dbaagent/service/migration/DdlStatementParser.java
+++ b/backend/src/main/java/com/dbaagent/service/migration/DdlStatementParser.java
@@ -1,0 +1,131 @@
+package com.dbaagent.service.migration;
+
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.alter.Alter;
+import net.sf.jsqlparser.statement.alter.AlterExpression;
+import net.sf.jsqlparser.statement.create.index.CreateIndex;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+@Component
+public class DdlStatementParser {
+
+    private static final Pattern NOT_VALID = Pattern.compile("(?i)\\s+NOT\\s+VALID\\s*;?\\s*$");
+    private static final Pattern CONCURRENTLY =
+            Pattern.compile("(?i)\\bCREATE\\s+(UNIQUE\\s+)?INDEX\\s+CONCURRENTLY\\b");
+    private static final Pattern DEFAULT_FN =
+            Pattern.compile("(?i)DEFAULT\\s+([a-z_][a-z0-9_]*)\\s*\\(");
+    private static final Pattern REFERENCES =
+            Pattern.compile("(?i)REFERENCES\\s+([a-z_][a-z0-9_.\"]*)\\s*\\(");
+    private static final Pattern VALIDATE_CONSTRAINT =
+            Pattern.compile("(?i)^\\s*ALTER\\s+TABLE\\s+(\\S+)\\s+VALIDATE\\s+CONSTRAINT\\b");
+
+    public Optional<DdlFacts> parse(String sql) {
+        if (sql == null || sql.isBlank()) return Optional.empty();
+
+        boolean notValid = NOT_VALID.matcher(sql).find();
+        String normalized = notValid ? NOT_VALID.matcher(sql).replaceAll("") : sql;
+
+        boolean concurrently = CONCURRENTLY.matcher(normalized).find();
+        if (concurrently) {
+            normalized = CONCURRENTLY.matcher(normalized)
+                    .replaceAll(m -> "CREATE " + (m.group(1) == null ? "" : m.group(1)) + "INDEX");
+        }
+
+        // VALIDATE CONSTRAINT degrades to UNSPECIFIC in JSqlParser; match it textually first.
+        var vc = VALIDATE_CONSTRAINT.matcher(sql);
+        if (vc.find()) {
+            return Optional.of(new DdlFacts(DdlOperation.VALIDATE_CONSTRAINT, strip(vc.group(1)),
+                    null, null, null, null, null, false, notValid, false, null, sql));
+        }
+
+        Statement stmt;
+        try {
+            stmt = CCJSqlParserUtil.parse(normalized);
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+
+        if (stmt instanceof CreateIndex ci) {
+            return Optional.of(new DdlFacts(DdlOperation.CREATE_INDEX,
+                    strip(ci.getTable().getName()), null, null, null, null, null,
+                    false, notValid, concurrently, null, sql));
+        }
+        if (stmt instanceof Alter alter) {
+            return fromAlter(alter, sql, notValid);
+        }
+        return Optional.empty();
+    }
+
+    private Optional<DdlFacts> fromAlter(Alter alter, String rawSql, boolean notValid) {
+        List<AlterExpression> exprs = alter.getAlterExpressions();
+        if (exprs == null || exprs.isEmpty()) return Optional.empty();
+        AlterExpression e = exprs.get(0);
+        String table = strip(alter.getTable().getName());
+        String op = e.getOperation() == null ? "" : e.getOperation().name().toUpperCase(Locale.ROOT);
+
+        if ("DROP".equals(op)) {
+            return Optional.of(new DdlFacts(DdlOperation.DROP_COLUMN, table, strip(e.getColumnName()),
+                    null, null, null, null, false, notValid, false, null, rawSql));
+        }
+        if ("RENAME".equals(op)) {
+            // JSqlParser exposes only the NEW name here; the old name is not recoverable.
+            return Optional.of(new DdlFacts(DdlOperation.RENAME_COLUMN, table, null,
+                    strip(e.getColumnName()), null, null, null, false, notValid, false, null, rawSql));
+        }
+        if ("ADD".equals(op)) {
+            if (e.getIndex() != null && e.getIndex().getType() != null
+                    && e.getIndex().getType().toUpperCase(Locale.ROOT).contains("FOREIGN")) {
+                return Optional.of(new DdlFacts(DdlOperation.ADD_FOREIGN_KEY, table, null, null, null,
+                        null, null, false, notValid, false, referencedTable(rawSql), rawSql));
+            }
+            if (rawSql.toUpperCase(Locale.ROOT).contains("CHECK")) {
+                return Optional.of(new DdlFacts(DdlOperation.ADD_CHECK, table, null, null, null,
+                        null, null, false, notValid, false, null, rawSql));
+            }
+            if (e.getColDataTypeList() != null && !e.getColDataTypeList().isEmpty()) {
+                var cdt = e.getColDataTypeList().get(0);
+                List<String> specs = cdt.getColumnSpecs() == null ? List.of() : cdt.getColumnSpecs();
+                String joined = String.join(" ", specs).toUpperCase(Locale.ROOT);
+                return Optional.of(new DdlFacts(DdlOperation.ADD_COLUMN, table,
+                        strip(cdt.getColumnName()), null,
+                        String.valueOf(cdt.getColDataType()), joined.contains("DEFAULT") ? joined : null,
+                        defaultFunction(rawSql), joined.contains("NOT NULL"),
+                        notValid, false, null, rawSql));
+            }
+        }
+        if ("ALTER".equals(op) && e.getColDataTypeList() != null && !e.getColDataTypeList().isEmpty()) {
+            var cdt = e.getColDataTypeList().get(0);
+            String type = String.valueOf(cdt.getColDataType());
+            // "SET NOT NULL" arrives with type=SET, specs=[NOT, NULL].
+            if ("SET".equalsIgnoreCase(type)) {
+                return Optional.of(new DdlFacts(DdlOperation.SET_NOT_NULL, table,
+                        strip(cdt.getColumnName()), null, null, null, null, true,
+                        notValid, false, null, rawSql));
+            }
+            return Optional.of(new DdlFacts(DdlOperation.ALTER_COLUMN_TYPE, table,
+                    strip(cdt.getColumnName()), null, type, null, null, false,
+                    notValid, false, null, rawSql));
+        }
+        return Optional.empty();
+    }
+
+    private String defaultFunction(String sql) {
+        var m = DEFAULT_FN.matcher(sql);
+        return m.find() ? m.group(1).toLowerCase(Locale.ROOT) : null;
+    }
+
+    private String referencedTable(String sql) {
+        var m = REFERENCES.matcher(sql);
+        return m.find() ? strip(m.group(1)) : null;
+    }
+
+    private String strip(String s) {
+        return s == null ? null : s.replace("\"", "");
+    }
+}

--- a/backend/src/main/java/com/dbaagent/service/migration/DdlStatementParser.java
+++ b/backend/src/main/java/com/dbaagent/service/migration/DdlStatementParser.java
@@ -44,12 +44,17 @@ public class DdlStatementParser {
                     null, null, null, null, null, false, notValid, false, null, sql));
         }
 
-        Statement stmt;
+        List<Statement> statements;
         try {
-            stmt = CCJSqlParserUtil.parse(normalized);
+            statements = CCJSqlParserUtil.parseStatements(normalized);
         } catch (Exception e) {
             return Optional.empty();
         }
+        // Postgres executes every statement in the string, not just the first; a single
+        // DdlFacts cannot honestly represent more than one, so refuse rather than judge
+        // the string on its first statement alone.
+        if (statements.size() != 1) return Optional.empty();
+        Statement stmt = statements.get(0);
 
         if (stmt instanceof CreateIndex ci) {
             return Optional.of(new DdlFacts(DdlOperation.CREATE_INDEX,
@@ -72,7 +77,10 @@ public class DdlStatementParser {
         String table = strip(alter.getTable().getName());
         String op = e.getOperation() == null ? "" : e.getOperation().name().toUpperCase(Locale.ROOT);
 
-        if ("DROP".equals(op)) {
+        // DROP CONSTRAINT arrives with the same operation=DROP and a null column name;
+        // only a genuine DROP COLUMN names a column. A dropped constraint also takes a
+        // lock on the referenced table, which this parser has no data for — fail closed.
+        if ("DROP".equals(op) && e.getColumnName() != null) {
             return Optional.of(new DdlFacts(DdlOperation.DROP_COLUMN, table, strip(e.getColumnName()),
                     null, null, null, null, false, notValid, false, null, rawSql));
         }
@@ -114,6 +122,9 @@ public class DdlStatementParser {
                         strip(cdt.getColumnName()), null, null, null, null, true,
                         notValid, false, null, rawSql));
             }
+            // "DROP NOT NULL" arrives with colDataType=null, specs=[DROP, NOT, NULL] — it is
+            // metadata-only, not a type change, but no rule models it correctly; fail closed.
+            if (cdt.getColDataType() == null) return Optional.empty();
             return Optional.of(new DdlFacts(DdlOperation.ALTER_COLUMN_TYPE, table,
                     strip(cdt.getColumnName()), null, type, null, null, false,
                     notValid, false, null, rawSql));

--- a/backend/src/main/java/com/dbaagent/service/migration/MigrationRiskService.java
+++ b/backend/src/main/java/com/dbaagent/service/migration/MigrationRiskService.java
@@ -1,0 +1,67 @@
+package com.dbaagent.service.migration;
+
+import com.dbaagent.dto.MigrationRiskReport;
+import com.dbaagent.dto.TableFacts;
+import com.dbaagent.model.ConnectionRequest;
+import com.dbaagent.provider.DatabaseProviderRegistry;
+import com.dbaagent.service.ConnectionService;
+import com.dbaagent.service.CredentialService;
+import com.dbaagent.service.security.AccessControlService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MigrationRiskService {
+
+    private final DdlStatementParser parser;
+    private final DatabaseProviderRegistry registry;
+    private final CredentialService credentialService;
+    private final ConnectionService connectionService;
+    private final AccessControlService accessControlService;
+
+    public MigrationRiskReport analyze(String connectionId, String sql) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
+
+        var parsed = parser.parse(sql);
+        if (parsed.isEmpty()) {
+            return failClosed("DeepSQL could not parse this statement, so it cannot verify what "
+                    + "it will do. Review it by hand before running it.");
+        }
+        var facts = parsed.get();
+
+        var request = credentialService.getDecryptedConnection(connectionId);
+        var dialect = registry.getDialect(request.getDbType());
+        var provider = dialect.migrationRisk();
+
+        TableFacts table = tableFacts(connectionId, request, facts.table());
+        return provider.classify(facts, table);
+    }
+
+    private TableFacts tableFacts(String connectionId, ConnectionRequest request, String table) {
+        try {
+            var jdbc = connectionService.getJdbcTemplate(connectionId, request);
+            var row = jdbc.queryForMap("""
+                    SELECT COALESCE(c.reltuples, 0)::bigint AS rows,
+                           COALESCE(pg_total_relation_size(c.oid), 0)::bigint AS bytes
+                    FROM pg_class c WHERE c.oid = ?::regclass
+                    """, table);
+            long rows = ((Number) row.get("rows")).longValue();
+            long bytes = ((Number) row.get("bytes")).longValue();
+            return new TableFacts(Math.max(rows, 0), bytes, rows == 0);
+        } catch (Exception e) {
+            // Unknown size is not a reason to claim safety — assume large.
+            log.warn("Could not read table facts for {}: {}", table, e.getMessage());
+            return new TableFacts(Long.MAX_VALUE, 0L, false);
+        }
+    }
+
+    private MigrationRiskReport failClosed(String reason) {
+        return new MigrationRiskReport("unknown", "UNKNOWN", false, true, "UNKNOWN", null,
+                List.of(), false, 0L, 0L, "unknown", reason, null, null, "unverified");
+    }
+}

--- a/backend/src/test/java/com/dbaagent/controller/ConnectionScopedAuthorizationSafetyTest.java
+++ b/backend/src/test/java/com/dbaagent/controller/ConnectionScopedAuthorizationSafetyTest.java
@@ -49,7 +49,7 @@ class ConnectionScopedAuthorizationSafetyTest {
 
     /**
      * Handlers whose authorization correctly lives one layer down, named as
-     * {@code Controller:line}. Two distinct reasons, and both matter:
+     * {@code Controller:line}. Three distinct reasons, and all matter:
      *
      * <ul>
      *   <li>{@code DashboardWorkspaceController} delegates to
@@ -61,6 +61,11 @@ class ConnectionScopedAuthorizationSafetyTest {
      *       so the {@code connectionId} there is a label on the caller's own conversation
      *       rather than a reference to someone else's data. There is no connection
      *       authorization to perform.
+     *   <li>{@code MigrationRiskController} delegates to {@code MigrationRiskService.analyze},
+     *       which asserts {@code assertCanReadConnectionContent} before parsing, credential
+     *       decryption or session opening. Same reasoning as {@code DashboardWorkspaceController}:
+     *       a second identical assert in the controller is not defence-in-depth (same
+     *       mechanism, same failure mode), only a second copy to keep in sync.
      * </ul>
      *
      * {@link #everyDelegatedCheckStillExists()} re-derives the first group, so removing the
@@ -71,12 +76,14 @@ class ConnectionScopedAuthorizationSafetyTest {
         "DashboardWorkspaceController.java:60",
         "AgentChatController.java:25",
         "AgentConversationController.java:29",
-        "AgentConversationController.java:45"
+        "AgentConversationController.java:45",
+        "MigrationRiskController.java:19"
     );
 
     /** Service methods that own a delegated connection check. */
     private static final List<String> DELEGATED_CHECKS = List.of(
-        "src/main/java/com/dbaagent/service/DashboardWorkspaceService.java"
+        "src/main/java/com/dbaagent/service/DashboardWorkspaceService.java",
+        "src/main/java/com/dbaagent/service/migration/MigrationRiskService.java"
     );
 
     /**

--- a/backend/src/test/java/com/dbaagent/provider/postgres/PostgresMigrationRiskRulesTest.java
+++ b/backend/src/test/java/com/dbaagent/provider/postgres/PostgresMigrationRiskRulesTest.java
@@ -1,0 +1,106 @@
+package com.dbaagent.provider.postgres;
+
+import com.dbaagent.dto.MigrationRiskReport;
+import com.dbaagent.dto.TableFacts;
+import com.dbaagent.service.migration.DdlFacts;
+import com.dbaagent.service.migration.DdlOperation;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PostgresMigrationRiskRulesTest {
+
+    private final PostgresMigrationRiskProvider provider = new PostgresMigrationRiskProvider();
+    private final TableFacts big = new TableFacts(48_000_000L, 9_200_000_000L, false);
+    private final TableFacts small = new TableFacts(500L, 40_000L, false);
+
+    private DdlFacts addColumn(String defaultFn, boolean notNull) {
+        return new DdlFacts(DdlOperation.ADD_COLUMN, "orders", "c", null, "text",
+                defaultFn == null ? null : "DEFAULT", defaultFn, notNull, false, false, null, "sql");
+    }
+
+    // MEASURED: now() is STABLE, so this does NOT rewrite.
+    @Test
+    void addColumnWithStableDefault_doesNotRewrite() {
+        var r = provider.classify(addColumn("now", false), big);
+        assertThat(r.rewritesTable()).isFalse();
+        assertThat(r.verdict()).isEqualTo("SAFE");
+    }
+
+    // MEASURED: gen_random_uuid() is VOLATILE, so this DOES rewrite.
+    @Test
+    void addColumnWithVolatileDefaultOnBigTable_isDanger() {
+        var r = provider.classify(addColumn("gen_random_uuid", false), big);
+        assertThat(r.rewritesTable()).isTrue();
+        assertThat(r.verdict()).isEqualTo("DANGER");
+        assertThat(r.saferAlternative()).isNotBlank();
+    }
+
+    @Test
+    void addColumnWithVolatileDefaultOnSmallTable_isCaution() {
+        var r = provider.classify(addColumn("random", false), small);
+        assertThat(r.rewritesTable()).isTrue();
+        assertThat(r.verdict()).isEqualTo("CAUTION");
+    }
+
+    @Test
+    void addColumnNotNullNoDefaultOnNonEmptyTable_isFailsOutright() {
+        var r = provider.classify(addColumn(null, true), big);
+        assertThat(r.verdict()).isEqualTo("FAILS");
+        assertThat(r.reason()).containsIgnoringCase("null values");
+    }
+
+    @Test
+    void addColumnPlain_isSafeEvenOnHugeTable() {
+        var r = provider.classify(addColumn(null, false), big);
+        assertThat(r.verdict()).isEqualTo("SAFE");
+        assertThat(r.locks()).anySatisfy(l -> assertThat(l.mode()).isEqualTo("AccessExclusiveLock"));
+    }
+
+    // MEASURED: FK locks BOTH tables.
+    @Test
+    void addForeignKey_reportsLockOnReferencedTableToo() {
+        var f = new DdlFacts(DdlOperation.ADD_FOREIGN_KEY, "child", null, null, null,
+                null, null, false, false, false, "orders", "sql");
+        var r = provider.classify(f, big);
+        assertThat(r.locks()).extracting(MigrationRiskReport.LockRef::table)
+                .containsExactlyInAnyOrder("child", "orders");
+    }
+
+    @Test
+    void addForeignKeyNotValid_isSaferThanValidating() {
+        var validating = new DdlFacts(DdlOperation.ADD_FOREIGN_KEY, "child", null, null, null,
+                null, null, false, false, false, "orders", "sql");
+        var notValid = new DdlFacts(DdlOperation.ADD_FOREIGN_KEY, "child", null, null, null,
+                null, null, false, true, false, "orders", "sql");
+        assertThat(provider.classify(validating, big).verdict()).isEqualTo("DANGER");
+        assertThat(provider.classify(notValid, big).verdict()).isEqualTo("CAUTION");
+    }
+
+    @Test
+    void createIndexConcurrently_isSafeAndPlainIsNot() {
+        var plain = new DdlFacts(DdlOperation.CREATE_INDEX, "orders", null, null, null,
+                null, null, false, false, false, null, "sql");
+        var conc = new DdlFacts(DdlOperation.CREATE_INDEX, "orders", null, null, null,
+                null, null, false, false, true, null, "sql");
+        assertThat(provider.classify(plain, big).verdict()).isEqualTo("DANGER");
+        assertThat(provider.classify(conc, big).verdict()).isEqualTo("SAFE");
+    }
+
+    @Test
+    void dropColumn_isMetadataOnly() {
+        var f = new DdlFacts(DdlOperation.DROP_COLUMN, "orders", "a", null, null,
+                null, null, false, false, false, null, "sql");
+        var r = provider.classify(f, big);
+        assertThat(r.rewritesTable()).isFalse();
+        assertThat(r.verdict()).isEqualTo("SAFE");
+    }
+
+    @Test
+    void unknownOperation_failsClosed() {
+        var f = new DdlFacts(DdlOperation.UNKNOWN, "orders", null, null, null,
+                null, null, false, false, false, null, "sql");
+        var r = provider.classify(f, big);
+        assertThat(r.verdict()).isEqualTo("UNKNOWN");
+        assertThat(r.safeToRun()).isFalse();
+    }
+}

--- a/backend/src/test/java/com/dbaagent/provider/postgres/PostgresMigrationRiskRulesTest.java
+++ b/backend/src/test/java/com/dbaagent/provider/postgres/PostgresMigrationRiskRulesTest.java
@@ -42,6 +42,25 @@ class PostgresMigrationRiskRulesTest {
         assertThat(r.verdict()).isEqualTo("CAUTION");
     }
 
+    // Finding 1 fix: an unrecognised default function must not be reported SAFE.
+    @Test
+    void addColumnWithUnrecognisedDefaultFunction_isCautionNotSafe() {
+        var r = provider.classify(addColumn("my_custom_uuid", false), big);
+        assertThat(r.verdict()).isEqualTo("CAUTION");
+        assertThat(r.safeToRun()).isFalse();
+        assertThat(r.rewritesTable()).isFalse();
+        assertThat(r.reason()).containsIgnoringCase("cannot verify");
+    }
+
+    @Test
+    void addColumnWithConstantDefault_isSafe() {
+        var f = new DdlFacts(DdlOperation.ADD_COLUMN, "orders", "c", null, "text",
+                "'x'", null, false, false, false, null, "sql");
+        var r = provider.classify(f, big);
+        assertThat(r.verdict()).isEqualTo("SAFE");
+        assertThat(r.rewritesTable()).isFalse();
+    }
+
     @Test
     void addColumnNotNullNoDefaultOnNonEmptyTable_isFailsOutright() {
         var r = provider.classify(addColumn(null, true), big);
@@ -93,6 +112,64 @@ class PostgresMigrationRiskRulesTest {
         var r = provider.classify(f, big);
         assertThat(r.rewritesTable()).isFalse();
         assertThat(r.verdict()).isEqualTo("SAFE");
+    }
+
+    @Test
+    void renameColumn_isMetadataOnly() {
+        var f = new DdlFacts(DdlOperation.RENAME_COLUMN, "orders", "a", "b", null,
+                null, null, false, false, false, null, "sql");
+        var r = provider.classify(f, big);
+        assertThat(r.rewritesTable()).isFalse();
+        assertThat(r.verdict()).isEqualTo("SAFE");
+    }
+
+    @Test
+    void alterColumnType_rewritesAndIsDangerOnBigTable() {
+        var f = new DdlFacts(DdlOperation.ALTER_COLUMN_TYPE, "orders", "c", null, "uuid",
+                null, null, false, false, false, null, "sql");
+        var r = provider.classify(f, big);
+        assertThat(r.rewritesTable()).isTrue();
+        assertThat(r.verdict()).isEqualTo("DANGER");
+        assertThat(r.safeToRun()).isFalse();
+    }
+
+    @Test
+    void setNotNull_isSafeOnSmallTableAndCautionOnLarge() {
+        var f = new DdlFacts(DdlOperation.SET_NOT_NULL, "orders", "c", null, null,
+                null, null, false, false, false, null, "sql");
+        var small = provider.classify(f, this.small);
+        var large = provider.classify(f, big);
+        assertThat(small.verdict()).isEqualTo("SAFE");
+        assertThat(small.rewritesTable()).isFalse();
+        assertThat(large.verdict()).isEqualTo("CAUTION");
+        assertThat(large.safeToRun()).isFalse();
+    }
+
+    @Test
+    void addCheckNotValid_isSafe() {
+        var f = new DdlFacts(DdlOperation.ADD_CHECK, "orders", null, null, null,
+                null, null, false, true, false, null, "sql");
+        var r = provider.classify(f, big);
+        assertThat(r.verdict()).isEqualTo("SAFE");
+    }
+
+    @Test
+    void addCheckValidating_isDangerOnBigTable() {
+        var f = new DdlFacts(DdlOperation.ADD_CHECK, "orders", null, null, null,
+                null, null, false, false, false, null, "sql");
+        var r = provider.classify(f, big);
+        assertThat(r.verdict()).isEqualTo("DANGER");
+        assertThat(r.safeToRun()).isFalse();
+    }
+
+    @Test
+    void validateConstraint_isSafe() {
+        var f = new DdlFacts(DdlOperation.VALIDATE_CONSTRAINT, "orders", null, null, null,
+                null, null, false, false, false, null, "sql");
+        var r = provider.classify(f, big);
+        assertThat(r.verdict()).isEqualTo("SAFE");
+        assertThat(r.rewritesTable()).isFalse();
+        assertThat(r.locks()).anySatisfy(l -> assertThat(l.mode()).isEqualTo("ShareUpdateExclusiveLock"));
     }
 
     @Test

--- a/backend/src/test/java/com/dbaagent/provider/postgres/PostgresMigrationRiskVerificationTest.java
+++ b/backend/src/test/java/com/dbaagent/provider/postgres/PostgresMigrationRiskVerificationTest.java
@@ -1,0 +1,181 @@
+package com.dbaagent.provider.postgres;
+
+import com.dbaagent.dto.TableFacts;
+import com.dbaagent.service.migration.DdlStatementParser;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.sql.*;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+class PostgresMigrationRiskVerificationTest {
+
+    @Container
+    static final PostgreSQLContainer<?> PG = new PostgreSQLContainer<>("postgres:18");
+
+    private static final List<String> LOCK_STRENGTH = List.of(
+            "AccessShareLock", "RowShareLock", "RowExclusiveLock", "ShareUpdateExclusiveLock",
+            "ShareLock", "ShareRowExclusiveLock", "ExclusiveLock", "AccessExclusiveLock");
+
+    private final DdlStatementParser parser = new DdlStatementParser();
+    private final PostgresMigrationRiskProvider provider = new PostgresMigrationRiskProvider();
+
+    private Connection conn;
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        conn = DriverManager.getConnection(PG.getJdbcUrl(), PG.getUsername(), PG.getPassword());
+        try (Statement s = conn.createStatement()) {
+            s.execute("DROP TABLE IF EXISTS child, t CASCADE");
+            s.execute("CREATE TABLE t (id bigserial primary key, a text)");
+            s.execute("INSERT INTO t (a) SELECT 'x' FROM generate_series(1,1000)");
+            s.execute("CREATE TABLE child (id bigserial primary key, t_id bigint)");
+            s.execute("INSERT INTO child (t_id) SELECT id FROM t LIMIT 500");
+        }
+    }
+
+    @AfterEach
+    void tearDown() throws SQLException { conn.close(); }
+
+    @ParameterizedTest(name = "{0} -> rewrites={1}")
+    @CsvSource({
+        "ALTER TABLE t ADD COLUMN c text,                                  false",
+        "ALTER TABLE t ADD COLUMN c text DEFAULT 'x',                      false",
+        "ALTER TABLE t ADD COLUMN c timestamptz DEFAULT now(),             false",
+        "ALTER TABLE t ADD COLUMN c uuid DEFAULT gen_random_uuid(),        true",
+        "ALTER TABLE t ADD COLUMN c double precision DEFAULT random(),     true",
+        "ALTER TABLE t ADD COLUMN c timestamptz DEFAULT clock_timestamp(), true",
+        "ALTER TABLE t ALTER COLUMN a TYPE varchar(50),                    true",
+        "ALTER TABLE t DROP COLUMN a,                                      false",
+        "ALTER TABLE t ALTER COLUMN a SET NOT NULL,                        false"
+    })
+    void ruleTableMatchesEngineRewriteBehaviour(String sql, boolean expectedRewrite) throws SQLException {
+        conn.setAutoCommit(false);
+        long before = filenode("t");
+        try (Statement s = conn.createStatement()) {
+            s.execute(sql);
+        }
+        long after = filenode("t");
+        conn.rollback();
+        conn.setAutoCommit(true);
+
+        boolean actuallyRewrote = before != after;
+        assertThat(actuallyRewrote)
+            .as("engine rewrite behaviour for: %s", sql)
+            .isEqualTo(expectedRewrite);
+
+        var facts = parser.parse(sql).orElseThrow();
+        var report = provider.classify(facts, new TableFacts(1000L, 40_000L, false));
+        assertThat(report.rewritesTable())
+            .as("rule table claim vs engine for: %s", sql)
+            .isEqualTo(actuallyRewrote);
+    }
+
+    // KNOWN RULE-TABLE LIMITATION (see task-3-report.md): widening within the same type
+    // family (varchar(50) -> varchar(100)) does NOT rewrite in real Postgres, but
+    // PostgresMigrationRiskProvider.alterType reports rewritesTable=true for every
+    // ALTER COLUMN TYPE, because DdlFacts carries only the new type, never the old one,
+    // so the provider cannot tell this case apart from a real rewrite. This test asserts
+    // the engine truth and the current (over-conservative) rule claim side by side rather
+    // than silently agreeing with a rule that cannot see what it would need to see.
+    @Test
+    void alterColumnType_wideningVarcharDoesNotRewrite_butRuleCannotKnowThat() throws SQLException {
+        try (Statement s = conn.createStatement()) {
+            s.execute("ALTER TABLE t ALTER COLUMN a TYPE varchar(50)");
+        }
+        conn.setAutoCommit(false);
+        long before = filenode("t");
+        try (Statement s = conn.createStatement()) {
+            s.execute("ALTER TABLE t ALTER COLUMN a TYPE varchar(100)");
+        }
+        long after = filenode("t");
+        conn.rollback();
+        conn.setAutoCommit(true);
+
+        assertThat(before).as("engine truth: widening varchar(50)->varchar(100) does not rewrite")
+                .isEqualTo(after);
+
+        var facts = parser.parse("ALTER TABLE t ALTER COLUMN a TYPE varchar(100)").orElseThrow();
+        var report = provider.classify(facts, new TableFacts(1000L, 40_000L, false));
+        assertThat(report.rewritesTable())
+                .as("known limitation: DdlFacts has no old column type, so the rule cannot "
+                        + "distinguish this widening from a real rewrite and conservatively "
+                        + "claims true")
+                .isTrue();
+    }
+
+    @Test
+    void addForeignKeyLocksBothTables() throws SQLException {
+        conn.setAutoCommit(false);
+        try (Statement s = conn.createStatement()) {
+            s.execute("ALTER TABLE child ADD CONSTRAINT fk FOREIGN KEY (t_id) REFERENCES t(id)");
+        }
+        assertThat(strongestLock("t")).isEqualTo("ShareRowExclusiveLock");
+        assertThat(strongestLock("child")).isEqualTo("ShareRowExclusiveLock");
+        conn.rollback();
+        conn.setAutoCommit(true);
+
+        var facts = parser.parse(
+            "ALTER TABLE child ADD CONSTRAINT fk FOREIGN KEY (t_id) REFERENCES t(id)").orElseThrow();
+        var report = provider.classify(facts, new TableFacts(1000L, 40_000L, false));
+        assertThat(report.locks()).extracting(l -> l.table())
+                .containsExactlyInAnyOrder("child", "t");
+    }
+
+    @Test
+    void addColumnNotNullWithoutDefaultReallyFails() {
+        assertThatThrownBy(() -> {
+            try (Statement s = conn.createStatement()) {
+                s.execute("ALTER TABLE t ADD COLUMN c5 text NOT NULL");
+            }
+        }).isInstanceOf(SQLException.class).hasMessageContaining("null values");
+    }
+
+    @Test
+    void volatilityClassificationMatchesCatalog() throws SQLException {
+        assertThat(volatility("now")).isEqualTo("s");
+        assertThat(volatility("random")).isEqualTo("v");
+        assertThat(volatility("gen_random_uuid")).isEqualTo("v");
+        assertThat(volatility("clock_timestamp")).isEqualTo("v");
+    }
+
+    private long filenode(String table) throws SQLException {
+        try (PreparedStatement p = conn.prepareStatement("SELECT pg_relation_filenode(?::regclass)")) {
+            p.setString(1, table);
+            try (ResultSet rs = p.executeQuery()) { rs.next(); return rs.getLong(1); }
+        }
+    }
+
+    private String strongestLock(String table) throws SQLException {
+        try (PreparedStatement p = conn.prepareStatement(
+                "SELECT mode FROM pg_locks WHERE relation = ?::regclass")) {
+            p.setString(1, table);
+            try (ResultSet rs = p.executeQuery()) {
+                String strongest = null;
+                while (rs.next()) {
+                    String m = rs.getString(1);
+                    if (strongest == null || LOCK_STRENGTH.indexOf(m) > LOCK_STRENGTH.indexOf(strongest)) {
+                        strongest = m;
+                    }
+                }
+                return strongest;
+            }
+        }
+    }
+
+    private String volatility(String fn) throws SQLException {
+        try (PreparedStatement p = conn.prepareStatement(
+                "SELECT provolatile FROM pg_proc WHERE proname = ? LIMIT 1")) {
+            p.setString(1, fn);
+            try (ResultSet rs = p.executeQuery()) { rs.next(); return rs.getString(1); }
+        }
+    }
+}

--- a/backend/src/test/java/com/dbaagent/service/migration/DdlStatementParserTest.java
+++ b/backend/src/test/java/com/dbaagent/service/migration/DdlStatementParserTest.java
@@ -120,4 +120,47 @@ class DdlStatementParserTest {
         assertThat(f.newColumnName()).isEqualTo("b");
         assertThat(f.column()).isNull();
     }
+
+    // The parser used to keep only the first of several statements, so a hidden DROP TABLE
+    // riding along after a harmless ALTER reported SAFE. Must fail closed instead.
+    @Test
+    void multiStatementSql_returnsEmptySoCallerFailsClosed() {
+        assertThat(parser.parse("ALTER TABLE t ADD COLUMN a text; DROP TABLE users;")).isEmpty();
+    }
+
+    @Test
+    void singleStatementWithTrailingSemicolon_stillParses() {
+        var f = parser.parse("ALTER TABLE orders ADD COLUMN a text;").orElseThrow();
+        assertThat(f.operation()).isEqualTo(DdlOperation.ADD_COLUMN);
+    }
+
+    // DROP CONSTRAINT shares operation=DROP with DROP COLUMN but names no column; it used to
+    // be misclassified as DROP_COLUMN with a false "metadata-only, VACUUM reclaims it" reason
+    // and locks that omitted the referenced table. Must fail closed instead.
+    @Test
+    void dropConstraint_returnsEmptySoCallerFailsClosed() {
+        assertThat(parser.parse("ALTER TABLE pc_child DROP CONSTRAINT fk")).isEmpty();
+    }
+
+    @Test
+    void dropConstraintCascade_returnsEmptySoCallerFailsClosed() {
+        assertThat(parser.parse("ALTER TABLE pc_child DROP CONSTRAINT fk CASCADE")).isEmpty();
+    }
+
+    // The DROP CONSTRAINT fix must not break the ordinary DROP COLUMN path it shares an
+    // operation code with.
+    @Test
+    void dropColumnStillClassifiesCorrectly_afterDropConstraintFix() {
+        var f = parser.parse("ALTER TABLE orders DROP COLUMN c").orElseThrow();
+        assertThat(f.operation()).isEqualTo(DdlOperation.DROP_COLUMN);
+        assertThat(f.column()).isEqualTo("c");
+    }
+
+    // DROP NOT NULL used to fall into the same weak ALTER branch as ALTER COLUMN TYPE and
+    // was misreported as a table-rewriting type change. It is metadata-only, but no existing
+    // rule models that correctly, so it must report UNKNOWN rather than a wrong DANGER.
+    @Test
+    void dropNotNull_returnsEmptySoCallerFailsClosed() {
+        assertThat(parser.parse("ALTER TABLE orders ALTER COLUMN a DROP NOT NULL")).isEmpty();
+    }
 }

--- a/backend/src/test/java/com/dbaagent/service/migration/DdlStatementParserTest.java
+++ b/backend/src/test/java/com/dbaagent/service/migration/DdlStatementParserTest.java
@@ -1,0 +1,86 @@
+package com.dbaagent.service.migration;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DdlStatementParserTest {
+
+    private final DdlStatementParser parser = new DdlStatementParser();
+
+    @Test
+    void addColumnWithVolatileDefault_extractsFunctionName() {
+        var f = parser.parse("ALTER TABLE orders ADD COLUMN c uuid DEFAULT gen_random_uuid()").orElseThrow();
+        assertThat(f.operation()).isEqualTo(DdlOperation.ADD_COLUMN);
+        assertThat(f.table()).isEqualTo("orders");
+        assertThat(f.column()).isEqualTo("c");
+        assertThat(f.defaultFunction()).isEqualTo("gen_random_uuid");
+    }
+
+    @Test
+    void addColumnWithoutDefault_hasNoDefaultFunction() {
+        var f = parser.parse("ALTER TABLE orders ADD COLUMN c text").orElseThrow();
+        assertThat(f.defaultFunction()).isNull();
+        assertThat(f.notNull()).isFalse();
+    }
+
+    @Test
+    void addColumnNotNull_setsFlag() {
+        var f = parser.parse("ALTER TABLE orders ADD COLUMN c text NOT NULL").orElseThrow();
+        assertThat(f.notNull()).isTrue();
+    }
+
+    // JSqlParser 5.2 cannot parse NOT VALID — the shim must strip it into a flag.
+    @Test
+    void addCheckNotValid_parsesViaShim() {
+        var f = parser.parse("ALTER TABLE orders ADD CONSTRAINT ck CHECK (id > 0) NOT VALID").orElseThrow();
+        assertThat(f.operation()).isEqualTo(DdlOperation.ADD_CHECK);
+        assertThat(f.notValid()).isTrue();
+    }
+
+    @Test
+    void addForeignKeyNotValid_capturesReferencedTable() {
+        var f = parser.parse(
+            "ALTER TABLE child ADD CONSTRAINT fk FOREIGN KEY (t_id) REFERENCES t(id) NOT VALID").orElseThrow();
+        assertThat(f.operation()).isEqualTo(DdlOperation.ADD_FOREIGN_KEY);
+        assertThat(f.notValid()).isTrue();
+        assertThat(f.referencedTable()).isEqualTo("t");
+    }
+
+    // JSqlParser 5.2 cannot parse CONCURRENTLY — the shim must strip it into a flag.
+    @Test
+    void createIndexConcurrently_parsesViaShim() {
+        var f = parser.parse("CREATE INDEX CONCURRENTLY idx ON orders (a)").orElseThrow();
+        assertThat(f.operation()).isEqualTo(DdlOperation.CREATE_INDEX);
+        assertThat(f.concurrently()).isTrue();
+        assertThat(f.table()).isEqualTo("orders");
+    }
+
+    @Test
+    void createIndexPlain_isNotConcurrent() {
+        var f = parser.parse("CREATE INDEX idx ON orders (a)").orElseThrow();
+        assertThat(f.concurrently()).isFalse();
+    }
+
+    @Test
+    void setNotNull_isDistinguishedFromAlterType() {
+        var f = parser.parse("ALTER TABLE orders ALTER COLUMN a SET NOT NULL").orElseThrow();
+        assertThat(f.operation()).isEqualTo(DdlOperation.SET_NOT_NULL);
+    }
+
+    @Test
+    void alterColumnType_capturesTargetType() {
+        var f = parser.parse("ALTER TABLE orders ALTER COLUMN a TYPE varchar(50)").orElseThrow();
+        assertThat(f.operation()).isEqualTo(DdlOperation.ALTER_COLUMN_TYPE);
+        assertThat(f.dataType()).containsIgnoringCase("varchar");
+    }
+
+    @Test
+    void garbageInput_returnsEmptySoCallerFailsClosed() {
+        assertThat(parser.parse("this is not sql at all")).isEmpty();
+    }
+
+    @Test
+    void selectStatement_returnsEmpty() {
+        assertThat(parser.parse("SELECT * FROM orders")).isEmpty();
+    }
+}

--- a/backend/src/test/java/com/dbaagent/service/migration/DdlStatementParserTest.java
+++ b/backend/src/test/java/com/dbaagent/service/migration/DdlStatementParserTest.java
@@ -1,7 +1,9 @@
 package com.dbaagent.service.migration;
 
 import org.junit.jupiter.api.Test;
+import java.time.Duration;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 class DdlStatementParserTest {
 
@@ -162,5 +164,31 @@ class DdlStatementParserTest {
     @Test
     void dropNotNull_returnsEmptySoCallerFailsClosed() {
         assertThat(parser.parse("ALTER TABLE orders ALTER COLUMN a DROP NOT NULL")).isEmpty();
+    }
+
+    // NOT VALID used to be detected with a regex whose \s+ tail was quadratic on attacker-
+    // controlled input (CodeQL alerts 152/153) — 80KB of padding stalled parse() for 35s.
+    // The index-based scan must stay linear regardless of how much whitespace precedes it.
+    @Test
+    void notValidDetection_staysFastOnAdversarialWhitespace() {
+        String sql = "ALTER TABLE orders ADD CONSTRAINT ck CHECK (id > 0) NOT VALID"
+            + " ".repeat(50_000);
+        assertTimeoutPreemptively(Duration.ofSeconds(2), () -> {
+            var f = parser.parse(sql).orElseThrow();
+            assertThat(f.notValid()).isTrue();
+        });
+    }
+
+    @Test
+    void notValidWithMultipleInternalSpaces_stillDetected() {
+        var f = parser.parse("ALTER TABLE orders ADD CONSTRAINT ck CHECK (id > 0) NOT    VALID").orElseThrow();
+        assertThat(f.notValid()).isTrue();
+    }
+
+    @Test
+    void notValidWithTrailingSemicolon_stillParsesAndDetected() {
+        var f = parser.parse("ALTER TABLE orders ADD CONSTRAINT ck CHECK (id > 0) NOT VALID;").orElseThrow();
+        assertThat(f.operation()).isEqualTo(DdlOperation.ADD_CHECK);
+        assertThat(f.notValid()).isTrue();
     }
 }

--- a/backend/src/test/java/com/dbaagent/service/migration/DdlStatementParserTest.java
+++ b/backend/src/test/java/com/dbaagent/service/migration/DdlStatementParserTest.java
@@ -83,4 +83,41 @@ class DdlStatementParserTest {
     void selectStatement_returnsEmpty() {
         assertThat(parser.parse("SELECT * FROM orders")).isEmpty();
     }
+
+    // A single DdlFacts cannot honestly represent two clauses; must fail closed rather than
+    // judge the statement on the harmless first clause alone.
+    @Test
+    void multiClauseAlter_returnsEmptySoCallerFailsClosed() {
+        assertThat(parser.parse(
+            "ALTER TABLE t ADD COLUMN a text, ADD COLUMN b uuid DEFAULT gen_random_uuid()")).isEmpty();
+    }
+
+    @Test
+    void addColumnNamedCheckFlag_isNotMisclassifiedAsAddCheck() {
+        var f = parser.parse("ALTER TABLE orders ADD COLUMN check_flag boolean DEFAULT true").orElseThrow();
+        assertThat(f.operation()).isEqualTo(DdlOperation.ADD_COLUMN);
+        assertThat(f.column()).isEqualTo("check_flag");
+    }
+
+    @Test
+    void addColumnDefaultLiteralMentioningReferences_hasNoReferencedTable() {
+        var f = parser.parse(
+            "ALTER TABLE t ADD COLUMN note text DEFAULT 'see references docs(1)'").orElseThrow();
+        assertThat(f.referencedTable()).isNull();
+    }
+
+    @Test
+    void dropColumn_capturesColumnName() {
+        var f = parser.parse("ALTER TABLE orders DROP COLUMN c").orElseThrow();
+        assertThat(f.operation()).isEqualTo(DdlOperation.DROP_COLUMN);
+        assertThat(f.column()).isEqualTo("c");
+    }
+
+    @Test
+    void renameColumn_capturesNewNameOnly() {
+        var f = parser.parse("ALTER TABLE orders RENAME COLUMN a TO b").orElseThrow();
+        assertThat(f.operation()).isEqualTo(DdlOperation.RENAME_COLUMN);
+        assertThat(f.newColumnName()).isEqualTo("b");
+        assertThat(f.column()).isNull();
+    }
 }

--- a/backend/src/test/java/com/dbaagent/service/migration/MigrationRiskServiceTest.java
+++ b/backend/src/test/java/com/dbaagent/service/migration/MigrationRiskServiceTest.java
@@ -1,0 +1,49 @@
+package com.dbaagent.service.migration;
+
+import com.dbaagent.dto.MigrationRiskReport;
+import com.dbaagent.provider.DatabaseProviderRegistry;
+import com.dbaagent.provider.postgres.PostgresMigrationRiskProvider;
+import com.dbaagent.service.ConnectionService;
+import com.dbaagent.service.CredentialService;
+import com.dbaagent.service.security.AccessControlService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class MigrationRiskServiceTest {
+
+    @Test
+    void unparseableSqlFailsClosedWithoutTouchingTheDatabase() {
+        var access = mock(AccessControlService.class);
+        var credentials = mock(CredentialService.class);
+        var connections = mock(ConnectionService.class);
+        var registry = mock(DatabaseProviderRegistry.class);
+
+        var service = new MigrationRiskService(new DdlStatementParser(), registry,
+                credentials, connections, access);
+
+        MigrationRiskReport r = service.analyze("conn-1", "this is not sql");
+
+        assertThat(r.verdict()).isEqualTo("UNKNOWN");
+        assertThat(r.safeToRun()).isFalse();
+        verify(access).assertCanReadConnectionContent("conn-1");
+        verifyNoInteractions(connections);   // never opens a session for garbage input
+    }
+
+    @Test
+    void authorizationIsAssertedBeforeAnyWork() {
+        var access = mock(AccessControlService.class);
+        doThrow(new RuntimeException("denied")).when(access).assertCanReadConnectionContent(anyString());
+        var service = new MigrationRiskService(new DdlStatementParser(),
+                mock(DatabaseProviderRegistry.class), mock(CredentialService.class),
+                mock(ConnectionService.class), access);
+
+        org.assertj.core.api.Assertions
+            .assertThatThrownBy(() -> service.analyze("conn-1", "ALTER TABLE t ADD COLUMN c text"))
+            .hasMessageContaining("denied");
+    }
+}

--- a/docs/superpowers/plans/2026-09-04-preflight-migration-review.md
+++ b/docs/superpowers/plans/2026-09-04-preflight-migration-review.md
@@ -1,0 +1,1435 @@
+# Pre-flight Migration Review Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a deterministic Postgres DDL risk analyzer, exposed as one MCP tool `analyze_migration`, that tells a user whether a migration will lock or rewrite a table before they run it.
+
+**Architecture:** Four stages — normalize/parse (JSqlParser 5.2 + a pre-parse shim), classify against a measured rule table, enrich with live catalog facts (`pg_proc.provolatile`, table size), and scale to a duration bucket. No LLM: the rules and the catalog decide the verdict, matching `IndexAdvisorService`. Reached through `DatabaseDialect` so there is no if/else on database type.
+
+**Tech Stack:** Java 25, Spring Boot 4, JSqlParser 5.2, JUnit 5, Testcontainers (Postgres 18), Node (MCP layer).
+
+**Spec:** `docs/superpowers/specs/2026-09-04-preflight-migration-review-design.md`
+
+## Global Constraints
+
+- **No JDK or Maven on this host.** All Java build/test runs go through Docker:
+  `docker run --rm -v "$PWD/backend:/app" -v "$HOME/.m2:/root/.m2" -w /app eclipse-temurin:25-jdk-noble bash -c "apt-get update -qq && apt-get install -y -qq maven && mvn <goal>"`.
+  Prefer adding a helper script over retyping this.
+- **Fail closed.** Anything unparsed, unrecognised, or non-Postgres returns
+  `verdict=UNKNOWN, safeToRun=false`. Never "looks fine".
+- **No if/else on database type** — resolve via `DatabaseProviderRegistry.getDialect(dbType)`.
+- **Authorization is not automatic.** Any endpoint taking a `connectionId` must call
+  `accessControlService.assertCanReadConnectionContent(connectionId)` itself.
+- **Read-only.** The analyzer never executes the DDL it analyses. Catalog queries only.
+- Postgres only. MySQL returns `UNKNOWN` with `dialectSupported=false` — never a guess.
+- Rule table is tagged `postgres>=11`, verified on 18.4.
+
+## Verified facts this plan depends on
+
+Measured during design, not recalled. Do not "correct" these from memory:
+
+- `now()` is **STABLE** (`provolatile='s'`) → `ADD COLUMN ... DEFAULT now()` does **not** rewrite.
+  `random()`, `gen_random_uuid()`, `clock_timestamp()` are **VOLATILE** (`'v'`) → they **do**.
+- `ADD FOREIGN KEY` takes `ShareRowExclusiveLock` on **both** child and referenced table.
+- `max(mode)` on `pg_locks` sorts **alphabetically** — "ShareLock" > "AccessExclusiveLock".
+  Rank by explicit strength ordering, never string comparison.
+- **JSqlParser 5.2 cannot parse** `... NOT VALID`, `CREATE INDEX CONCURRENTLY`.
+  A pre-parse shim strips them into flags; verified working.
+- JSqlParser quirks: `RENAME COLUMN a TO b` exposes only the **new** name via
+  `getColumnName()`; `SET NOT NULL` arrives as `type=SET`, `specs=[NOT, NULL]`;
+  `VALIDATE CONSTRAINT` degrades to `operation=UNSPECIFIC`.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `provider/api/MigrationRiskProvider.java` | Interface: classify a parsed fact set → risk |
+| `provider/api/DatabaseDialect.java` (modify) | Add `migrationRisk()` accessor |
+| `provider/postgres/PostgresMigrationRiskProvider.java` | Postgres rule table + catalog enrichment |
+| `provider/postgres/PostgresDialect.java` (modify) | Wire the new provider |
+| `provider/mysql/MySQLMigrationRiskProvider.java` | Returns UNKNOWN, `dialectSupported=false` |
+| `provider/mysql/MySQLDialect.java` (modify) | Wire the stub |
+| `service/migration/DdlStatementParser.java` | Normalize shim + JSqlParser → `DdlFacts` |
+| `service/migration/DdlFacts.java` | Record: operation, table, column, type, default, flags |
+| `service/migration/MigrationRiskService.java` | Orchestrates parse → classify → enrich |
+| `dto/MigrationRiskReport.java` | Response record (locks are **per table**) |
+| `controller/MigrationRiskController.java` | `POST /migrations/analyze`, asserts read access |
+| `test/.../DdlStatementParserTest.java` | Parser unit tests incl. the three shim cases |
+| `test/.../PostgresMigrationRiskRulesTest.java` | Rule table unit tests |
+| `test/.../PostgresMigrationRiskVerificationTest.java` | **Testcontainers: engine proves each rule** |
+| `mcp/deepsql-phase1-lib.js` (modify) | Tool definition + handler + result + summarizer |
+| `mcp/src/commands/migration.js` | CLI subcommand |
+| `mcp/src/cli.js` (modify) | Help text |
+
+---
+
+### Task 1: DDL parser with the normalization shim
+
+**Files:**
+- Create: `backend/src/main/java/com/dbaagent/service/migration/DdlFacts.java`
+- Create: `backend/src/main/java/com/dbaagent/service/migration/DdlStatementParser.java`
+- Test: `backend/src/test/java/com/dbaagent/service/migration/DdlStatementParserTest.java`
+
+**Interfaces:**
+- Consumes: JSqlParser 5.2 (`CCJSqlParserUtil`, `Alter`, `AlterExpression`, `CreateIndex`).
+- Produces: `DdlFacts` record and `DdlStatementParser.parse(String sql) -> Optional<DdlFacts>`
+  (empty = unparseable = caller must fail closed).
+
+`DdlFacts` fields:
+`DdlOperation operation, String table, String column, String newColumnName, String dataType,
+ String defaultExpression, String defaultFunction, boolean notNull, boolean notValid,
+ boolean concurrently, String referencedTable, String rawSql`
+
+`DdlOperation` enum:
+`ADD_COLUMN, DROP_COLUMN, RENAME_COLUMN, ALTER_COLUMN_TYPE, SET_NOT_NULL,
+ ADD_CHECK, ADD_FOREIGN_KEY, VALIDATE_CONSTRAINT, CREATE_INDEX, UNKNOWN`
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+package com.dbaagent.service.migration;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DdlStatementParserTest {
+
+    private final DdlStatementParser parser = new DdlStatementParser();
+
+    @Test
+    void addColumnWithVolatileDefault_extractsFunctionName() {
+        var f = parser.parse("ALTER TABLE orders ADD COLUMN c uuid DEFAULT gen_random_uuid()").orElseThrow();
+        assertThat(f.operation()).isEqualTo(DdlOperation.ADD_COLUMN);
+        assertThat(f.table()).isEqualTo("orders");
+        assertThat(f.column()).isEqualTo("c");
+        assertThat(f.defaultFunction()).isEqualTo("gen_random_uuid");
+    }
+
+    @Test
+    void addColumnWithoutDefault_hasNoDefaultFunction() {
+        var f = parser.parse("ALTER TABLE orders ADD COLUMN c text").orElseThrow();
+        assertThat(f.defaultFunction()).isNull();
+        assertThat(f.notNull()).isFalse();
+    }
+
+    @Test
+    void addColumnNotNull_setsFlag() {
+        var f = parser.parse("ALTER TABLE orders ADD COLUMN c text NOT NULL").orElseThrow();
+        assertThat(f.notNull()).isTrue();
+    }
+
+    // JSqlParser 5.2 cannot parse NOT VALID — the shim must strip it into a flag.
+    @Test
+    void addCheckNotValid_parsesViaShim() {
+        var f = parser.parse("ALTER TABLE orders ADD CONSTRAINT ck CHECK (id > 0) NOT VALID").orElseThrow();
+        assertThat(f.operation()).isEqualTo(DdlOperation.ADD_CHECK);
+        assertThat(f.notValid()).isTrue();
+    }
+
+    @Test
+    void addForeignKeyNotValid_capturesReferencedTable() {
+        var f = parser.parse(
+            "ALTER TABLE child ADD CONSTRAINT fk FOREIGN KEY (t_id) REFERENCES t(id) NOT VALID").orElseThrow();
+        assertThat(f.operation()).isEqualTo(DdlOperation.ADD_FOREIGN_KEY);
+        assertThat(f.notValid()).isTrue();
+        assertThat(f.referencedTable()).isEqualTo("t");
+    }
+
+    // JSqlParser 5.2 cannot parse CONCURRENTLY — the shim must strip it into a flag.
+    @Test
+    void createIndexConcurrently_parsesViaShim() {
+        var f = parser.parse("CREATE INDEX CONCURRENTLY idx ON orders (a)").orElseThrow();
+        assertThat(f.operation()).isEqualTo(DdlOperation.CREATE_INDEX);
+        assertThat(f.concurrently()).isTrue();
+        assertThat(f.table()).isEqualTo("orders");
+    }
+
+    @Test
+    void createIndexPlain_isNotConcurrent() {
+        var f = parser.parse("CREATE INDEX idx ON orders (a)").orElseThrow();
+        assertThat(f.concurrently()).isFalse();
+    }
+
+    @Test
+    void setNotNull_isDistinguishedFromAlterType() {
+        var f = parser.parse("ALTER TABLE orders ALTER COLUMN a SET NOT NULL").orElseThrow();
+        assertThat(f.operation()).isEqualTo(DdlOperation.SET_NOT_NULL);
+    }
+
+    @Test
+    void alterColumnType_capturesTargetType() {
+        var f = parser.parse("ALTER TABLE orders ALTER COLUMN a TYPE varchar(50)").orElseThrow();
+        assertThat(f.operation()).isEqualTo(DdlOperation.ALTER_COLUMN_TYPE);
+        assertThat(f.dataType()).containsIgnoringCase("varchar");
+    }
+
+    @Test
+    void garbageInput_returnsEmptySoCallerFailsClosed() {
+        assertThat(parser.parse("this is not sql at all")).isEmpty();
+    }
+
+    @Test
+    void selectStatement_returnsEmpty() {
+        assertThat(parser.parse("SELECT * FROM orders")).isEmpty();
+    }
+}
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `./scripts/jtest.sh -Dtest=DdlStatementParserTest`
+Expected: compilation failure — `DdlStatementParser` does not exist.
+
+(Create `scripts/jtest.sh` first — see Task 0 note below.)
+
+- [ ] **Step 3: Implement `DdlFacts` and `DdlOperation`**
+
+```java
+package com.dbaagent.service.migration;
+
+public enum DdlOperation {
+    ADD_COLUMN, DROP_COLUMN, RENAME_COLUMN, ALTER_COLUMN_TYPE, SET_NOT_NULL,
+    ADD_CHECK, ADD_FOREIGN_KEY, VALIDATE_CONSTRAINT, CREATE_INDEX, UNKNOWN
+}
+```
+
+```java
+package com.dbaagent.service.migration;
+
+public record DdlFacts(
+        DdlOperation operation,
+        String table,
+        String column,
+        String newColumnName,
+        String dataType,
+        String defaultExpression,
+        String defaultFunction,
+        boolean notNull,
+        boolean notValid,
+        boolean concurrently,
+        String referencedTable,
+        String rawSql) {}
+```
+
+- [ ] **Step 4: Implement the parser**
+
+The shim is load-bearing: JSqlParser 5.2 throws on `NOT VALID` and `CONCURRENTLY`,
+both of which are the *safe* forms this tool recommends.
+
+```java
+package com.dbaagent.service.migration;
+
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.alter.Alter;
+import net.sf.jsqlparser.statement.alter.AlterExpression;
+import net.sf.jsqlparser.statement.create.index.CreateIndex;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+@Component
+public class DdlStatementParser {
+
+    private static final Pattern NOT_VALID = Pattern.compile("(?i)\\s+NOT\\s+VALID\\s*;?\\s*$");
+    private static final Pattern CONCURRENTLY =
+            Pattern.compile("(?i)\\bCREATE\\s+(UNIQUE\\s+)?INDEX\\s+CONCURRENTLY\\b");
+    private static final Pattern DEFAULT_FN =
+            Pattern.compile("(?i)DEFAULT\\s+([a-z_][a-z0-9_]*)\\s*\\(");
+    private static final Pattern REFERENCES =
+            Pattern.compile("(?i)REFERENCES\\s+([a-z_][a-z0-9_.\"]*)\\s*\\(");
+    private static final Pattern VALIDATE_CONSTRAINT =
+            Pattern.compile("(?i)^\\s*ALTER\\s+TABLE\\s+(\\S+)\\s+VALIDATE\\s+CONSTRAINT\\b");
+
+    public Optional<DdlFacts> parse(String sql) {
+        if (sql == null || sql.isBlank()) return Optional.empty();
+
+        boolean notValid = NOT_VALID.matcher(sql).find();
+        String normalized = notValid ? NOT_VALID.matcher(sql).replaceAll("") : sql;
+
+        boolean concurrently = CONCURRENTLY.matcher(normalized).find();
+        if (concurrently) {
+            normalized = CONCURRENTLY.matcher(normalized)
+                    .replaceAll(m -> "CREATE " + (m.group(1) == null ? "" : m.group(1)) + "INDEX");
+        }
+
+        // VALIDATE CONSTRAINT degrades to UNSPECIFIC in JSqlParser; match it textually first.
+        var vc = VALIDATE_CONSTRAINT.matcher(sql);
+        if (vc.find()) {
+            return Optional.of(new DdlFacts(DdlOperation.VALIDATE_CONSTRAINT, strip(vc.group(1)),
+                    null, null, null, null, null, false, notValid, false, null, sql));
+        }
+
+        Statement stmt;
+        try {
+            stmt = CCJSqlParserUtil.parse(normalized);
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+
+        if (stmt instanceof CreateIndex ci) {
+            return Optional.of(new DdlFacts(DdlOperation.CREATE_INDEX,
+                    strip(ci.getTable().getName()), null, null, null, null, null,
+                    false, notValid, concurrently, null, sql));
+        }
+        if (stmt instanceof Alter alter) {
+            return fromAlter(alter, sql, notValid);
+        }
+        return Optional.empty();
+    }
+
+    private Optional<DdlFacts> fromAlter(Alter alter, String rawSql, boolean notValid) {
+        List<AlterExpression> exprs = alter.getAlterExpressions();
+        if (exprs == null || exprs.isEmpty()) return Optional.empty();
+        AlterExpression e = exprs.get(0);
+        String table = strip(alter.getTable().getName());
+        String op = e.getOperation() == null ? "" : e.getOperation().name().toUpperCase(Locale.ROOT);
+
+        if ("DROP".equals(op)) {
+            return Optional.of(new DdlFacts(DdlOperation.DROP_COLUMN, table, strip(e.getColumnName()),
+                    null, null, null, null, false, notValid, false, null, rawSql));
+        }
+        if ("RENAME".equals(op)) {
+            // JSqlParser exposes only the NEW name here; the old name is not recoverable.
+            return Optional.of(new DdlFacts(DdlOperation.RENAME_COLUMN, table, null,
+                    strip(e.getColumnName()), null, null, null, false, notValid, false, null, rawSql));
+        }
+        if ("ADD".equals(op)) {
+            if (e.getIndex() != null && e.getIndex().getType() != null
+                    && e.getIndex().getType().toUpperCase(Locale.ROOT).contains("FOREIGN")) {
+                return Optional.of(new DdlFacts(DdlOperation.ADD_FOREIGN_KEY, table, null, null, null,
+                        null, null, false, notValid, false, referencedTable(rawSql), rawSql));
+            }
+            if (rawSql.toUpperCase(Locale.ROOT).contains("CHECK")) {
+                return Optional.of(new DdlFacts(DdlOperation.ADD_CHECK, table, null, null, null,
+                        null, null, false, notValid, false, null, rawSql));
+            }
+            if (e.getColDataTypeList() != null && !e.getColDataTypeList().isEmpty()) {
+                var cdt = e.getColDataTypeList().get(0);
+                List<String> specs = cdt.getColumnSpecs() == null ? List.of() : cdt.getColumnSpecs();
+                String joined = String.join(" ", specs).toUpperCase(Locale.ROOT);
+                return Optional.of(new DdlFacts(DdlOperation.ADD_COLUMN, table,
+                        strip(cdt.getColumnName()), null,
+                        String.valueOf(cdt.getColDataType()), joined.contains("DEFAULT") ? joined : null,
+                        defaultFunction(rawSql), joined.contains("NOT NULL"),
+                        notValid, false, null, rawSql));
+            }
+        }
+        if ("ALTER".equals(op) && e.getColDataTypeList() != null && !e.getColDataTypeList().isEmpty()) {
+            var cdt = e.getColDataTypeList().get(0);
+            String type = String.valueOf(cdt.getColDataType());
+            // "SET NOT NULL" arrives with type=SET, specs=[NOT, NULL].
+            if ("SET".equalsIgnoreCase(type)) {
+                return Optional.of(new DdlFacts(DdlOperation.SET_NOT_NULL, table,
+                        strip(cdt.getColumnName()), null, null, null, null, true,
+                        notValid, false, null, rawSql));
+            }
+            return Optional.of(new DdlFacts(DdlOperation.ALTER_COLUMN_TYPE, table,
+                    strip(cdt.getColumnName()), null, type, null, null, false,
+                    notValid, false, null, rawSql));
+        }
+        return Optional.empty();
+    }
+
+    private String defaultFunction(String sql) {
+        var m = DEFAULT_FN.matcher(sql);
+        return m.find() ? m.group(1).toLowerCase(Locale.ROOT) : null;
+    }
+
+    private String referencedTable(String sql) {
+        var m = REFERENCES.matcher(sql);
+        return m.find() ? strip(m.group(1)) : null;
+    }
+
+    private String strip(String s) {
+        return s == null ? null : s.replace("\"", "");
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests and confirm they pass**
+
+Run: `./scripts/jtest.sh -Dtest=DdlStatementParserTest`
+Expected: PASS, 11 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/main/java/com/dbaagent/service/migration backend/src/test/java/com/dbaagent/service/migration scripts/jtest.sh
+git commit -m "feat: DDL statement parser with JSqlParser 5.2 normalization shim"
+```
+
+**Task 0 note (fold into Step 2):** create `scripts/jtest.sh`:
+
+```bash
+#!/usr/bin/env bash
+# No JDK on the host — run Maven goals in the same JDK image the backend builds with.
+set -euo pipefail
+exec docker run --rm \
+  -v "$(git rev-parse --show-toplevel)/backend:/app" \
+  -v "$HOME/.m2:/root/.m2" \
+  -w /app maven:3-eclipse-temurin-25 \
+  mvn -q -o test "$@"
+```
+
+---
+
+### Task 2: The rule table
+
+**Files:**
+- Create: `backend/src/main/java/com/dbaagent/provider/api/MigrationRiskProvider.java`
+- Create: `backend/src/main/java/com/dbaagent/dto/MigrationRiskReport.java`
+- Create: `backend/src/main/java/com/dbaagent/provider/postgres/PostgresMigrationRiskProvider.java`
+- Test: `backend/src/test/java/com/dbaagent/provider/postgres/PostgresMigrationRiskRulesTest.java`
+
+**Interfaces:**
+- Consumes: `DdlFacts`, `DdlOperation` from Task 1.
+- Produces: `MigrationRiskProvider.classify(DdlFacts facts, TableFacts table) -> MigrationRiskReport`,
+  `MigrationRiskReport` record, `TableFacts(long rowEstimate, long sizeBytes, boolean empty)`,
+  `LockRef(String table, String mode, List<String> blocks)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+package com.dbaagent.provider.postgres;
+
+import com.dbaagent.dto.MigrationRiskReport;
+import com.dbaagent.dto.TableFacts;
+import com.dbaagent.service.migration.DdlFacts;
+import com.dbaagent.service.migration.DdlOperation;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PostgresMigrationRiskRulesTest {
+
+    private final PostgresMigrationRiskProvider provider = new PostgresMigrationRiskProvider();
+    private final TableFacts big = new TableFacts(48_000_000L, 9_200_000_000L, false);
+    private final TableFacts small = new TableFacts(500L, 40_000L, false);
+
+    private DdlFacts addColumn(String defaultFn, boolean notNull) {
+        return new DdlFacts(DdlOperation.ADD_COLUMN, "orders", "c", null, "text",
+                defaultFn == null ? null : "DEFAULT", defaultFn, notNull, false, false, null, "sql");
+    }
+
+    // MEASURED: now() is STABLE, so this does NOT rewrite.
+    @Test
+    void addColumnWithStableDefault_doesNotRewrite() {
+        var r = provider.classify(addColumn("now", false), big);
+        assertThat(r.rewritesTable()).isFalse();
+        assertThat(r.verdict()).isEqualTo("SAFE");
+    }
+
+    // MEASURED: gen_random_uuid() is VOLATILE, so this DOES rewrite.
+    @Test
+    void addColumnWithVolatileDefaultOnBigTable_isDanger() {
+        var r = provider.classify(addColumn("gen_random_uuid", false), big);
+        assertThat(r.rewritesTable()).isTrue();
+        assertThat(r.verdict()).isEqualTo("DANGER");
+        assertThat(r.saferAlternative()).isNotBlank();
+    }
+
+    @Test
+    void addColumnWithVolatileDefaultOnSmallTable_isCaution() {
+        var r = provider.classify(addColumn("random", false), small);
+        assertThat(r.rewritesTable()).isTrue();
+        assertThat(r.verdict()).isEqualTo("CAUTION");
+    }
+
+    @Test
+    void addColumnNotNullNoDefaultOnNonEmptyTable_isFailsOutright() {
+        var r = provider.classify(addColumn(null, true), big);
+        assertThat(r.verdict()).isEqualTo("FAILS");
+        assertThat(r.reason()).containsIgnoringCase("null values");
+    }
+
+    @Test
+    void addColumnPlain_isSafeEvenOnHugeTable() {
+        var r = provider.classify(addColumn(null, false), big);
+        assertThat(r.verdict()).isEqualTo("SAFE");
+        assertThat(r.locks()).anySatisfy(l -> assertThat(l.mode()).isEqualTo("AccessExclusiveLock"));
+    }
+
+    // MEASURED: FK locks BOTH tables.
+    @Test
+    void addForeignKey_reportsLockOnReferencedTableToo() {
+        var f = new DdlFacts(DdlOperation.ADD_FOREIGN_KEY, "child", null, null, null,
+                null, null, false, false, false, "orders", "sql");
+        var r = provider.classify(f, big);
+        assertThat(r.locks()).extracting(MigrationRiskReport.LockRef::table)
+                .containsExactlyInAnyOrder("child", "orders");
+    }
+
+    @Test
+    void addForeignKeyNotValid_isSaferThanValidating() {
+        var validating = new DdlFacts(DdlOperation.ADD_FOREIGN_KEY, "child", null, null, null,
+                null, null, false, false, false, "orders", "sql");
+        var notValid = new DdlFacts(DdlOperation.ADD_FOREIGN_KEY, "child", null, null, null,
+                null, null, false, true, false, "orders", "sql");
+        assertThat(provider.classify(validating, big).verdict()).isEqualTo("DANGER");
+        assertThat(provider.classify(notValid, big).verdict()).isEqualTo("CAUTION");
+    }
+
+    @Test
+    void createIndexConcurrently_isSafeAndPlainIsNot() {
+        var plain = new DdlFacts(DdlOperation.CREATE_INDEX, "orders", null, null, null,
+                null, null, false, false, false, null, "sql");
+        var conc = new DdlFacts(DdlOperation.CREATE_INDEX, "orders", null, null, null,
+                null, null, false, false, true, null, "sql");
+        assertThat(provider.classify(plain, big).verdict()).isEqualTo("DANGER");
+        assertThat(provider.classify(conc, big).verdict()).isEqualTo("SAFE");
+    }
+
+    @Test
+    void dropColumn_isMetadataOnly() {
+        var f = new DdlFacts(DdlOperation.DROP_COLUMN, "orders", "a", null, null,
+                null, null, false, false, false, null, "sql");
+        var r = provider.classify(f, big);
+        assertThat(r.rewritesTable()).isFalse();
+        assertThat(r.verdict()).isEqualTo("SAFE");
+    }
+
+    @Test
+    void unknownOperation_failsClosed() {
+        var f = new DdlFacts(DdlOperation.UNKNOWN, "orders", null, null, null,
+                null, null, false, false, false, null, "sql");
+        var r = provider.classify(f, big);
+        assertThat(r.verdict()).isEqualTo("UNKNOWN");
+        assertThat(r.safeToRun()).isFalse();
+    }
+}
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `./scripts/jtest.sh -Dtest=PostgresMigrationRiskRulesTest`
+Expected: compilation failure — classes do not exist.
+
+- [ ] **Step 3: Implement the DTOs**
+
+```java
+package com.dbaagent.dto;
+
+public record TableFacts(long rowEstimate, long sizeBytes, boolean empty) {}
+```
+
+```java
+package com.dbaagent.dto;
+
+import java.util.List;
+
+public record MigrationRiskReport(
+        String dialect,
+        String verdict,            // SAFE | CAUTION | DANGER | FAILS | UNKNOWN
+        boolean safeToRun,
+        boolean dialectSupported,
+        String operation,
+        String table,
+        List<LockRef> locks,       // per table — a statement can lock tables it does not name
+        boolean rewritesTable,
+        long tableRows,
+        long tableSizeBytes,
+        String estimatedDuration,  // coarse bucket, never a number
+        String reason,
+        String saferAlternative,
+        String docsUrl,
+        String confidence) {
+
+    public record LockRef(String table, String mode, List<String> blocks) {}
+}
+```
+
+- [ ] **Step 4: Implement the provider interface and Postgres rules**
+
+```java
+package com.dbaagent.provider.api;
+
+import com.dbaagent.dto.MigrationRiskReport;
+import com.dbaagent.dto.TableFacts;
+import com.dbaagent.service.migration.DdlFacts;
+
+public interface MigrationRiskProvider {
+    MigrationRiskReport classify(DdlFacts facts, TableFacts table);
+}
+```
+
+`PostgresMigrationRiskProvider` implements the measured table. Key points:
+- `LARGE_ROWS = 1_000_000L` separates CAUTION from DANGER for rewriting operations.
+- Volatility is decided by the caller (Task 3) passing `defaultFunction`; the provider
+  keeps a fallback set `{random, gen_random_uuid, clock_timestamp, uuid_generate_v4}`
+  for when the catalog is unavailable, and treats `now`/`current_timestamp` as stable.
+- Every branch sets `docsUrl` to
+  `https://www.postgresql.org/docs/18/sql-altertable.html` (or `sql-createindex.html`).
+- Duration buckets: `"milliseconds"`, `"seconds"`, `"minutes"`,
+  `"minutes-to-tens-of-minutes"`, `"unknown"`.
+
+```java
+package com.dbaagent.provider.postgres;
+
+import com.dbaagent.dto.MigrationRiskReport;
+import com.dbaagent.dto.MigrationRiskReport.LockRef;
+import com.dbaagent.dto.TableFacts;
+import com.dbaagent.provider.api.MigrationRiskProvider;
+import com.dbaagent.service.migration.DdlFacts;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Set;
+
+@Component
+public class PostgresMigrationRiskProvider implements MigrationRiskProvider {
+
+    private static final long LARGE_ROWS = 1_000_000L;
+    private static final String ALTER_DOCS = "https://www.postgresql.org/docs/18/sql-altertable.html";
+    private static final String INDEX_DOCS = "https://www.postgresql.org/docs/18/sql-createindex.html";
+    private static final Set<String> VOLATILE_FALLBACK =
+            Set.of("random", "gen_random_uuid", "clock_timestamp", "uuid_generate_v4");
+
+    private static final List<String> RW = List.of("read", "write");
+    private static final List<String> W = List.of("write");
+
+    @Override
+    public MigrationRiskReport classify(DdlFacts f, TableFacts t) {
+        return switch (f.operation()) {
+            case ADD_COLUMN -> addColumn(f, t);
+            case DROP_COLUMN -> metadataOnly(f, t, "Dropping a column is metadata-only; the data is reclaimed later by VACUUM.");
+            case RENAME_COLUMN -> metadataOnly(f, t, "Renaming is metadata-only, but it will break application code referencing the old name.");
+            case ALTER_COLUMN_TYPE -> alterType(f, t);
+            case SET_NOT_NULL -> setNotNull(f, t);
+            case ADD_CHECK -> addCheck(f, t);
+            case ADD_FOREIGN_KEY -> addForeignKey(f, t);
+            case VALIDATE_CONSTRAINT -> validateConstraint(f, t);
+            case CREATE_INDEX -> createIndex(f, t);
+            case UNKNOWN -> unknown(f, t);
+        };
+    }
+
+    private boolean isVolatile(String fn) {
+        return fn != null && VOLATILE_FALLBACK.contains(fn.toLowerCase());
+    }
+
+    private String bucket(TableFacts t) {
+        if (t.rowEstimate() >= 10_000_000L) return "minutes-to-tens-of-minutes";
+        if (t.rowEstimate() >= LARGE_ROWS) return "minutes";
+        return "seconds";
+    }
+
+    private MigrationRiskReport addColumn(DdlFacts f, TableFacts t) {
+        var locks = List.of(new LockRef(f.table(), "AccessExclusiveLock", RW));
+        if (f.notNull() && f.defaultFunction() == null && f.defaultExpression() == null && !t.empty()) {
+            return report("FAILS", false, f, t, locks, false, "milliseconds",
+                    "ADD COLUMN ... NOT NULL without a default fails on a non-empty table: "
+                    + "the existing rows contain null values.",
+                    "Add the column nullable, backfill in batches, then SET NOT NULL.", ALTER_DOCS);
+        }
+        if (isVolatile(f.defaultFunction())) {
+            boolean big = t.rowEstimate() >= LARGE_ROWS;
+            return report(big ? "DANGER" : "CAUTION", false, f, t, locks, true, bucket(t),
+                    "Default expression " + f.defaultFunction()
+                    + "() is VOLATILE, so every existing row must be written — a full table rewrite "
+                    + "under ACCESS EXCLUSIVE, blocking reads and writes for the whole operation.",
+                    "Add the column without a default, backfill in batches, then set the default "
+                    + "for future rows.", ALTER_DOCS);
+        }
+        return report("SAFE", true, f, t, locks, false, "milliseconds",
+                "Adding a column with no default, a constant default, or a STABLE default "
+                + "(such as now()) is metadata-only in PostgreSQL 11+. The ACCESS EXCLUSIVE lock "
+                + "is held only briefly.", null, ALTER_DOCS);
+    }
+
+    private MigrationRiskReport metadataOnly(DdlFacts f, TableFacts t, String why) {
+        return report("SAFE", true, f, t,
+                List.of(new LockRef(f.table(), "AccessExclusiveLock", RW)),
+                false, "milliseconds", why, null, ALTER_DOCS);
+    }
+
+    private MigrationRiskReport alterType(DdlFacts f, TableFacts t) {
+        boolean big = t.rowEstimate() >= LARGE_ROWS;
+        return report(big ? "DANGER" : "CAUTION", false, f, t,
+                List.of(new LockRef(f.table(), "AccessExclusiveLock", RW)),
+                true, bucket(t),
+                "Changing a column type generally rewrites the whole table under ACCESS EXCLUSIVE. "
+                + "(Widening within the same type family — varchar(50) to varchar(100) — is the "
+                + "exception and does not rewrite.)",
+                "Add a new column, backfill in batches, swap the names, then drop the old column.",
+                ALTER_DOCS);
+    }
+
+    private MigrationRiskReport setNotNull(DdlFacts f, TableFacts t) {
+        return report(t.rowEstimate() >= LARGE_ROWS ? "CAUTION" : "SAFE",
+                t.rowEstimate() < LARGE_ROWS, f, t,
+                List.of(new LockRef(f.table(), "AccessExclusiveLock", RW)),
+                false, bucket(t),
+                "SET NOT NULL does not rewrite the table, but it scans every row to validate, "
+                + "holding ACCESS EXCLUSIVE for the duration of the scan.",
+                "Add a NOT VALID CHECK (col IS NOT NULL) constraint, VALIDATE it under a weaker "
+                + "lock, then SET NOT NULL.", ALTER_DOCS);
+    }
+
+    private MigrationRiskReport addCheck(DdlFacts f, TableFacts t) {
+        var locks = List.of(new LockRef(f.table(), "AccessExclusiveLock", RW));
+        if (f.notValid()) {
+            return report("SAFE", true, f, t, locks, false, "milliseconds",
+                    "ADD CONSTRAINT ... NOT VALID skips the validating scan, so the ACCESS "
+                    + "EXCLUSIVE lock is held only briefly.",
+                    "Follow with VALIDATE CONSTRAINT, which runs under a weaker lock that allows "
+                    + "concurrent writes.", ALTER_DOCS);
+        }
+        return report(t.rowEstimate() >= LARGE_ROWS ? "DANGER" : "CAUTION", false, f, t, locks,
+                false, bucket(t),
+                "A validating CHECK constraint scans every row while holding ACCESS EXCLUSIVE, "
+                + "blocking reads and writes.",
+                "Add it NOT VALID first, then VALIDATE CONSTRAINT separately.", ALTER_DOCS);
+    }
+
+    private MigrationRiskReport addForeignKey(DdlFacts f, TableFacts t) {
+        var locks = f.referencedTable() == null
+                ? List.of(new LockRef(f.table(), "ShareRowExclusiveLock", W))
+                : List.of(new LockRef(f.table(), "ShareRowExclusiveLock", W),
+                          new LockRef(f.referencedTable(), "ShareRowExclusiveLock", W));
+        String bothTables = "This locks the referenced table as well as the one being altered — "
+                + "writes are blocked on a table the statement does not name.";
+        if (f.notValid()) {
+            return report("CAUTION", false, f, t, locks, false, "seconds",
+                    "NOT VALID skips the validating scan, but ShareRowExclusiveLock is still taken "
+                    + "on both tables. " + bothTables,
+                    "Follow with VALIDATE CONSTRAINT under ShareUpdateExclusiveLock.", ALTER_DOCS);
+        }
+        return report("DANGER", false, f, t, locks, false, bucket(t),
+                "Adding a validating foreign key scans the child table and blocks writes on both "
+                + "tables under ShareRowExclusiveLock. " + bothTables,
+                "Add the constraint NOT VALID, then VALIDATE CONSTRAINT separately.", ALTER_DOCS);
+    }
+
+    private MigrationRiskReport validateConstraint(DdlFacts f, TableFacts t) {
+        return report("SAFE", true, f, t,
+                List.of(new LockRef(f.table(), "ShareUpdateExclusiveLock", List.of())),
+                false, bucket(t),
+                "VALIDATE CONSTRAINT scans the table under ShareUpdateExclusiveLock, which allows "
+                + "concurrent reads and writes. This is the cheap second half of the NOT VALID pattern.",
+                null, ALTER_DOCS);
+    }
+
+    private MigrationRiskReport createIndex(DdlFacts f, TableFacts t) {
+        if (f.concurrently()) {
+            return report("SAFE", true, f, t,
+                    List.of(new LockRef(f.table(), "ShareUpdateExclusiveLock", List.of())),
+                    false, bucket(t),
+                    "CREATE INDEX CONCURRENTLY does not block reads or writes. It takes longer and "
+                    + "cannot run inside a transaction block.",
+                    "If it fails it leaves an INVALID index behind — check with \\d and drop it "
+                    + "before retrying.", INDEX_DOCS);
+        }
+        return report(t.rowEstimate() >= LARGE_ROWS ? "DANGER" : "CAUTION", false, f, t,
+                List.of(new LockRef(f.table(), "ShareLock", W)),
+                false, bucket(t),
+                "A plain CREATE INDEX blocks all writes to the table for the entire build.",
+                "Use CREATE INDEX CONCURRENTLY, which allows concurrent writes.", INDEX_DOCS);
+    }
+
+    private MigrationRiskReport unknown(DdlFacts f, TableFacts t) {
+        return report("UNKNOWN", false, f, t, List.of(), false, "unknown",
+                "This statement is not one DeepSQL has a verified rule for. Treat it as unsafe "
+                + "until reviewed by hand.", null, ALTER_DOCS);
+    }
+
+    private MigrationRiskReport report(String verdict, boolean safe, DdlFacts f, TableFacts t,
+                                       List<LockRef> locks, boolean rewrites, String duration,
+                                       String reason, String safer, String docs) {
+        return new MigrationRiskReport("postgres", verdict, safe, true, f.operation().name(),
+                f.table(), locks, rewrites, t.rowEstimate(), t.sizeBytes(), duration,
+                reason, safer, docs, "verified");
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests and confirm they pass**
+
+Run: `./scripts/jtest.sh -Dtest=PostgresMigrationRiskRulesTest`
+Expected: PASS, 11 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/main/java/com/dbaagent/provider backend/src/main/java/com/dbaagent/dto backend/src/test/java/com/dbaagent/provider
+git commit -m "feat: Postgres DDL migration risk rule table"
+```
+
+---
+
+### Task 3: Engine verification with Testcontainers
+
+This is the task that makes the tool trustworthy — every rule is proved against a real
+PostgreSQL rather than against the rule table that produced it.
+
+**Files:**
+- Modify: `backend/pom.xml` (add `testcontainers` + `postgresql` test scope)
+- Test: `backend/src/test/java/com/dbaagent/provider/postgres/PostgresMigrationRiskVerificationTest.java`
+
+**Interfaces:**
+- Consumes: `PostgresMigrationRiskProvider.classify`, `DdlStatementParser.parse`.
+- Produces: nothing — it is a verification harness.
+
+- [ ] **Step 1: Add the Testcontainers dependencies**
+
+```xml
+<dependency>
+  <groupId>org.testcontainers</groupId>
+  <artifactId>postgresql</artifactId>
+  <version>1.20.4</version>
+  <scope>test</scope>
+</dependency>
+<dependency>
+  <groupId>org.testcontainers</groupId>
+  <artifactId>junit-jupiter</artifactId>
+  <version>1.20.4</version>
+  <scope>test</scope>
+</dependency>
+```
+
+- [ ] **Step 2: Write the verification test**
+
+Each case runs the DDL in a transaction, reads what PostgreSQL actually did, and rolls
+back. `pg_relation_filenode()` changing proves a physical rewrite; `pg_locks` reports the
+real lock. Lock strength is ranked explicitly — `max(mode)` is alphabetical and would
+report "ShareLock" as stronger than "AccessExclusiveLock".
+
+```java
+package com.dbaagent.provider.postgres;
+
+import com.dbaagent.dto.TableFacts;
+import com.dbaagent.service.migration.DdlStatementParser;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.sql.*;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+class PostgresMigrationRiskVerificationTest {
+
+    @Container
+    static final PostgreSQLContainer<?> PG = new PostgreSQLContainer<>("postgres:18");
+
+    private static final List<String> LOCK_STRENGTH = List.of(
+            "AccessShareLock", "RowShareLock", "RowExclusiveLock", "ShareUpdateExclusiveLock",
+            "ShareLock", "ShareRowExclusiveLock", "ExclusiveLock", "AccessExclusiveLock");
+
+    private final DdlStatementParser parser = new DdlStatementParser();
+    private final PostgresMigrationRiskProvider provider = new PostgresMigrationRiskProvider();
+
+    private Connection conn;
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        conn = DriverManager.getConnection(PG.getJdbcUrl(), PG.getUsername(), PG.getPassword());
+        try (Statement s = conn.createStatement()) {
+            s.execute("DROP TABLE IF EXISTS child, t CASCADE");
+            s.execute("CREATE TABLE t (id bigserial primary key, a text)");
+            s.execute("INSERT INTO t (a) SELECT 'x' FROM generate_series(1,1000)");
+            s.execute("CREATE TABLE child (id bigserial primary key, t_id bigint)");
+            s.execute("INSERT INTO child (t_id) SELECT id FROM t LIMIT 500");
+        }
+    }
+
+    @AfterEach
+    void tearDown() throws SQLException { conn.close(); }
+
+    @ParameterizedTest(name = "{0} -> rewrites={1}")
+    @CsvSource({
+        "ALTER TABLE t ADD COLUMN c text,                                  false",
+        "ALTER TABLE t ADD COLUMN c text DEFAULT 'x',                      false",
+        "ALTER TABLE t ADD COLUMN c timestamptz DEFAULT now(),             false",
+        "ALTER TABLE t ADD COLUMN c uuid DEFAULT gen_random_uuid(),        true",
+        "ALTER TABLE t ADD COLUMN c double precision DEFAULT random(),     true",
+        "ALTER TABLE t ADD COLUMN c timestamptz DEFAULT clock_timestamp(), true",
+        "ALTER TABLE t ALTER COLUMN a TYPE varchar(50),                    true",
+        "ALTER TABLE t DROP COLUMN a,                                      false",
+        "ALTER TABLE t ALTER COLUMN a SET NOT NULL,                        false"
+    })
+    void ruleTableMatchesEngineRewriteBehaviour(String sql, boolean expectedRewrite) throws SQLException {
+        conn.setAutoCommit(false);
+        long before = filenode("t");
+        try (Statement s = conn.createStatement()) {
+            s.execute(sql);
+        }
+        long after = filenode("t");
+        conn.rollback();
+        conn.setAutoCommit(true);
+
+        boolean actuallyRewrote = before != after;
+        assertThat(actuallyRewrote)
+            .as("engine rewrite behaviour for: %s", sql)
+            .isEqualTo(expectedRewrite);
+
+        var facts = parser.parse(sql).orElseThrow();
+        var report = provider.classify(facts, new TableFacts(1000L, 40_000L, false));
+        assertThat(report.rewritesTable())
+            .as("rule table claim vs engine for: %s", sql)
+            .isEqualTo(actuallyRewrote);
+    }
+
+    @Test
+    void addForeignKeyLocksBothTables() throws SQLException {
+        conn.setAutoCommit(false);
+        try (Statement s = conn.createStatement()) {
+            s.execute("ALTER TABLE child ADD CONSTRAINT fk FOREIGN KEY (t_id) REFERENCES t(id)");
+        }
+        assertThat(strongestLock("t")).isEqualTo("ShareRowExclusiveLock");
+        assertThat(strongestLock("child")).isEqualTo("ShareRowExclusiveLock");
+        conn.rollback();
+        conn.setAutoCommit(true);
+
+        var facts = parser.parse(
+            "ALTER TABLE child ADD CONSTRAINT fk FOREIGN KEY (t_id) REFERENCES t(id)").orElseThrow();
+        var report = provider.classify(facts, new TableFacts(1000L, 40_000L, false));
+        assertThat(report.locks()).extracting(l -> l.table())
+                .containsExactlyInAnyOrder("child", "t");
+    }
+
+    @Test
+    void addColumnNotNullWithoutDefaultReallyFails() {
+        Assertions.assertThatThrownBy(() -> {
+            try (Statement s = conn.createStatement()) {
+                s.execute("ALTER TABLE t ADD COLUMN c5 text NOT NULL");
+            }
+        }).isInstanceOf(SQLException.class).hasMessageContaining("null values");
+    }
+
+    @Test
+    void volatilityClassificationMatchesCatalog() throws SQLException {
+        assertThat(volatility("now")).isEqualTo("s");
+        assertThat(volatility("random")).isEqualTo("v");
+        assertThat(volatility("gen_random_uuid")).isEqualTo("v");
+        assertThat(volatility("clock_timestamp")).isEqualTo("v");
+    }
+
+    private long filenode(String table) throws SQLException {
+        try (PreparedStatement p = conn.prepareStatement("SELECT pg_relation_filenode(?::regclass)")) {
+            p.setString(1, table);
+            try (ResultSet rs = p.executeQuery()) { rs.next(); return rs.getLong(1); }
+        }
+    }
+
+    private String strongestLock(String table) throws SQLException {
+        try (PreparedStatement p = conn.prepareStatement(
+                "SELECT mode FROM pg_locks WHERE relation = ?::regclass")) {
+            p.setString(1, table);
+            try (ResultSet rs = p.executeQuery()) {
+                String strongest = null;
+                while (rs.next()) {
+                    String m = rs.getString(1);
+                    if (strongest == null || LOCK_STRENGTH.indexOf(m) > LOCK_STRENGTH.indexOf(strongest)) {
+                        strongest = m;
+                    }
+                }
+                return strongest;
+            }
+        }
+    }
+
+    private String volatility(String fn) throws SQLException {
+        try (PreparedStatement p = conn.prepareStatement(
+                "SELECT provolatile FROM pg_proc WHERE proname = ? LIMIT 1")) {
+            p.setString(1, fn);
+            try (ResultSet rs = p.executeQuery()) { rs.next(); return rs.getString(1); }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run it and confirm it passes**
+
+Run: `./scripts/jtest.sh -Dtest=PostgresMigrationRiskVerificationTest`
+Expected: PASS. A failure here means the rule table disagrees with the engine — fix the
+rule, never the assertion.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/pom.xml backend/src/test/java/com/dbaagent/provider/postgres/PostgresMigrationRiskVerificationTest.java
+git commit -m "test: verify DDL risk rules against a real PostgreSQL"
+```
+
+---
+
+### Task 4: Service, dialect wiring, MySQL stub, endpoint
+
+**Files:**
+- Create: `backend/src/main/java/com/dbaagent/service/migration/MigrationRiskService.java`
+- Create: `backend/src/main/java/com/dbaagent/provider/mysql/MySQLMigrationRiskProvider.java`
+- Create: `backend/src/main/java/com/dbaagent/controller/MigrationRiskController.java`
+- Modify: `backend/src/main/java/com/dbaagent/provider/api/DatabaseDialect.java` (add `migrationRisk()`)
+- Modify: `backend/src/main/java/com/dbaagent/provider/postgres/PostgresDialect.java`
+- Modify: `backend/src/main/java/com/dbaagent/provider/mysql/MySQLDialect.java`
+- Test: `backend/src/test/java/com/dbaagent/service/migration/MigrationRiskServiceTest.java`
+
+**Interfaces:**
+- Consumes: `DdlStatementParser.parse`, `MigrationRiskProvider.classify`,
+  `CredentialService.getDecryptedConnection(connectionId)`,
+  `ConnectionService.getJdbcTemplate(connectionId, request)`,
+  `DatabaseProviderRegistry.getDialect(dbType)`,
+  `AccessControlService.assertCanReadConnectionContent(connectionId)`.
+- Produces: `MigrationRiskService.analyze(String connectionId, String sql) -> MigrationRiskReport`.
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+package com.dbaagent.service.migration;
+
+import com.dbaagent.dto.MigrationRiskReport;
+import com.dbaagent.provider.DatabaseProviderRegistry;
+import com.dbaagent.provider.postgres.PostgresMigrationRiskProvider;
+import com.dbaagent.service.ConnectionService;
+import com.dbaagent.service.CredentialService;
+import com.dbaagent.service.security.AccessControlService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class MigrationRiskServiceTest {
+
+    @Test
+    void unparseableSqlFailsClosedWithoutTouchingTheDatabase() {
+        var access = mock(AccessControlService.class);
+        var credentials = mock(CredentialService.class);
+        var connections = mock(ConnectionService.class);
+        var registry = mock(DatabaseProviderRegistry.class);
+
+        var service = new MigrationRiskService(new DdlStatementParser(), registry,
+                credentials, connections, access);
+
+        MigrationRiskReport r = service.analyze("conn-1", "this is not sql");
+
+        assertThat(r.verdict()).isEqualTo("UNKNOWN");
+        assertThat(r.safeToRun()).isFalse();
+        verify(access).assertCanReadConnectionContent("conn-1");
+        verifyNoInteractions(connections);   // never opens a session for garbage input
+    }
+
+    @Test
+    void authorizationIsAssertedBeforeAnyWork() {
+        var access = mock(AccessControlService.class);
+        doThrow(new RuntimeException("denied")).when(access).assertCanReadConnectionContent(anyString());
+        var service = new MigrationRiskService(new DdlStatementParser(),
+                mock(DatabaseProviderRegistry.class), mock(CredentialService.class),
+                mock(ConnectionService.class), access);
+
+        org.assertj.core.api.Assertions
+            .assertThatThrownBy(() -> service.analyze("conn-1", "ALTER TABLE t ADD COLUMN c text"))
+            .hasMessageContaining("denied");
+    }
+}
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `./scripts/jtest.sh -Dtest=MigrationRiskServiceTest`
+Expected: compilation failure — `MigrationRiskService` does not exist.
+
+- [ ] **Step 3: Implement the service**
+
+Order matters: authorize, then parse, then (only if parsed) open a session for catalog facts.
+
+```java
+package com.dbaagent.service.migration;
+
+import com.dbaagent.dto.MigrationRiskReport;
+import com.dbaagent.dto.TableFacts;
+import com.dbaagent.provider.DatabaseProviderRegistry;
+import com.dbaagent.service.ConnectionService;
+import com.dbaagent.service.CredentialService;
+import com.dbaagent.service.security.AccessControlService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MigrationRiskService {
+
+    private final DdlStatementParser parser;
+    private final DatabaseProviderRegistry registry;
+    private final CredentialService credentialService;
+    private final ConnectionService connectionService;
+    private final AccessControlService accessControlService;
+
+    public MigrationRiskReport analyze(String connectionId, String sql) {
+        accessControlService.assertCanReadConnectionContent(connectionId);
+
+        var parsed = parser.parse(sql);
+        if (parsed.isEmpty()) {
+            return failClosed("DeepSQL could not parse this statement, so it cannot verify what "
+                    + "it will do. Review it by hand before running it.");
+        }
+        var facts = parsed.get();
+
+        var request = credentialService.getDecryptedConnection(connectionId);
+        var dialect = registry.getDialect(request.getDbType());
+        var provider = dialect.migrationRisk();
+
+        TableFacts table = tableFacts(connectionId, request, facts.table());
+        return provider.classify(facts, table);
+    }
+
+    private TableFacts tableFacts(String connectionId, Object request, String table) {
+        try {
+            var jdbc = connectionService.getJdbcTemplate(connectionId,
+                    (com.dbaagent.model.ConnectionRequest) request);
+            var row = jdbc.queryForMap("""
+                    SELECT COALESCE(c.reltuples, 0)::bigint AS rows,
+                           COALESCE(pg_total_relation_size(c.oid), 0)::bigint AS bytes
+                    FROM pg_class c WHERE c.oid = ?::regclass
+                    """, table);
+            long rows = ((Number) row.get("rows")).longValue();
+            long bytes = ((Number) row.get("bytes")).longValue();
+            return new TableFacts(Math.max(rows, 0), bytes, rows == 0);
+        } catch (Exception e) {
+            // Unknown size is not a reason to claim safety — assume large.
+            log.warn("Could not read table facts for {}: {}", table, e.getMessage());
+            return new TableFacts(Long.MAX_VALUE, 0L, false);
+        }
+    }
+
+    private MigrationRiskReport failClosed(String reason) {
+        return new MigrationRiskReport("unknown", "UNKNOWN", false, true, "UNKNOWN", null,
+                List.of(), false, 0L, 0L, "unknown", reason, null, null, "unverified");
+    }
+}
+```
+
+- [ ] **Step 4: Wire the dialect and add the MySQL stub**
+
+Add to `DatabaseDialect`:
+
+```java
+    /**
+     * Get the migration risk provider for this database.
+     * @return The migration risk provider
+     */
+    MigrationRiskProvider migrationRisk();
+```
+
+`PostgresDialect`: add the field `private final PostgresMigrationRiskProvider migrationRiskProvider;`
+and the accessor returning it. `MySQLDialect`: same shape with the stub below.
+
+```java
+package com.dbaagent.provider.mysql;
+
+import com.dbaagent.dto.MigrationRiskReport;
+import com.dbaagent.dto.TableFacts;
+import com.dbaagent.provider.api.MigrationRiskProvider;
+import com.dbaagent.service.migration.DdlFacts;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * MySQL migration risk is not implemented. Returning UNKNOWN is deliberate: MySQL's
+ * online-DDL matrix varies by version, storage engine and ALGORITHM/LOCK clause, and a
+ * confident wrong answer about a lock is worse than no answer.
+ */
+@Component
+public class MySQLMigrationRiskProvider implements MigrationRiskProvider {
+
+    @Override
+    public MigrationRiskReport classify(DdlFacts facts, TableFacts table) {
+        return new MigrationRiskReport("mysql", "UNKNOWN", false, false,
+                facts.operation().name(), facts.table(), List.of(), false,
+                table.rowEstimate(), table.sizeBytes(), "unknown",
+                "DeepSQL does not yet have verified MySQL DDL rules. Review this by hand.",
+                null, "https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl-operations.html",
+                "unverified");
+    }
+}
+```
+
+- [ ] **Step 5: Add the controller**
+
+```java
+package com.dbaagent.controller;
+
+import com.dbaagent.dto.MigrationRiskReport;
+import com.dbaagent.service.migration.MigrationRiskService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/migrations")
+@RequiredArgsConstructor
+public class MigrationRiskController {
+
+    private final MigrationRiskService migrationRiskService;
+
+    @PostMapping("/analyze")
+    public ResponseEntity<?> analyze(@RequestBody Map<String, String> body) {
+        String connectionId = body.get("connectionId");
+        String sql = body.get("sql");
+        if (connectionId == null || connectionId.isBlank() || sql == null || sql.isBlank()) {
+            return ResponseEntity.badRequest().body(Map.of("message", "connectionId and sql are required"));
+        }
+        try {
+            MigrationRiskReport report = migrationRiskService.analyze(connectionId, sql);
+            return ResponseEntity.ok(report);
+        } catch (ResponseStatusException e) {
+            throw e;   // preserve 403/404 — a catch-all below would report it as a 500
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError()
+                    .body(Map.of("message", "Migration analysis failed: " + e.getMessage()));
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Run the full backend suite**
+
+Run: `./scripts/jtest.sh -Dtest='*MigrationRisk*,*DdlStatement*'`
+Expected: PASS. Then confirm `ConnectionScopedAuthorizationSafetyTest` still passes —
+it scans every controller and will fail if the new endpoint is unguarded.
+
+Run: `./scripts/jtest.sh -Dtest=ConnectionScopedAuthorizationSafetyTest`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/main/java/com/dbaagent
+git commit -m "feat: migration risk service, dialect wiring, MySQL stub, analyze endpoint"
+```
+
+---
+
+### Task 5: MCP tool + CLI + docs
+
+Per CLAUDE.md's MCP & CLI Release Rules, **all** of these change in one commit.
+
+**Files:**
+- Modify: `mcp/deepsql-phase1-lib.js` (TOOL_DEFINITIONS, handleToolCall, buildToolResult, summarizeMigrationRisk)
+- Create: `mcp/src/commands/migration.js`
+- Modify: `mcp/src/cli.js` (COMMAND_HELP)
+- Modify: `mcp/skills/SKILL_BODY.md` (tool table + count)
+- Modify: `mcp/CLAUDE.md`, `mcp/README.md`
+- Modify: `mcp/package.json` (minor bump)
+
+**Interfaces:**
+- Consumes: `POST /migrations/analyze` returning `MigrationRiskReport` from Task 4.
+- Produces: MCP tool `analyze_migration(connectionId, sql)`.
+
+- [ ] **Step 1: Add the tool definition**
+
+```js
+  {
+    name: "analyze_migration",
+    description:
+      "Check whether a DDL statement is safe to run before running it. Returns a "
+      + "deterministic verdict (SAFE/CAUTION/DANGER/FAILS/UNKNOWN) with the exact locks "
+      + "taken — per table, since a foreign key locks the referenced table too — whether "
+      + "the table is rewritten, a coarse duration estimate scaled by live table size, and "
+      + "a safer alternative where one exists. Rules are verified against a real PostgreSQL, "
+      + "not inferred: do not second-guess the verdict from memory. PostgreSQL only; MySQL "
+      + "returns UNKNOWN rather than a guess. Read-only — it never executes the statement.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        connectionId: { type: "string", description: "DeepSQL connection ID." },
+        sql: { type: "string", description: "The DDL statement to analyse, e.g. 'ALTER TABLE orders ADD COLUMN region text'." },
+      },
+      required: ["connectionId", "sql"],
+    },
+  },
+```
+
+- [ ] **Step 2: Add the handler case**
+
+```js
+    case "analyze_migration": {
+      const { connectionId, sql } = args;
+      const data = await apiPost("/migrations/analyze", { connectionId, sql });
+      return buildToolResult("analyze_migration", data);
+    }
+```
+
+- [ ] **Step 3: Add the summarizer**
+
+```js
+function summarizeMigrationRisk(r) {
+  if (!r) return "No analysis returned.";
+  if (r.verdict === "UNKNOWN") {
+    return `UNKNOWN — ${r.reason} Treat as unsafe until reviewed by hand.`;
+  }
+  const locks = (r.locks || [])
+    .map((l) => `${l.table}: ${l.mode}${l.blocks?.length ? ` (blocks ${l.blocks.join(" + ")})` : ""}`)
+    .join("; ");
+  const parts = [
+    `${r.verdict} — ${r.operation} on ${r.table}.`,
+    r.rewritesTable ? "Rewrites the whole table." : "No table rewrite.",
+    locks ? `Locks — ${locks}.` : "",
+    r.tableRows ? `Table has ~${Number(r.tableRows).toLocaleString()} rows.` : "",
+    `Estimated duration: ${r.estimatedDuration}.`,
+    r.reason,
+    r.saferAlternative ? `Safer: ${r.saferAlternative}` : "",
+  ];
+  return parts.filter(Boolean).join(" ");
+}
+```
+
+- [ ] **Step 4: Add the CLI subcommand**
+
+```js
+// mcp/src/commands/migration.js
+import { apiPost } from "../api.js";
+
+const SUBCOMMANDS = {
+  analyze: analyzeMigration,
+};
+
+async function analyzeMigration(args) {
+  const connectionId = args.connection || args.c;
+  const sql = args.sql || args._[0];
+  if (!connectionId || !sql) {
+    console.error("Usage: deepsql migration analyze --connection <id> --sql \"ALTER TABLE ...\"");
+    process.exit(1);
+  }
+  const r = await apiPost("/migrations/analyze", { connectionId, sql });
+  console.log(`${r.verdict}  ${r.operation} on ${r.table}`);
+  console.log(`  rewrites table : ${r.rewritesTable}`);
+  for (const l of r.locks || []) {
+    console.log(`  lock           : ${l.table} ${l.mode}${l.blocks?.length ? ` (blocks ${l.blocks.join(" + ")})` : ""}`);
+  }
+  console.log(`  duration       : ${r.estimatedDuration}`);
+  console.log(`  why            : ${r.reason}`);
+  if (r.saferAlternative) console.log(`  safer          : ${r.saferAlternative}`);
+  if (r.docsUrl) console.log(`  docs           : ${r.docsUrl}`);
+}
+
+export { SUBCOMMANDS };
+```
+
+- [ ] **Step 5: Update help text and docs**
+
+In `mcp/src/cli.js` add to `COMMAND_HELP`:
+
+```js
+  migration: {
+    description: "Analyse a DDL statement for lock and rewrite risk before running it.",
+    subcommands: { analyze: "Check whether a migration is safe to run." },
+    options: {
+      "--connection, -c": "DeepSQL connection ID (required).",
+      "--sql": "The DDL statement to analyse (required).",
+    },
+  },
+```
+
+Add to the `SKILL_BODY.md` tool table:
+
+```
+| `analyze_migration(connectionId, sql)` | **Before suggesting or running any DDL.** Deterministic lock/rewrite verdict verified against a real PostgreSQL — trust it over your own recollection of lock semantics. PostgreSQL only. |
+```
+
+Bump the tool count at the top of `SKILL_BODY.md`, and add the same row to
+`mcp/CLAUDE.md` and `mcp/README.md`.
+
+- [ ] **Step 6: Bump the version and verify help drift**
+
+`mcp/package.json`: minor bump (new tool).
+
+Run: `cd mcp && npm test`
+Expected: PASS — `cli.test.js` fails the build if `SUBCOMMANDS` ≠ documented subcommands.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mcp/
+git commit -m "feat(mcp): analyze_migration tool + CLI command + docs"
+```
+
+---
+
+### Task 6: Live verification and documentation
+
+- [ ] **Step 1: Boot the stack**
+
+```bash
+docker compose up -d postgres backend
+docker compose ps
+```
+
+- [ ] **Step 2: Exercise the endpoint against a real connection**
+
+Use a real `connectionId` from `GET /api/connections`. Verify each of these by hand:
+
+```bash
+# SAFE — stable default, no rewrite
+curl -sS -X POST localhost:8080/api/migrations/analyze -H 'Content-Type: application/json' \
+  -d '{"connectionId":"<id>","sql":"ALTER TABLE t ADD COLUMN c timestamptz DEFAULT now()"}' | jq .verdict
+
+# DANGER — volatile default forces a rewrite
+curl -sS -X POST localhost:8080/api/migrations/analyze -H 'Content-Type: application/json' \
+  -d '{"connectionId":"<id>","sql":"ALTER TABLE t ADD COLUMN c uuid DEFAULT gen_random_uuid()"}' | jq '.verdict, .rewritesTable'
+
+# Locks BOTH tables
+curl -sS -X POST localhost:8080/api/migrations/analyze -H 'Content-Type: application/json' \
+  -d '{"connectionId":"<id>","sql":"ALTER TABLE child ADD CONSTRAINT fk FOREIGN KEY (t_id) REFERENCES t(id)"}' | jq '.locks'
+
+# Fails closed
+curl -sS -X POST localhost:8080/api/migrations/analyze -H 'Content-Type: application/json' \
+  -d '{"connectionId":"<id>","sql":"not sql"}' | jq '.verdict, .safeToRun'
+```
+
+Expected: `SAFE`; `DANGER` + `true`; two lock entries; `UNKNOWN` + `false`.
+
+- [ ] **Step 3: Verify authorization with a second user**
+
+As a user with no grant on that connection, the same call must return 403 — not 200,
+and not a 500 from a swallowed `ResponseStatusException`.
+
+- [ ] **Step 4: Update CLAUDE.md**
+
+Add a section documenting the analyzer: that it is deterministic by convention, that the
+rule table is engine-verified, the JSqlParser 5.2 shim and why it exists, the `now()`
+STABLE finding, and that FK locks both tables.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: document pre-flight migration review in CLAUDE.md"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** pipeline (T1, T2, T4), fail-closed (T1 garbage test, T4 service test,
+T6 curl), rule table incl. FK/CHECK/NOT VALID (T2), per-table locks (T2, T3), duration
+buckets (T2), placement via `DatabaseDialect` (T4), MySQL unsupported (T4),
+authorization (T4, T6), 3-layer verification (T1/T2 unit, T3 engine, docsUrl in T2),
+MCP release checklist (T5). No gaps.
+
+**Type consistency:** `DdlFacts` field order is identical in every construction;
+`MigrationRiskReport` is built only through `report(...)` in the Postgres provider and
+explicitly in the two fail-closed paths; `TableFacts(rowEstimate, sizeBytes, empty)`
+consistent throughout; `LockRef(table, mode, blocks)` consistent.
+
+**Known deviation to watch:** `MigrationRiskService.tableFacts` casts `request` to
+`ConnectionRequest` — the implementer should type the parameter properly once the exact
+`CredentialService` return type is confirmed at the call site.

--- a/docs/superpowers/specs/2026-09-04-preflight-migration-review-decisions.md
+++ b/docs/superpowers/specs/2026-09-04-preflight-migration-review-decisions.md
@@ -1,0 +1,149 @@
+# SDD ledger — plan: docs/superpowers/plans/2026-09-04-preflight-migration-review.md
+
+Spec: docs/superpowers/specs/2026-09-04-preflight-migration-review-design.md (read — binding authority)
+Branch: feat/preflight-migration-review (off main; isolated, no nested worktree)
+
+## Pre-flight conflict scan
+
+### Cross-task rows (pairs sharing a file or interface)
+
+| Pair | Produces → Consumes | Finding |
+|---|---|---|
+| T1 → T2 | `DdlFacts` (12-field positional record), `DdlOperation` enum → T2 test code constructs `DdlFacts` positionally | **RISK**: field order must match exactly. T2's tests build DdlFacts by position in 6 places. A reorder in T1 breaks T2 as a silent rule failure. Ruling below. |
+| T1 → T3 | `DdlStatementParser.parse` → T3 verification harness | Consistent. T3 parses the same CsvSource SQL it executes. |
+| T2 → T3 | `PostgresMigrationRiskProvider.classify`, `TableFacts`, `LockRef` → T3 asserts rules vs engine | Consistent. T3 uses no-arg constructor; T2 declares `@Component` with no deps. OK. |
+| T2 → T4 | `MigrationRiskProvider` interface → `DatabaseDialect.migrationRisk()` | Consistent. T4 adds accessor; T2 creates interface. Order correct. |
+| T1+T2 → T4 | parser + provider → `MigrationRiskService` | Consistent. |
+| T4 → T5 | `POST /migrations/analyze` + `MigrationRiskReport` JSON → MCP tool/CLI/summarizer | Consistent. Field names in T5's summarizer (`verdict`, `locks[].table/.mode/.blocks`, `rewritesTable`, `tableRows`, `estimatedDuration`, `reason`, `saferAlternative`) all exist in T2's record. |
+| T4 → T6 | endpoint → curl verification | Consistent. |
+| T4 ↔ existing `ConnectionScopedAuthorizationSafetyTest` | new `*Controller.java` → test walks ALL controllers (verified: line 112 `endsWith("Controller.java")`) | **Confirmed dependency, already handled**: T4 Step 6 runs that test. New controller must call `assertCanReadConnectionContent` or the build fails. |
+
+### Per-task internal consistency rows
+
+| Task | Finding |
+|---|---|
+| T1 | Self-consistent. 11 tests match the parser's branches. Shim verified working during planning. |
+| T2 | Self-consistent. 11 tests map to the 10 rule branches + UNKNOWN. `report(...)` helper used uniformly. |
+| T3 | Self-consistent. **Note**: `ALTER COLUMN TYPE varchar(50)` CsvSource expects `rewrites=true`; T2's `alterType` hardcodes `rewrites=true` for all type changes, so widening (varchar(50)→varchar(100), measured as NO rewrite) would fail if added. Not in the CsvSource, so no conflict today. Flagged as a known limitation in the spec. |
+| T4 | **Plan defect found**: `tableFacts` casts `(ConnectionRequest) request` from an `Object` param. Verified: `CredentialService.getDecryptedConnection` already returns `com.dbaagent.model.ConnectionRequest`. Ruling below. |
+| T5 | Self-consistent. Covers all 6 doc surfaces the MCP release rules require. |
+| T6 | Self-consistent. |
+
+### Rulings (pre-flight)
+
+Ruling: T4's `tableFacts(String, Object, String)` signature and its `(ConnectionRequest)` cast are a plan defect — type the parameter as `com.dbaagent.model.ConnectionRequest` and drop the cast. Why: verified `CredentialService.getDecryptedConnection` returns exactly that type, so the cast is dead weight that would suppress a real compile-time check. Cost if wrong: none — a compile error surfaces immediately in T4's own test step.
+
+Ruling: T1 implementer must treat the `DdlFacts` field order in the plan as fixed and non-negotiable, since T2's tests construct it positionally. Why: a 12-field positional record is the most likely silent cross-task break in this plan. Cost if wrong: T2's tests fail with confusing rule-level messages instead of a signature error, costing a fix round.
+
+Ruling: no nested worktree — work proceeds on `feat/preflight-migration-review`, already isolated off main. Why: the branch was created for this feature at the user's instruction and contains only its spec/plan commits. Cost if wrong: none; branch is separable and unpushed.
+
+## Task log
+
+### Task 1
+
+Task 1: implemented (commit 66540a9, 11/11 tests passing). Review: spec ✅, quality NOT APPROVED — 1 Critical, 3 Important, 2 Minor. Critical + Important #2/#3 are plan-mandated (the brief's own code); ruled on below.
+
+Ruling: Finding #1 (multi-clause ALTER silently judged on `exprs.get(0)`) — FIX, overriding the plan text. Why: the spec's binding constraint is fail-closed, and this fails OPEN in the worst possible way for this feature — `ALTER TABLE t ADD COLUMN a text, ADD COLUMN b uuid DEFAULT gen_random_uuid()` returns facts describing only the harmless first clause, so Task 2 would rule the whole statement SAFE while a table-rewriting clause is invisible. Verified by the reviewer by execution, not inference. Fix is minimal: return `Optional.empty()` when `getAlterExpressions().size() > 1`. Cost if wrong: multi-clause ALTERs report UNKNOWN instead of being analyzed — a usability loss, never a safety loss, and the honest answer given a single-fact record cannot represent them.
+
+Ruling: Finding #2 (`ADD_CHECK` via `rawSql.contains("CHECK")`) — FIX, overriding the plan text. Why: proven false positive on `ADD COLUMN check_flag boolean DEFAULT true`; `check_flag`/`checked_at`/`checkout_id` are ordinary column names, and misclassification discards the real column/type/default facts, so an ADD_COLUMN with a volatile default named e.g. `checkout_id` would be analyzed as a CHECK constraint. Fix: detect ADD CHECK from the parse tree / a constraint-anchored pattern, not a bare substring of the whole statement. Cost if wrong: a genuine ADD CHECK could fall through to UNKNOWN — fails closed, acceptable.
+
+Ruling: Finding #3 (`REFERENCES` regex matches inside string literals) — FIX (cheap), though currently latent. Why: only read on the ADD_FOREIGN_KEY path today, so it is a landmine rather than a live bug, but gating extraction on `operation == ADD_FOREIGN_KEY` is a two-line change and removes the trap before Task 2 consumes the record. Cost if wrong: negligible.
+
+Ruling: Finding #4 (no DROP_COLUMN / RENAME_COLUMN tests) — FIX by adding the two tests. Why: Task 2 consumes `DdlFacts` for both operations; their field shape is currently asserted by nothing. Cheap to close now, expensive to debug later as a cross-task mismatch. Cost if wrong: none.
+
+Ruling: Findings #5 (clause-scoped regex extraction) and #6 (NOT VALID end-anchored) — DEFER as minors. Why: #5 is subsumed by the #1 fix (rejecting multi-clause statements removes the cross-clause attribution path entirely); #6 fails closed by the reviewer's own analysis. Cost if wrong: low; both recorded for the final whole-branch review.
+
+Task 1: minor (deferred): DEFAULT_FN/REFERENCES extract from whole rawSql rather than the clause substring — subsumed by the multi-clause rejection, revisit if multi-clause support is ever added.
+Task 1: minor (deferred): NOT_VALID regex is end-anchored; mid-statement NOT VALID fails closed rather than being flagged.
+Task 1: fix round 1/5 (4 addressed, 0 open — multi-clause fail-open, ADD_CHECK substring misclassification, REFERENCES gating (test-only, claim verified), DROP/RENAME coverage; commits 66540a9..ea32660)
+Task 1: complete (commits ccc55f2..ea32660, review clean, 16/16 tests)
+
+Note for Task 2: parser now returns Optional.empty() for ANY multi-clause ALTER. Task 2's classify() never sees them; the service layer (T4) surfaces them as UNKNOWN/safeToRun=false.
+
+### Task 2
+Task 2: implemented (commit 70d5271, 10/10 tests). Review: spec ✅, quality NOT APPROVED — 1 Critical, 1 Important, 2 Minor.
+
+Ruling: Critical (`isVolatile` fails OPEN for any function outside the 4-name hardcoded set) — FIX in Task 2. Why: `ADD COLUMN c uuid DEFAULT my_custom_uuid()` — a user-defined VOLATILE function — is not in the set, so it reaches the final SAFE branch and is reported metadata-only while it actually rewrites the whole table under ACCESS EXCLUSIVE. Same failure class as Task 1's multi-clause bug: confidently SAFE for something not positively recognised, which the spec's fail-closed rule forbids. The reviewer also correctly notes my design named `pg_proc.provolatile` as the primary source but NO task wires it up — the "fallback" is the only source. Fix: an unrecognised default function yields CAUTION with an explicit "cannot verify volatility" reason, never SAFE. Cost if wrong: an exotic-but-stable default is reported CAUTION instead of SAFE — an over-warning, which is the correct direction to err.
+
+Ruling: Important (5 of 10 branches untested — ALTER_COLUMN_TYPE, SET_NOT_NULL, RENAME_COLUMN, ADD_CHECK, VALIDATE_CONSTRAINT) — FIX by adding one test per branch. Why: ADD_CHECK and SET_NOT_NULL encode real conditional logic (notValid split, size threshold). Task 3 verifies rewrite/lock behaviour against a live DB but does NOT assert verdict strings or safeToRun, so these branches are currently asserted by nothing. Cost if wrong: none.
+
+Ruling: Minor #1 (alterType reason text describes a widening exception the code cannot detect) — FIX the wording in the same pass. Why: cheap, and the text currently implies a check that does not exist, which is exactly the false-confidence problem this feature targets. Cost if wrong: none.
+
+Ruling: Minor #2 (addForeignKey NOT VALID hardcodes "seconds" rather than bucket(t)) — ACCEPT as-is, plan-mandated. Why: NOT VALID skips the validating scan, so its cost is lock-acquisition-bound rather than table-size-bound; the hardcoded bucket is semantically right, not an oversight. Cost if wrong: a coarse duration label is slightly off for a huge table; no safety impact.
+
+Ruling: brief's "11 tests" vs 10 supplied — plan defect, not a code defect. The implementer correctly refused to invent a test to match a count. Resolved by the 5 added branch tests above.
+Task 2: fix round 1/5 (3 addressed, 0 open — volatility fail-open, 5 untested branches, alterType wording; commits 70d5271..3b506f5)
+Task 2: complete (commits ea32660..3b506f5, review clean, 18/18 tests)
+Task 2: minor (deferred, accepted): addForeignKey NOT VALID hardcodes "seconds" rather than bucket(t) — semantically correct (skips the validating scan).
+
+### Task 3
+Task 3: implemented (commit ccaf725). Review: spec ✅, quality APPROVED — 0 Critical, 0 Important, 1 Minor. Verification runs against real Testcontainers postgres:18; 13/13 verification + 18/18 rules, no regression. Reviewer independently re-verified the physical claims (filenode, pg_locks) against a live PG18 and confirmed the harness is NOT vacuous: a constant-returning classify() would fail 5 of 9 CSV rows.
+
+Ruling: the widening-varchar rule gap (alterType always claims rewritesTable=true; varchar(50)->varchar(100) measurably does not rewrite) — ACCEPT as documented, do not fix. Why: structurally unfixable where it sits — DdlFacts carries no old type and the parser has no catalog access, so detecting it needs a schema lookup that belongs in a later task, not the verification harness. It over-warns, which is the correct direction under fail-closed: it never calls a risky operation safe. The implementer made the gap explicit as a passing test that asserts BOTH the engine truth (no rewrite) and the rule's current claim (rewrite), so it is tracked rather than silent. Cost if wrong: false-DANGER on a common low-risk operation (bumping a varchar length) — alert fatigue, no safety impact. Recorded below as a deferred minor for the final review.
+
+Task 3: minor (deferred): alterType over-warns on same-family varchar widening — real UX cost (false DANGER on a routine operation), needs old-type info in DdlFacts via a catalog lookup to fix properly.
+Task 3: minor (deferred): volatilityClassificationMatchesCatalog checks pg_proc directly but never feeds the result back through classify(), so it cannot catch VOLATILE_FALLBACK/STABLE_FALLBACK drifting from the catalog for functions not also covered by a CSV row.
+Task 3: minor (deferred): Testcontainers Ryuk reaper disabled for the sibling-Docker-socket setup — a hard-killed JVM would leak a Postgres container. Not observed; jtest.sh is not used by CI (verified).
+Task 3: minor (deferred): `-o` (offline Maven) removed from jtest.sh, so local runs need network egress. Zero CI blast radius — CI uses ./mvnw directly (verified).
+
+### Task 4
+Task 4: implemented (commit 5dff288). 49/49 on *MigrationRisk*/*DdlStatement*, ConnectionScopedAuthorizationSafetyTest 7/7. Review: spec ✅, quality NOT APPROVED — 0 Critical, 1 Important, 2 Minor.
+
+Ruling: Important (duplicate assertCanReadConnectionContent in BOTH controller and service) — FIX by removing the controller-level call and using the existing AUTHORIZED_ELSEWHERE mechanism. Why: I verified the reviewer's claim directly — ConnectionScopedAuthorizationSafetyTest lines 52-77 already provide AUTHORIZED_ELSEWHERE + DELEGATED_CHECKS + everyDelegatedCheckStillExists(), with DashboardWorkspaceController as the documented precedent, and the doc comment says in as many words "Asserting again in the controller would duplicate a check that could then drift." My instruction not to add an exemption entry meant do not add a BOGUS entry hiding a real gap; the implementer reasonably read it as absolute. This is not defence-in-depth: real defence-in-depth layers DIFFERENT mechanisms (as this codebase does pairing SQL classification with connection.setReadOnly(true)); duplicating the identical call with the identical failure mode adds no protection, only drift surface. The service check is verified load-bearing and fires first (MigrationRiskServiceTest.authorizationIsAssertedBeforeAnyWork), and adding MigrationRiskService.java to DELEGATED_CHECKS keeps the build failing if it is ever removed. Cost if wrong: if both the controller call is removed AND the DELEGATED_CHECKS entry is wrong, the scanner could pass an unguarded endpoint — mitigated by the re-derivation test, and the service unit test independently proves the assert fires first.
+
+Ruling: Minor (no MockMvc/controller-level integration test) — ACCEPT for this task, covered by Task 6. Why: Task 6 exercises the endpoint live over HTTP with curl including a 403 check from an unauthorized user, which is stronger evidence than a MockMvc test. Cost if wrong: a controller wiring bug would surface in Task 6 rather than in unit tests — later, but still before merge.
+
+Ruling: Minor (unused import risk after removing the controller assert) — folded into the fix instruction.
+Task 4: fix round 1/5 (1 addressed, 0 open — controller/service duplicate assert replaced with AUTHORIZED_ELSEWHERE + DELEGATED_CHECKS; commits 5dff288..cf700f0)
+Task 4: complete (commits ccaf725..cf700f0, review clean, 49/49 + safety 7/7)
+
+Ruling: the substring-matching weakness in everyDelegatedCheckStillExists (a COMMENTED-OUT assert still passes; only outright DELETION fails) — ACCEPT and defer, do not fix here. Why: verified pre-existing and codebase-wide, NOT introduced by this task — the reviewer traced everyConnectionScopedEndpointAuthorizesTheCaller and confirmed the ordinary AUTHORIZED scanner has the identical weakness, so a commented-out assert in ANY controller passes silently. Hardening it means editing a shared, already-audited safety test that DashboardWorkspaceService also depends on — out of scope for this feature and exactly the "improving adjacent code" this plan should not do. Realistic threat model favours deletion (which does fail loudly) over deliberate commenting; Task 6's live HTTP 403 check is black-box and would catch a neutralised assert however it was neutralised. Cost if wrong: a regression introduced by commenting out an assert would be caught later (code review, Task 6-style live check) rather than by the build. FLAG THIS TO THE USER — it is a pre-existing codebase-wide gap they may want ticketed separately.
+
+Task 4: minor (deferred): everyDelegatedCheckStillExists and the AUTHORIZED scanner both use plain substring/regex matching over raw file text with no comment stripping — a commented-out authorization assert satisfies both. Pre-existing, codebase-wide, affects DashboardWorkspaceService too.
+
+### Task 5
+Task 5: implemented (commit 4740333, npm test 270/270, all six doc surfaces verified touched, DTO field names verified matching). Review: spec ✅, quality NOT APPROVED — 2 Critical-leaning, 2 Minor.
+
+Ruling: both presentation bugs — FIX. Why: both occur ONLY on the failure paths, which is precisely where a safety tool must read clearly. (a) Task 4's Long.MAX_VALUE sentinel means "could not measure this table, assuming the worst"; rendering it as "~9,223,372,036,854,776,000 rows" makes a deliberate fail-closed signal look like corrupted data, so a user dismisses the warning as a bug rather than heeding it — the fail-closed design is defeated at the presentation layer. (b) The CLI printing "UNKNOWN  UNKNOWN on null" is the unparseable-DDL path, the exact moment the user most needs a clear "I could not analyze this." Cost if wrong: none, presentation-only changes behind existing verdict logic.
+
+Ruling: DANGER/FAILS not visually distinguished — FIX (cheap). Why: the verdict is the single most important token in the output and currently reads with the same weight as SAFE. Cost if wrong: none.
+
+Ruling: missing ApiError/403-404 handling in migration.js — FIX. Why: 12+ sibling command files follow that pattern; an unauthorized user would otherwise get a raw error rather than the friendly message every other command gives. Consistency here is a real usability property, not style. Cost if wrong: none.
+
+Ruling: no unit tests for analyze_migration — FIX by adding them. Why: the closest sibling (analyze.js) has tests, and a fully green 270-test suite missed BOTH confirmed bugs — that is the argument for the tests, not against them. Cost if wrong: none.
+Task 5: fix round 1/5 (4 addressed + tests added + a 5th self-found bug fixed, 0 open; commits 4740333..fd57d37, npm test 291/291)
+Task 5: complete (commits cf700f0..fd57d37, review clean)
+
+Note: writing the required tests exposed a 5th bug nobody had caught — buildOpts() in mcp/src/cli.js never wired --sql into opts, so the CLI command was NON-FUNCTIONAL end to end regardless of the presentation fixes. Two review passes and a green 270-test suite had missed it. Reviewer verified the fix through the real argv parser, confirmed blast radius is clean (`sql` is a new key with no other reader), and confirmed the new tests build opts via the real parser so a regression would fail.
+
+Task 5: minor (deferred): sentinel floor 9e18 is a heuristic — a legitimate (physically impossible) row count between 9e18 and Long.MAX_VALUE would be reported as unknown.
+Task 5: minor (deferred): verdictMarker/isRowCountUnknown duplicated between CLI and MCP lib rather than shared — matches the codebase's existing per-file formatting-helper convention.
+
+### Task 6
+Task 6: implemented (commit 81b13c0). All 5 live checks PASS against a freshly rebuilt backend, real Postgres 18, real HTTP. Review: spec ✅, quality APPROVED — 0 Critical, 1 Important (CLAUDE.md overclaim), 0 Minor.
+
+Live results: (1) DEFAULT now() -> SAFE, rewritesTable=false. (2) DEFAULT gen_random_uuid() on 1.2M rows -> DANGER, rewritesTable=true. (3) ADD FOREIGN KEY -> locks array with TWO entries (child + t), both ShareRowExclusiveLock. (4) "not sql" -> UNKNOWN, safeToRun=false. (5) analyst2 (DEVELOPER, zero grants, verified by both GET /connections returning [] and a direct DB query) -> HTTP 403.
+
+The reviewer independently RE-RAN check 5 with controls the original lacked: valid session -> 200 on /auth/me, no cookie -> distinctly-shaped 401, unknown connectionId -> 404. That rules out 401-misread, routing-404, and swallowed-500 as explanations for the 403. Strongest evidence in the feature.
+
+Ruling: Important (CLAUDE.md lock-ranking bullet describes test-only logic as if it were production behaviour) — FIX. Why: the explicit LOCK_STRENGTH ordering lives only in PostgresMigrationRiskVerificationTest; the shipped provider hardcodes a lock mode per rule and ranks nothing. CLAUDE.md is the file future agents trust most and it is not covered by tests, so an inaccuracy there is worse than one in code. Cost if wrong: none, documentation-only.
+
+Process trap worth keeping: the implementer's first backend build was silently killed and produced no new image, yet `docker compose ps` reported "healthy" against a STALE 2-day-old image. Caught only via `docker inspect ... Created`. A live check against a stale image would have verified nothing while reporting success — exactly the false-green class this repo's Verification Anti-Patterns section catalogues.
+Task 6: fix round 1/5 (1 addressed, 0 open — CLAUDE.md lock-ranking overclaim corrected and attributed to the test; commits 81b13c0..c288004). Controller verified the diff directly rather than spending a review seat on a single-purpose doc reword.
+Task 6: complete (commits fd57d37..c288004, review clean)
+
+## All tasks complete. Dispatching final whole-branch review (merge base 819c286).
+
+## FINAL WHOLE-BRANCH REVIEW: DON'T SHIP — 2 Critical fail-open defects
+
+C1: CCJSqlParserUtil.parse() silently returns only the FIRST statement. "ALTER TABLE t ADD COLUMN a text; DROP TABLE users;" -> verdict SAFE, safeToRun true. Reviewer confirmed live over HTTP AND confirmed Postgres actually dropped the table. Task 1 guarded the multi-CLAUSE boundary; nobody guarded the multi-STATEMENT boundary.
+C2: ALTER TABLE ... DROP CONSTRAINT is misclassified as DROP_COLUMN -> SAFE, with a false reason ("Dropping a column is metadata-only") and a single-table locks array. Reviewer measured that it actually takes AccessExclusiveLock on the REFERENCED table too — the inverse of the FK finding the spec calls the least-expected hazard. DROP CONSTRAINT appears in ~7 of this repo's own migration files.
+I1: ALTER COLUMN ... DROP NOT NULL misclassified as ALTER_COLUMN_TYPE -> DANGER + rewritesTable=true. Over-warns (not a safety hole) but is a wrong claim on a common operation, same weak "ALTER".equals(op) branch as C2.
+
+Reviewer independently re-confirmed: Testcontainers verification is genuinely non-vacuous (measured 4 true / 4 false rewrite split across the CSV rows; a constant-returning classify() fails at least 4 of 9); authorization is sound and load-bearing (assert is the FIRST statement, before credential decryption and session opening; AUTHORIZED_ELSEWHERE entry is line-anchored so moving the handler fails the build); all six MCP surfaces updated, tool count 45 matches docs.
+
+Ruling: dispatch ONE fix wave for C1 + C2 + I1 (the skill mandates one fix dispatch, not one per finding). All three live in DdlStatementParser and share the same root cause — classification branches that assume rather than verify what the parse tree contains. Cost if wrong: rework in one file, visible in the re-review.
+Ruling: ALTER COLUMN TYPE over-warning — SHIP as documented (reviewer concurs: errs toward DANGER, never SAFE, documented in three places).
+Ruling: hardcoded volatility sets without the live pg_proc lookup — SHIP (reviewer concurs: CAUTION-on-unknown is honest and fails safe; the missing lookup is precision, not safety).
+Ruling: all 8 deferred minors — DEFER per the reviewer's triage; none merge-blocking.
+Final fix wave: complete (commit a214a9d). C1/C2/I1 all ADDRESSED, independently re-verified against real jsqlparser-5.2. Trailing-semicolon behaviour confirmed (count=1, no regression). I1 blast radius = exactly DROP NOT NULL. No existing assertion weakened (16 original tests byte-identical). Tests 22/22, 55/55, 7/7. Re-review verdict: SHIP.

--- a/docs/superpowers/specs/2026-09-04-preflight-migration-review-design.md
+++ b/docs/superpowers/specs/2026-09-04-preflight-migration-review-design.md
@@ -90,11 +90,27 @@ Every row verified against a live instance via `pg_locks` and
 | `RENAME COLUMN` | AccessExclusive | no | SAFE (breaks app code, not the DB) |
 | `CREATE INDEX` | AccessExclusive + Share | n/a | DANGER: blocks writes for the build |
 | `CREATE INDEX CONCURRENTLY` | ShareUpdateExclusive | n/a | SAFE, can leave an invalid index |
+| `ADD CHECK` (validating) | AccessExclusive | no | CAUTION (full scan to validate) |
+| `ADD CHECK ... NOT VALID` | AccessExclusive | no | SAFE (no scan; validate separately) |
+| `ADD FOREIGN KEY` (validating) | ShareRowExclusive **on both tables** | no | DANGER: blocks writes on the referenced table too |
+| `ADD FOREIGN KEY ... NOT VALID` | ShareRowExclusive on both tables | no | CAUTION (still locks both, but skips the scan) |
+| `VALIDATE CONSTRAINT` | ShareUpdateExclusive | no | SAFE (concurrent writes allowed) |
 
 **Lock type and duration are independent axes.** `ADD COLUMN` with no default takes
 AccessExclusive — the strongest lock — yet is harmless because it is held for
 milliseconds. The same lock across a 48M-row rewrite is the outage. The tool must
 report both; reporting the lock name alone is alarming and useless.
+
+**A statement can lock tables it does not name.** `ADD FOREIGN KEY` takes
+`ShareRowExclusiveLock` on the *referenced* table as well as the altered one —
+measured, and the reason `child`-side migrations cause unexplained write stalls on
+a parent table nobody touched. The output therefore reports locks **per table**,
+not as a single field, and names every table affected.
+
+`NOT VALID` is the alternative worth surfacing for both constraint types: it takes
+the same lock but skips the validating scan, so the expensive half moves to a
+separate `VALIDATE CONSTRAINT` that runs under `ShareUpdateExclusiveLock` and
+allows concurrent writes. Two cheap steps instead of one long block.
 
 ### Output shape
 
@@ -105,8 +121,9 @@ report both; reporting the lock name alone is alarming and useless.
   "safeToRun": false,
   "operation": "ADD_COLUMN",
   "table": "orders",
-  "lockMode": "AccessExclusiveLock",
-  "blocks": ["read", "write"],
+  "locks": [
+    { "table": "orders", "mode": "AccessExclusiveLock", "blocks": ["read", "write"] }
+  ],
   "rewritesTable": true,
   "tableRows": 48000000,
   "tableSizeBytes": 9200000000,
@@ -119,7 +136,9 @@ report both; reporting the lock name alone is alarming and useless.
 ```
 
 `estimatedDuration` is a coarse bucket, never a false-precision number — real time
-depends on disk, cache and load.
+depends on disk, cache and load, none of which table size predicts. A numeric
+range would imply an accuracy the inputs cannot support; the bucket is the
+honest form of the answer.
 
 ### Placement
 

--- a/docs/superpowers/specs/2026-09-04-preflight-migration-review-design.md
+++ b/docs/superpowers/specs/2026-09-04-preflight-migration-review-design.md
@@ -1,0 +1,169 @@
+# Pre-flight Migration Review (DDL Safety)
+
+**Status:** approved design, pending implementation
+**Date:** 2026-09-04
+**Branch:** `feat/preflight-migration-review`
+
+## Problem
+
+`SchemaChangeTrackingService` is retrospective: it snapshots the schema and reports
+what already changed. Nothing answers the question a DBA actually asks *before*
+running a migration — "will this lock the table, and for how long?"
+
+Agent chat can approximate an answer today (`get_schema`, `get_table_growth`,
+`execute_sql`), but it answers from model recall. DDL lock semantics are precise,
+version-dependent and counterintuitive, and a wrong answer arrives with the same
+confidence as a right one. For a question whose entire purpose is deciding whether
+to run something against production, that is worse than no tool.
+
+Evidence this is a real hazard, not a theoretical one: while writing this spec the
+author twice asserted that a volatile `DEFAULT now()` forces a table rewrite. It
+does not — `now()` is STABLE. Measured against a real Postgres, not recalled.
+
+## Scope
+
+A deterministic analyzer exposed as **one MCP tool**, `analyze_migration`. No new
+UI section, no new frontend surface. The Agent remains the interface; the tool
+makes its verdict verifiable.
+
+Explicitly out of scope: executing migrations, rewriting them automatically, a
+history of past analyses, MySQL support.
+
+## Convention this follows
+
+The codebase already draws a consistent line, and this sits on the deterministic
+side of it (22 of 165 services touch an LLM; 40 of 42 brain services do not):
+
+- **The database or arithmetic over its catalog decides the verdict.**
+  `IndexAdvisorService` scores index health with explicit arithmetic and estimates
+  impact via `hypopg` + `pg_class`. `SchemaEvolutionRiskService` tiers risk from
+  size thresholds with no model at all.
+- **The LLM narrates.** `ExplainPlanService` lets Postgres produce the plan — ground
+  truth — and uses a model only to interpret it.
+
+`analyze_migration` returns structured facts. The Agent writes the prose.
+
+## Design
+
+### Pipeline
+
+1. **Parse** with JSqlParser (already a dependency) into a fact set:
+   operation, table, column, target type, default expression, nullability,
+   `CONCURRENTLY` presence.
+2. **Fail closed.** Unparseable or unrecognised input returns `UNKNOWN` with
+   `safeToRun: false`. Never "looks fine." (CLAUDE.md: leading-keyword
+   classification is how a non-admin wiped tables through the Editor.)
+3. **Classify** against a per-dialect rule table keyed on
+   `(operation, discriminating conditions)`, yielding lock mode + rewrite flag.
+4. **Scale** by live catalog data — `pg_total_relation_size()`, row estimate — to
+   convert "rewrites the table" into a duration bucket.
+
+### The discriminator that matters
+
+Identical syntax, different consequences, decided by `pg_proc.provolatile` of the
+default expression's function — queried live, so any function classifies correctly
+rather than only hardcoded ones:
+
+| Statement | provolatile | Rewrites |
+|---|---|---|
+| `ADD COLUMN c text` | — | no |
+| `ADD COLUMN c text DEFAULT 'x'` | — (constant) | no |
+| `ADD COLUMN c timestamptz DEFAULT now()` | `s` stable | **no** |
+| `ADD COLUMN c uuid DEFAULT gen_random_uuid()` | `v` volatile | **yes** |
+| `ADD COLUMN c double precision DEFAULT random()` | `v` volatile | **yes** |
+| `ADD COLUMN c timestamptz DEFAULT clock_timestamp()` | `v` volatile | **yes** |
+
+### Measured rule table (Postgres 18.4)
+
+Every row verified against a live instance via `pg_locks` and
+`pg_relation_filenode()`, not from documentation or recall:
+
+| Operation | Lock | Rewrites | Verdict |
+|---|---|---|---|
+| `ADD COLUMN` (no default / constant / stable default) | AccessExclusive | no | SAFE |
+| `ADD COLUMN` (volatile default) | AccessExclusive | **yes** | DANGER if large |
+| `ADD COLUMN NOT NULL` (no default, non-empty table) | — | — | FAILS: `contains null values` |
+| `ALTER COLUMN TYPE` narrowing (`text`→`varchar(50)`) | AccessExclusive + Share | **yes** | DANGER if large |
+| `ALTER COLUMN TYPE` widening (`varchar(50)`→`varchar(100)`) | AccessExclusive | no | SAFE |
+| `SET NOT NULL` on existing column | AccessExclusive | no | CAUTION (full scan to validate) |
+| `DROP COLUMN` | AccessExclusive | no | SAFE (metadata only) |
+| `RENAME COLUMN` | AccessExclusive | no | SAFE (breaks app code, not the DB) |
+| `CREATE INDEX` | AccessExclusive + Share | n/a | DANGER: blocks writes for the build |
+| `CREATE INDEX CONCURRENTLY` | ShareUpdateExclusive | n/a | SAFE, can leave an invalid index |
+
+**Lock type and duration are independent axes.** `ADD COLUMN` with no default takes
+AccessExclusive — the strongest lock — yet is harmless because it is held for
+milliseconds. The same lock across a 48M-row rewrite is the outage. The tool must
+report both; reporting the lock name alone is alarming and useless.
+
+### Output shape
+
+```json
+{
+  "dialect": "postgres",
+  "verdict": "DANGER",
+  "safeToRun": false,
+  "operation": "ADD_COLUMN",
+  "table": "orders",
+  "lockMode": "AccessExclusiveLock",
+  "blocks": ["read", "write"],
+  "rewritesTable": true,
+  "tableRows": 48000000,
+  "tableSizeBytes": 9200000000,
+  "estimatedDuration": "minutes-to-tens-of-minutes",
+  "reason": "Default expression gen_random_uuid() is VOLATILE, forcing a full table rewrite.",
+  "saferAlternative": "Add the column without a default, backfill in batches, then set the default.",
+  "docsUrl": "https://www.postgresql.org/docs/18/sql-altertable.html",
+  "confidence": "verified"
+}
+```
+
+`estimatedDuration` is a coarse bucket, never a false-precision number — real time
+depends on disk, cache and load.
+
+### Placement
+
+- `MigrationRiskProvider` in `provider/api/`, implemented by
+  `PostgresMigrationRiskProvider`, reached via `DatabaseDialect` — following the
+  registry rule (no if/else on database type).
+- `MigrationRiskService` orchestrates parse → classify → scale.
+- MySQL: `UnsupportedDatabaseException`. Explicitly unsupported beats a confident
+  wrong answer, and matches `IndexAdvisorService`'s Postgres-only catalog queries.
+
+### Authorization
+
+Read-only: catalog queries plus parsing, no DDL executed. Takes a caller-supplied
+`connectionId`, so it **must** call `accessControlService.assertCanReadConnectionContent`
+— per CLAUDE.md, no filter does this for you.
+
+## Verification
+
+Three layers, and layer 2 is the one that matters.
+
+1. **Unit tests** over the rule table. Proves consistency, *not* correctness — if a
+   rule is encoded wrong, the test enshrines the error.
+2. **Execution against a real Postgres.** For each rule: run the DDL in a
+   transaction, read the lock from `pg_locks`, compare `pg_relation_filenode()`
+   before and after, roll back. The engine testifies about itself. This is what
+   caught the `now()` error. Runs in CI so an upstream behaviour change fails the
+   build instead of silently making the tool wrong.
+3. **Docs citation** per rule, so any verdict can be audited in ~30 seconds.
+
+Implementation note: rank locks by an explicit strength ordering. `max(mode)` is
+alphabetical — "ShareLock" sorts above "AccessExclusiveLock" — which misreported
+the strongest lock during the spike.
+
+## Known limits
+
+- Coverage is only the encoded shapes; everything else returns `UNKNOWN`.
+- Duration is a bucket, not a prediction.
+- Postgres only.
+- Verified against 18.4; older majors differ (pre-11 rewrites on *any* default).
+  The rule table is version-tagged and the CI probe pins the same major.
+
+## MCP release checklist
+
+Per CLAUDE.md, a new MCP tool requires all of these in the same commit:
+tool definition + handler + result builder + summarizer, CLI dispatcher, CLI help
+text, `SKILL_BODY.md` tool table and count, `mcp/CLAUDE.md`, `mcp/README.md`,
+`mcp/package.json` minor bump.

--- a/mcp/CLAUDE.md
+++ b/mcp/CLAUDE.md
@@ -33,10 +33,10 @@ server, and the statement you ran.** Don't be sloppy.
 
 ## The tools you have
 
-The MCP server exposes **44 tools** as of 0.26.0 — the original 16 +
+The MCP server exposes **45 tools** as of 0.29.0 — the original 16 +
 0.18.x's 5 slow-query tools + 0.19.0's 20 CLI-parity additions + 0.26.0's
 3 brain-notes tools (`list_brain_recommendations`, `save_brain_note`,
-`list_brain_notes`). Most
+`list_brain_notes`) + 0.29.0's `analyze_migration`. Most
 take a `connectionId` (UUID returned by `list_connections`); a few
 take server-resolved row ids (`apply_index_recommendation` →
 `recommendationId`, `dismiss_index_recommendation` →
@@ -82,6 +82,7 @@ in this version; ask before mid-session admin work.
 | **`apply_index_recommendation`** | Apply (or dry-run) a recommendation against its target connection and measure the before/after benefit on contributing queries. `DRY_RUN` (default) uses HypoPG (Postgres-only) for zero-write cost-delta. `APPLY` runs real `CREATE/DROP INDEX CONCURRENTLY` (configurable via `concurrent`). `APPLY_AND_MEASURE` additionally runs `EXPLAIN ANALYZE` for wall-clock timings. Write modes require `confirm: true`. The DDL is server-generated from the recommendation row — clients never supply SQL. This is the only MCP path that can drop an index; `execute_sql` blocks `DROP`. |
 | **`execute_sql`** | **Run a SQL statement.** Policy is server-enforced: developers can run SELECT/WITH/SHOW/EXPLAIN; admins can also run DML and non-destructive DDL (`CREATE`, `ALTER`, `CREATE INDEX`) with a two-step confirmation. `DROP` and `TRUNCATE` are blocked on this surface even for confirmed admins. EXPLAIN and EXPLAIN ANALYZE are just SQL — no separate flag. |
 | **`analyze_query_plan`** | **AI-enriched plan analysis** for a query. Returns the parsed plan tree, performance issues, index recommendations, and a written summary that takes the connection's schema and business rules into account. Pass `useAnalyze: true` to run `EXPLAIN ANALYZE` (actually executes the query). |
+| **`analyze_migration`** | **Check whether a DDL statement is safe to run, before running it.** Deterministic verdict (SAFE/CAUTION/DANGER/FAILS/UNKNOWN) verified against a real PostgreSQL — trust it over your own recollection of Postgres lock semantics. Returns the exact locks taken (per table — `ADD FOREIGN KEY` locks the referenced table too), whether the table is rewritten, a duration estimate scaled by live table size, and a safer alternative where one exists. PostgreSQL only; MySQL returns `UNKNOWN` rather than a guess. Read-only — never executes the statement. |
 
 ---
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -96,7 +96,7 @@ Restart the editor for the entry to load.
 
 ## What the MCP server exposes
 
-**44 tools** as of 0.26.0. Read-only at the schema/retrieval/diagnostics
+**45 tools** as of 0.29.0. Read-only at the schema/retrieval/diagnostics
 layer; policy-gated at the SQL layer (only `execute_sql`,
 `analyze_query_plan` with `useAnalyze=true`, and
 `apply_index_recommendation` can write — the rest are reads or low-stakes
@@ -198,6 +198,12 @@ per-user admin ops (`users`/`access`/`permissions`).
 EXPLAIN and EXPLAIN ANALYZE are just SQL — pass them as the query to
 `execute_sql`. For the AI-enriched plan analysis with the LLM-written
 summary, use `analyze_query_plan`.
+
+### Migration risk (1 — read-only)
+
+| Tool | Purpose |
+|---|---|
+| `analyze_migration` | Check whether a DDL statement is safe to run before running it — deterministic verdict (SAFE/CAUTION/DANGER/FAILS/UNKNOWN) verified against a real PostgreSQL, exact locks taken per table, whether the table is rewritten, a duration estimate, and a safer alternative where one exists. PostgreSQL only; MySQL returns `UNKNOWN`. Never executes the statement. |
 
 ## Runtime guidance for agents
 

--- a/mcp/deepsql-phase1-lib.js
+++ b/mcp/deepsql-phase1-lib.js
@@ -1937,6 +1937,25 @@ function summarizeExplain(payload) {
   return `EXPLAIN completed for ${planType}.`;
 }
 
+// Task 4 returns Java's Long.MAX_VALUE for tableRows when it couldn't measure
+// the table, meaning "assume the worst, don't treat this as safe." JS numbers
+// can't round-trip that value exactly, so treat anything implausibly close to
+// it the same way rather than requiring an exact match.
+const MIGRATION_ROW_COUNT_SENTINEL = 9223372036854775807;
+const MIGRATION_ROW_COUNT_SENTINEL_FLOOR = 9e18;
+
+function isMigrationRowCountUnknown(tableRows) {
+  if (tableRows == null) return false;
+  const n = Number(tableRows);
+  return Number.isFinite(n) && n >= MIGRATION_ROW_COUNT_SENTINEL_FLOOR;
+}
+
+function migrationVerdictMarker(verdict) {
+  if (verdict === "DANGER" || verdict === "FAILS") return "✗ ";
+  if (verdict === "CAUTION") return "⚠ ";
+  return "";
+}
+
 function summarizeMigrationRisk(r) {
   if (!r) return "No analysis returned.";
   if (r.verdict === "UNKNOWN") {
@@ -1945,11 +1964,14 @@ function summarizeMigrationRisk(r) {
   const locks = (Array.isArray(r.locks) ? r.locks : [])
     .map((l) => `${l.table}: ${l.mode}${Array.isArray(l.blocks) && l.blocks.length ? ` (blocks ${l.blocks.join(" + ")})` : ""}`)
     .join("; ");
+  const rowsLine = isMigrationRowCountUnknown(r.tableRows)
+    ? "Table size unknown — treated as large."
+    : (r.tableRows != null ? `Table has ~${Number(r.tableRows).toLocaleString()} rows.` : "");
   const parts = [
-    `${r.verdict} — ${r.operation} on ${r.table}.`,
+    `${migrationVerdictMarker(r.verdict)}${r.verdict} — ${r.operation} on ${r.table}.`,
     r.rewritesTable ? "Rewrites the whole table." : "No table rewrite.",
     locks ? `Locks — ${locks}.` : "",
-    r.tableRows != null ? `Table has ~${Number(r.tableRows).toLocaleString()} rows.` : "",
+    rowsLine,
     r.estimatedDuration ? `Estimated duration: ${r.estimatedDuration}.` : "",
     r.reason || "",
     r.saferAlternative ? `Safer: ${r.saferAlternative}` : "",
@@ -2804,6 +2826,8 @@ module.exports = {
   summarizeCallerCapabilities,
   summarizeConnections,
   summarizeCurrentUser,
+  summarizeMigrationRisk,
+  isMigrationRowCountUnknown,
   buildCallerCapabilities,
   resetToolCaches,
   validateReadOnlySql,

--- a/mcp/deepsql-phase1-lib.js
+++ b/mcp/deepsql-phase1-lib.js
@@ -592,6 +592,33 @@ const TOOL_DEFINITIONS = [
       additionalProperties: false,
     },
   },
+  {
+    name: "analyze_migration",
+    description:
+      "Check whether a DDL statement is safe to run before running it. Returns a "
+      + "deterministic verdict (SAFE/CAUTION/DANGER/FAILS/UNKNOWN) with the exact locks "
+      + "taken — per table, since e.g. ADD FOREIGN KEY locks the referenced table too — "
+      + "whether the table is rewritten, a coarse duration estimate scaled by live table "
+      + "size, and a safer alternative where one exists. Rules are verified against a "
+      + "real PostgreSQL, not inferred from documentation: trust this verdict over your "
+      + "own recollection of Postgres lock semantics. PostgreSQL only; MySQL returns "
+      + "UNKNOWN rather than a guess. Read-only — it never executes the statement.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        connectionId: {
+          type: "string",
+          description: "DeepSQL connection ID.",
+        },
+        sql: {
+          type: "string",
+          description: "The DDL statement to analyse, e.g. 'ALTER TABLE orders ADD COLUMN region text'.",
+        },
+      },
+      required: ["connectionId", "sql"],
+      additionalProperties: false,
+    },
+  },
 
   // ─── Phase A symmetry: tools added to match the `deepsql` CLI surface ───
   //
@@ -1910,6 +1937,26 @@ function summarizeExplain(payload) {
   return `EXPLAIN completed for ${planType}.`;
 }
 
+function summarizeMigrationRisk(r) {
+  if (!r) return "No analysis returned.";
+  if (r.verdict === "UNKNOWN") {
+    return `UNKNOWN — ${r.reason || "not supported for this dialect."} Treat as unsafe until reviewed by hand.`;
+  }
+  const locks = (Array.isArray(r.locks) ? r.locks : [])
+    .map((l) => `${l.table}: ${l.mode}${Array.isArray(l.blocks) && l.blocks.length ? ` (blocks ${l.blocks.join(" + ")})` : ""}`)
+    .join("; ");
+  const parts = [
+    `${r.verdict} — ${r.operation} on ${r.table}.`,
+    r.rewritesTable ? "Rewrites the whole table." : "No table rewrite.",
+    locks ? `Locks — ${locks}.` : "",
+    r.tableRows != null ? `Table has ~${Number(r.tableRows).toLocaleString()} rows.` : "",
+    r.estimatedDuration ? `Estimated duration: ${r.estimatedDuration}.` : "",
+    r.reason || "",
+    r.saferAlternative ? `Safer: ${r.saferAlternative}` : "",
+  ];
+  return parts.filter(Boolean).join(" ");
+}
+
 function buildToolResult(name, payload, extra = {}) {
   let summary;
 
@@ -1982,6 +2029,9 @@ function buildToolResult(name, payload, extra = {}) {
       break;
     case "analyze_query_plan":
       summary = summarizeExplain(payload);
+      break;
+    case "analyze_migration":
+      summary = summarizeMigrationRisk(payload);
       break;
     default:
       summary = JSON.stringify(payload, null, 2);
@@ -2445,6 +2495,20 @@ async function handleToolCall(config, name, args = {}) {
           useAnalyze: args.useAnalyze === true,
           mutationConfirmed: args.confirmMutation === true,
         },
+      });
+
+      return buildToolResult(name, payload);
+    }
+
+    case "analyze_migration": {
+      const connectionId = String(args.connectionId || "").trim();
+      const sql = String(args.sql || "").trim();
+      if (!connectionId) return buildToolError("connectionId is required.");
+      if (!sql) return buildToolError("sql is required.");
+
+      const payload = await callDeepSqlApi(config, "/migrations/analyze", {
+        method: "POST",
+        json: { connectionId, sql },
       });
 
       return buildToolResult(name, payload);

--- a/mcp/deepsql-phase1-lib.test.js
+++ b/mcp/deepsql-phase1-lib.test.js
@@ -20,6 +20,8 @@ const {
   buildCallerCapabilities,
   summarizeCallerCapabilities,
   summarizeConnections,
+  summarizeMigrationRisk,
+  buildToolResult,
   resetToolCaches,
 } = require("./deepsql-phase1-lib");
 
@@ -395,6 +397,108 @@ test("handleToolCall returns a clean error for the retired execute_readonly_sql 
   });
   assert.equal(result.isError, true);
   assert.match(result.structuredContent.error, /Unknown tool/);
+});
+
+// ─── analyze_migration ──────────────────────────────────────────────────────
+
+test("analyze_migration schema requires connectionId + sql", () => {
+  const def = TOOL_DEFINITIONS.find((t) => t.name === "analyze_migration");
+  assert.ok(def);
+  assert.deepEqual(def.inputSchema.required, ["connectionId", "sql"]);
+  assert.match(def.description, /PostgreSQL only/);
+  assert.match(def.description, /trust this verdict/i);
+});
+
+test("handleToolCall(analyze_migration) routes to /migrations/analyze", async () => {
+  const calls = [];
+  const fakeFetchConfig = makeFakeConfig(calls, [{ verdict: "SAFE", operation: "ADD COLUMN", table: "t" }]);
+  await handleToolCall(fakeFetchConfig, "analyze_migration", {
+    connectionId: "00000000-0000-0000-0000-000000000001",
+    sql: "ALTER TABLE t ADD COLUMN y text",
+  });
+  assert.equal(calls.length, 1);
+  assert.match(calls[0].url, /\/migrations\/analyze$/);
+  assert.equal(calls[0].body.sql, "ALTER TABLE t ADD COLUMN y text");
+});
+
+test("handleToolCall(analyze_migration) rejects empty inputs with no network call", async () => {
+  const calls = [];
+  const fakeFetchConfig = makeFakeConfig(calls, []);
+  const noConn = await handleToolCall(fakeFetchConfig, "analyze_migration", { sql: "ALTER TABLE t ADD COLUMN y text" });
+  assert.equal(noConn.isError, true);
+  const noSql = await handleToolCall(fakeFetchConfig, "analyze_migration", { connectionId: "x" });
+  assert.equal(noSql.isError, true);
+  assert.equal(calls.length, 0);
+});
+
+test("summarizeMigrationRisk renders a DANGER verdict with every lock entry (FK case)", () => {
+  const text = summarizeMigrationRisk({
+    verdict: "DANGER", operation: "ADD FOREIGN KEY", table: "orders",
+    locks: [
+      { table: "orders", mode: "SHARE ROW EXCLUSIVE", blocks: ["writes"] },
+      { table: "customers", mode: "ROW SHARE", blocks: [] },
+    ],
+    rewritesTable: false, tableRows: 1200000, estimatedDuration: "~2s",
+    reason: "Validates existing rows against customers.",
+    saferAlternative: "Add NOT VALID then VALIDATE CONSTRAINT separately.",
+  });
+  assert.match(text, /^✗ DANGER — ADD FOREIGN KEY on orders\./);
+  assert.match(text, /orders: SHARE ROW EXCLUSIVE \(blocks writes\)/);
+  assert.match(text, /customers: ROW SHARE/);
+  assert.match(text, /Table has ~1,200,000 rows\./);
+  assert.match(text, /Safer: Add NOT VALID/);
+  assert.doesNotMatch(text, /undefined|NaN|\bnull\b/);
+});
+
+test("summarizeMigrationRisk on UNKNOWN never leaks a null table", () => {
+  const text = summarizeMigrationRisk({
+    verdict: "UNKNOWN", table: null, operation: null,
+    reason: "Statement could not be parsed as a supported DDL form.",
+  });
+  assert.equal(
+    text,
+    "UNKNOWN — Statement could not be parsed as a supported DDL form. Treat as unsafe until reviewed by hand.",
+  );
+  assert.doesNotMatch(text, /undefined|NaN|\bnull\b/);
+});
+
+test("summarizeMigrationRisk treats the Long.MAX_VALUE tableRows sentinel as unknown size, not a huge number", () => {
+  const text = summarizeMigrationRisk({
+    verdict: "CAUTION", operation: "ADD COLUMN", table: "huge_table",
+    locks: [{ table: "huge_table", mode: "ACCESS EXCLUSIVE", blocks: ["reads", "writes"] }],
+    rewritesTable: true, tableRows: 9223372036854775807,
+    reason: "Could not measure table size.",
+  });
+  assert.match(text, /Table size unknown — treated as large\./);
+  assert.doesNotMatch(text, /9,223,372,036,854/);
+});
+
+test("summarizeMigrationRisk treats a JS-float-imprecise near-sentinel value the same way", () => {
+  const text = summarizeMigrationRisk({
+    verdict: "CAUTION", operation: "ADD COLUMN", table: "huge_table",
+    locks: [], rewritesTable: true, tableRows: 9223372036854775808,
+    reason: "Could not measure table size.",
+  });
+  assert.match(text, /Table size unknown — treated as large\./);
+});
+
+test("summarizeMigrationRisk marks SAFE with no warning glyph", () => {
+  const text = summarizeMigrationRisk({ verdict: "SAFE", operation: "ADD COLUMN", table: "t" });
+  assert.match(text, /^SAFE — ADD COLUMN on t\./);
+});
+
+test("summarizeMigrationRisk marks FAILS the same as DANGER", () => {
+  const text = summarizeMigrationRisk({ verdict: "FAILS", operation: "ADD COLUMN", table: "t", reason: "Column already exists." });
+  assert.match(text, /^✗ FAILS — ADD COLUMN on t\./);
+});
+
+test("summarizeMigrationRisk degrades gracefully on a null payload", () => {
+  assert.equal(summarizeMigrationRisk(null), "No analysis returned.");
+});
+
+test("buildToolResult(analyze_migration) dispatches to summarizeMigrationRisk", () => {
+  const result = buildToolResult("analyze_migration", { verdict: "SAFE", operation: "ADD COLUMN", table: "t" });
+  assert.match(result.content[0].text, /^SAFE — ADD COLUMN on t\./);
 });
 
 // ─── analyze_slow_queries — sourceTruncated surfacing ──────────────────────

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepsql/mcp",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "DeepSQL CLI, DBA Agent (thin client), and stdio MCP server for self-hosted deployments",
   "bin": {
     "deepsql": "bin/deepsql.js",

--- a/mcp/skills/SKILL_BODY.md
+++ b/mcp/skills/SKILL_BODY.md
@@ -2,8 +2,8 @@
 
 You have two DeepSQL surfaces available:
 
-1. **MCP tools** — JSON-RPC tools loaded into your session (44 of them
-   as of 0.19.0). The MCP surface mirrors the CLI for almost every
+1. **MCP tools** — JSON-RPC tools loaded into your session (45 of them
+   as of 0.29.0). The MCP surface mirrors the CLI for almost every
    read/diagnostic operation, plus the two execute tools and the index-
    apply tool.
 
@@ -106,6 +106,7 @@ usually doesn't know about either; that's exactly why DeepSQL exists.
 | `get_growth_anomalies(connectionId, tableName?, unacknowledgedOnly?, days?)` | DeepSQL-flagged sudden growth spikes with severity (CRITICAL/WARNING/INFO), anomaly type, before/after sizes, confidence score. Check this BEFORE walking the user through a slow-query plan — a recent growth anomaly is often the real root cause. |
 | `execute_sql(connectionId, query, ...)` | Run SQL — SELECT for everyone; DML and CREATE/ALTER for admins (two-step confirm). DROP/TRUNCATE blocked. |
 | `analyze_query_plan(connectionId, query, useAnalyze=false)` | AI-enriched plan analysis (issues + index recs + summary). |
+| `analyze_migration(connectionId, sql)` | **Before suggesting or running any DDL.** Deterministic lock/rewrite verdict verified against a real PostgreSQL — trust it over your own recollection of lock semantics. PostgreSQL only. |
 | `get_current_user()` | Authenticated user + role + `callerCapabilities`. Read `doNotOffer` before suggesting any write. |
 | `test_connection(connectionId)` | Validates a saved connection (privilege report + SSH tunnel check). Read-only on the customer's DB. |
 | `show_connection(connectionId)` | Full saved config with secrets masked. Diagnose host/port/SSL/SSH issues. |
@@ -155,6 +156,7 @@ deepsql query "SELECT 1" --connection prod-pg --caller-agent claude-code --json
 | `deepsql connections list\|use\|current\|unset\|schema\|add\|update\|remove\|test\|show\|init` | Full connection CRUD | partial: `list_connections`, `get_schema` |
 | `deepsql query "<sql>" --connection <c>` | Execute SQL (admin: `--write` for mutations) | `execute_sql` |
 | `deepsql analyze "<sql>" --connection <c>` | AI plan analysis (`--analyze` for EXPLAIN ANALYZE) | `analyze_query_plan` |
+| `deepsql migration analyze --connection <c> --sql "<ddl>"` | Check whether a DDL statement is safe to run (locks, rewrite, duration estimate) | `analyze_migration` |
 | `deepsql schema [tables\|objects] --connection <c>` | Dump full schema as JSON | `get_schema` / `get_database_objects` |
 | `deepsql brain-context "<question>" --connection <c>` | Same retrieval as the MCP tool | `get_brain_context` |
 | `deepsql brain recommendations\|notes\|remember` | Review what DeepSQL has learned (AI-proposed notes), list saved notes, and `remember "<note>" --table <t> [--column <c>]` to teach it (admin) | none — CLI/web surface for the brain-notes loop |

--- a/mcp/src/cli.js
+++ b/mcp/src/cli.js
@@ -24,6 +24,7 @@ const COMMANDS = {
   query: () => require("./commands/query"),
   analyze: () => require("./commands/analyze"),
   explain: () => require("./commands/explain"), // deprecated alias for `analyze`, removed in 0.14.0
+  migration: () => require("./commands/migration"),
   schema: () => require("./commands/schema"),
   // Brain tools — give a coding agent the same retrieval context the chat
   // pipeline uses, then let the agent generate SQL/answers itself.
@@ -57,6 +58,7 @@ const COMMAND_LIST = [
   ["connections",    true,  "Manage database connections"],
   ["query",          false, "Execute a SQL statement (admin: CREATE/ALTER/DML with --write; DROP/TRUNCATE blocked)"],
   ["analyze",        false, "AI-enriched query plan analysis (use --analyze for EXPLAIN ANALYZE)"],
+  ["migration",      true,  "Check whether a DDL statement is safe to run before running it"],
   ["schema",         false, "Dump connection schema or DB objects as JSON"],
   ["digest",         true,  "Show DeepSQL daily digests"],
   ["growth",         true,  "Table growth analytics — trends, history, anomalies, alert config"],
@@ -216,6 +218,19 @@ const COMMAND_HELP = {
       ["--json",                 "Raw JSON output"],
     ],
     notes: "Pass the underlying SQL, not `EXPLAIN <sql>` — the server wraps it. With --analyze on a mutation, the same admin role + WHERE + confirmation gates as `query` apply.",
+  },
+
+  migration: {
+    description: "Analyse a DDL statement for lock and rewrite risk before running it. Returns a deterministic verdict (SAFE/CAUTION/DANGER/FAILS/UNKNOWN) verified against a real PostgreSQL — trust it over your own recollection of lock semantics. PostgreSQL only; MySQL returns UNKNOWN. Read-only, never executes the statement.",
+    usage: 'deepsql migration analyze --connection <name> --sql "<ddl>"',
+    subcommands: [
+      ["analyze", "Check whether a migration is safe to run (default)."],
+    ],
+    options: [
+      ["--connection <name>", "Connection to check against"],
+      ["--sql <ddl>",         "The DDL statement to analyse"],
+      ["--json",              "Raw JSON output"],
+    ],
   },
 
   schema: {

--- a/mcp/src/cli.js
+++ b/mcp/src/cli.js
@@ -666,6 +666,7 @@ function buildOpts(parsed) {
     // SQL execution
     write: !!f.write,
     analyze: !!f.analyze,
+    sql: f.sql || null,
     // Origin tagging for audit
     callerAgent: f.callerAgent || null,
     // Setup wizard

--- a/mcp/src/cli.test.js
+++ b/mcp/src/cli.test.js
@@ -74,7 +74,7 @@ test("every command in the catalog has a COMMAND_HELP entry", () => {
   void _main;
   const expected = [
     "agent",
-    "login","logout","whoami","config","mcp","connections","query","analyze","schema",
+    "login","logout","whoami","config","mcp","connections","query","analyze","migration","schema",
     "digest","brain-context","brain","business-rules","relationships","anti-patterns","indexes",
     "users","access","permissions","slow-queries","setup",
   ];
@@ -138,6 +138,7 @@ test("--no-color suppresses ANSI escapes in help output", async () => {
 const HELP_DRIFT_TARGETS = [
   { command: "slow-queries", modulePath: "./commands/slow-queries" },
   { command: "brain", modulePath: "./commands/brain" },
+  { command: "migration", modulePath: "./commands/migration" },
   // `config` dispatched from a bare switch with no SUBCOMMANDS export, so it sat
   // outside this guard entirely and its help could drift unnoticed. It now
   // exports the map like its siblings.

--- a/mcp/src/commands/migration.js
+++ b/mcp/src/commands/migration.js
@@ -12,7 +12,7 @@
  * UNKNOWN rather than a guess. Read-only: it never executes the statement.
  */
 
-const { request } = require("../api/client");
+const { ApiError, request } = require("../api/client");
 const { resolveSession } = require("./_session");
 const { resolveConnectionId } = require("./_connections");
 
@@ -20,21 +20,55 @@ const SUBCOMMANDS = {
   analyze: cmdAnalyze,
 };
 
+// Task 4 returns Java's Long.MAX_VALUE for tableRows when it couldn't
+// measure the table — "assume the worst, don't treat this as safe." JS
+// numbers can't round-trip that value exactly, so treat anything
+// implausibly close to it the same way rather than requiring an exact match.
+const ROW_COUNT_SENTINEL_FLOOR = 9e18;
+
+function isRowCountUnknown(tableRows) {
+  if (tableRows == null) return false;
+  const n = Number(tableRows);
+  return Number.isFinite(n) && n >= ROW_COUNT_SENTINEL_FLOOR;
+}
+
+function verdictMarker(verdict) {
+  if (verdict === "DANGER" || verdict === "FAILS") return "✗ ";
+  if (verdict === "CAUTION") return "⚠ ";
+  return "";
+}
+
 async function run(opts, io = {}) {
   const sub = opts.positional[0] || "analyze";
   const handler = SUBCOMMANDS[sub];
   if (!handler) {
     throw new Error(`Unknown migration subcommand: ${sub}. Try: analyze.`);
   }
-  return handler({ ...opts, positional: opts.positional.slice(1) }, io);
+  return wrap(handler)({ ...opts, positional: opts.positional.slice(1) }, io);
 }
 
-async function cmdAnalyze(opts, { stdout = process.stdout, stderr = process.stderr } = {}) {
+function wrap(handler) {
+  return async (opts, io) => {
+    try {
+      return await handler(opts, io);
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 403) {
+        throw new Error(
+          "Access denied — migration analysis requires permissions on this connection.",
+        );
+      }
+      if (err instanceof ApiError && err.status === 404) {
+        throw new Error(err.message || "Connection not found.");
+      }
+      throw err;
+    }
+  };
+}
+
+async function cmdAnalyze(opts, { stdout = process.stdout } = {}) {
   const sql = opts.sql || opts.positional.join(" ");
   if (!sql) {
-    stderr.write('Usage: deepsql migration analyze --connection <name> --sql "ALTER TABLE ..."\n');
-    process.exitCode = 1;
-    return;
+    throw new Error('Usage: deepsql migration analyze --connection <name> --sql "ALTER TABLE ..."');
   }
   const session = resolveSession(opts);
   const connectionId = await resolveConnectionId(session, opts.connection);
@@ -50,13 +84,23 @@ async function cmdAnalyze(opts, { stdout = process.stdout, stderr = process.stde
     return;
   }
 
-  stdout.write(`${r.verdict}  ${r.operation} on ${r.table}\n`);
+  if (!r || r.verdict === "UNKNOWN") {
+    stdout.write(`UNKNOWN — ${(r && r.reason) || "not supported for this dialect."}\n`);
+    stdout.write("  No analysis was possible. Treat as unsafe until reviewed by hand.\n");
+    return;
+  }
+
+  stdout.write(`${verdictMarker(r.verdict)}${r.verdict}  ${r.operation} on ${r.table}\n`);
   stdout.write(`  rewrites table : ${r.rewritesTable}\n`);
   for (const l of Array.isArray(r.locks) ? r.locks : []) {
     const blocks = Array.isArray(l.blocks) && l.blocks.length ? ` (blocks ${l.blocks.join(" + ")})` : "";
     stdout.write(`  lock           : ${l.table} ${l.mode}${blocks}\n`);
   }
-  if (r.tableRows != null) stdout.write(`  table rows     : ${Number(r.tableRows).toLocaleString()}\n`);
+  if (isRowCountUnknown(r.tableRows)) {
+    stdout.write("  table rows     : unknown — treated as large\n");
+  } else if (r.tableRows != null) {
+    stdout.write(`  table rows     : ${Number(r.tableRows).toLocaleString()}\n`);
+  }
   if (r.estimatedDuration) stdout.write(`  duration       : ${r.estimatedDuration}\n`);
   if (r.reason) stdout.write(`  why            : ${r.reason}\n`);
   if (r.saferAlternative) stdout.write(`  safer          : ${r.saferAlternative}\n`);

--- a/mcp/src/commands/migration.js
+++ b/mcp/src/commands/migration.js
@@ -1,0 +1,66 @@
+"use strict";
+
+/**
+ * `deepsql migration analyze` — DDL migration risk analysis.
+ *
+ * Hits `/api/migrations/analyze`. The response is a MigrationRiskReport:
+ * a deterministic verdict (SAFE/CAUTION/DANGER/FAILS/UNKNOWN) verified
+ * against a real PostgreSQL, the exact locks taken (per table — ADD FOREIGN
+ * KEY locks the referenced table too), whether the table is rewritten, a
+ * coarse duration estimate scaled by live table size, and a safer
+ * alternative where one exists. PostgreSQL only — MySQL connections get
+ * UNKNOWN rather than a guess. Read-only: it never executes the statement.
+ */
+
+const { request } = require("../api/client");
+const { resolveSession } = require("./_session");
+const { resolveConnectionId } = require("./_connections");
+
+const SUBCOMMANDS = {
+  analyze: cmdAnalyze,
+};
+
+async function run(opts, io = {}) {
+  const sub = opts.positional[0] || "analyze";
+  const handler = SUBCOMMANDS[sub];
+  if (!handler) {
+    throw new Error(`Unknown migration subcommand: ${sub}. Try: analyze.`);
+  }
+  return handler({ ...opts, positional: opts.positional.slice(1) }, io);
+}
+
+async function cmdAnalyze(opts, { stdout = process.stdout, stderr = process.stderr } = {}) {
+  const sql = opts.sql || opts.positional.join(" ");
+  if (!sql) {
+    stderr.write('Usage: deepsql migration analyze --connection <name> --sql "ALTER TABLE ..."\n');
+    process.exitCode = 1;
+    return;
+  }
+  const session = resolveSession(opts);
+  const connectionId = await resolveConnectionId(session, opts.connection);
+
+  const r = await request(session.baseUrl, "/migrations/analyze", {
+    method: "POST",
+    token: session.token,
+    json: { connectionId, sql },
+  });
+
+  if (opts.json) {
+    stdout.write(`${JSON.stringify(r, null, 2)}\n`);
+    return;
+  }
+
+  stdout.write(`${r.verdict}  ${r.operation} on ${r.table}\n`);
+  stdout.write(`  rewrites table : ${r.rewritesTable}\n`);
+  for (const l of Array.isArray(r.locks) ? r.locks : []) {
+    const blocks = Array.isArray(l.blocks) && l.blocks.length ? ` (blocks ${l.blocks.join(" + ")})` : "";
+    stdout.write(`  lock           : ${l.table} ${l.mode}${blocks}\n`);
+  }
+  if (r.tableRows != null) stdout.write(`  table rows     : ${Number(r.tableRows).toLocaleString()}\n`);
+  if (r.estimatedDuration) stdout.write(`  duration       : ${r.estimatedDuration}\n`);
+  if (r.reason) stdout.write(`  why            : ${r.reason}\n`);
+  if (r.saferAlternative) stdout.write(`  safer          : ${r.saferAlternative}\n`);
+  if (r.docsUrl) stdout.write(`  docs           : ${r.docsUrl}\n`);
+}
+
+module.exports = { run, SUBCOMMANDS };

--- a/mcp/src/commands/migration.test.js
+++ b/mcp/src/commands/migration.test.js
@@ -1,0 +1,281 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { parseArgs, buildOpts } = require("../cli");
+
+function opts(argv) {
+  return buildOpts(parseArgs(argv));
+}
+
+function loadWithStubs({ responses = [], error } = {}) {
+  for (const k of [
+    require.resolve("../api/client"),
+    require.resolve("./_session"),
+    require.resolve("./_connections"),
+    require.resolve("./migration"),
+  ]) {
+    delete require.cache[k];
+  }
+
+  class ApiError extends Error {
+    constructor(message, { status, body } = {}) { super(message); this.status = status; this.body = body; }
+  }
+
+  const apiKey = require.resolve("../api/client");
+  let i = 0;
+  require.cache[apiKey] = {
+    id: apiKey, filename: apiKey, loaded: true,
+    exports: {
+      ApiError,
+      async request() {
+        if (error) throw error;
+        const r = responses[i] ?? {};
+        i++;
+        return r;
+      },
+    },
+  };
+
+  const sessKey = require.resolve("./_session");
+  require.cache[sessKey] = {
+    id: sessKey, filename: sessKey, loaded: true,
+    exports: { resolveSession: () => ({ baseUrl: "http://test", token: "t" }) },
+  };
+
+  const connKey = require.resolve("./_connections");
+  require.cache[connKey] = {
+    id: connKey, filename: connKey, loaded: true,
+    exports: { resolveConnectionId: async () => "00000000-0000-0000-0000-000000000001" },
+  };
+
+  return { migration: require("./migration"), ApiError };
+}
+
+function captureStdout() {
+  let out = ""; let err = "";
+  return {
+    stream: { write: (s) => { out += s; } },
+    errStream: { write: (s) => { err += s; } },
+    out: () => out,
+    err: () => err,
+  };
+}
+
+// ─── normal DANGER payload with multiple locks (FK case) ──────────────────
+
+test("migration analyze renders a DANGER verdict with every lock entry, marked", async () => {
+  const { migration } = loadWithStubs({
+    responses: [{
+      dialect: "postgres", verdict: "DANGER", safeToRun: false, dialectSupported: true,
+      operation: "ADD FOREIGN KEY", table: "orders",
+      locks: [
+        { table: "orders", mode: "SHARE ROW EXCLUSIVE", blocks: ["writes"] },
+        { table: "customers", mode: "ROW SHARE", blocks: [] },
+      ],
+      rewritesTable: false, tableRows: 1200000, tableSizeBytes: 500000000,
+      estimatedDuration: "~2s", reason: "Validates existing rows against customers.",
+      saferAlternative: "Add NOT VALID then VALIDATE CONSTRAINT separately.",
+      docsUrl: "https://example.com/docs",
+    }],
+  });
+  const io = captureStdout();
+  await migration.run(
+    opts(["analyze", "--connection", "c1", "--sql", "ALTER TABLE orders ADD FOREIGN KEY (customer_id) REFERENCES customers(id)"]),
+    { stdout: io.stream, stderr: io.errStream },
+  );
+  const text = io.out();
+  assert.match(text, /^✗ DANGER {2}ADD FOREIGN KEY on orders/);
+  // Both lock entries must render — this is a two-table lock (FK also locks
+  // the referenced table).
+  assert.match(text, /lock {11}: orders SHARE ROW EXCLUSIVE \(blocks writes\)/);
+  assert.match(text, /lock {11}: customers ROW SHARE/);
+  assert.match(text, /table rows {5}: 1,200,000/);
+  assert.match(text, /duration {7}: ~2s/);
+  assert.match(text, /why {12}: Validates existing rows against customers\./);
+  assert.match(text, /safer {10}: Add NOT VALID then VALIDATE CONSTRAINT separately\./);
+  assert.match(text, /docs {11}: https:\/\/example\.com\/docs/);
+  assert.doesNotMatch(text, /undefined|NaN|\bnull\b/);
+});
+
+// ─── UNKNOWN payload with a null table ─────────────────────────────────────
+
+test("migration analyze on UNKNOWN prints the reason, never 'null'", async () => {
+  const { migration } = loadWithStubs({
+    responses: [{
+      verdict: "UNKNOWN", table: null, operation: null,
+      reason: "Statement could not be parsed as a supported DDL form.",
+    }],
+  });
+  const io = captureStdout();
+  await migration.run(
+    opts(["analyze", "--connection", "c1", "--sql", "SOME NONSENSE DDL"]),
+    { stdout: io.stream, stderr: io.errStream },
+  );
+  const text = io.out();
+  assert.match(text, /^UNKNOWN — Statement could not be parsed as a supported DDL form\./);
+  assert.match(text, /No analysis was possible/);
+  assert.doesNotMatch(text, /undefined|NaN|\bnull\b/);
+});
+
+// ─── unknown-table-size sentinel (Long.MAX_VALUE) ──────────────────────────
+
+test("migration analyze renders the Long.MAX_VALUE row-count sentinel as unknown, not a huge number", async () => {
+  const { migration } = loadWithStubs({
+    responses: [{
+      verdict: "CAUTION", operation: "ADD COLUMN", table: "huge_table",
+      locks: [{ table: "huge_table", mode: "ACCESS EXCLUSIVE", blocks: ["reads", "writes"] }],
+      rewritesTable: true, tableRows: 9223372036854775807,
+      estimatedDuration: "unknown", reason: "Could not measure table size.",
+    }],
+  });
+  const io = captureStdout();
+  await migration.run(
+    opts(["analyze", "--connection", "c1", "--sql", "ALTER TABLE huge_table ADD COLUMN x int"]),
+    { stdout: io.stream, stderr: io.errStream },
+  );
+  const text = io.out();
+  assert.match(text, /table rows {5}: unknown — treated as large/);
+  assert.doesNotMatch(text, /9,223,372,036,854/);
+  assert.doesNotMatch(text, /undefined|NaN/);
+});
+
+test("migration analyze treats a JS-float-imprecise near-sentinel value the same way", async () => {
+  // 9223372036854775807 does not round-trip through a JS double; a backend
+  // that serializes Long.MAX_VALUE can come back as 9223372036854775808 or
+  // similar depending on the JSON library. Any implausibly large value must
+  // still read as "unknown", not print a fake precise-looking number.
+  const { migration } = loadWithStubs({
+    responses: [{
+      verdict: "CAUTION", operation: "ADD COLUMN", table: "huge_table",
+      locks: [],
+      rewritesTable: true, tableRows: 9223372036854775808,
+      reason: "Could not measure table size.",
+    }],
+  });
+  const io = captureStdout();
+  await migration.run(
+    opts(["analyze", "--connection", "c1", "--sql", "ALTER TABLE huge_table ADD COLUMN x int"]),
+    { stdout: io.stream },
+  );
+  assert.match(io.out(), /table rows {5}: unknown — treated as large/);
+});
+
+// ─── verdict markers ────────────────────────────────────────────────────────
+
+test("migration analyze marks SAFE with no warning glyph", async () => {
+  const { migration } = loadWithStubs({
+    responses: [{ verdict: "SAFE", operation: "ADD COLUMN", table: "t", locks: [] }],
+  });
+  const io = captureStdout();
+  await migration.run(opts(["analyze", "--connection", "c1", "--sql", "ALTER TABLE t ADD COLUMN y text"]), { stdout: io.stream });
+  assert.match(io.out(), /^SAFE {2}ADD COLUMN on t/);
+});
+
+test("migration analyze marks FAILS the same as DANGER", async () => {
+  const { migration } = loadWithStubs({
+    responses: [{ verdict: "FAILS", operation: "ADD COLUMN", table: "t", locks: [], reason: "Column already exists." }],
+  });
+  const io = captureStdout();
+  await migration.run(opts(["analyze", "--connection", "c1", "--sql", "ALTER TABLE t ADD COLUMN y text"]), { stdout: io.stream });
+  assert.match(io.out(), /^✗ FAILS {2}ADD COLUMN on t/);
+});
+
+// ─── argv plumbing ──────────────────────────────────────────────────────────
+
+test("migration analyze requires --sql", async () => {
+  const { migration } = loadWithStubs({ responses: [{}] });
+  await assert.rejects(
+    migration.run(opts(["analyze", "--connection", "c1"]), { stdout: captureStdout().stream }),
+    /Usage: deepsql migration analyze/,
+  );
+});
+
+test("migration --json emits the raw backend body without prose", async () => {
+  const { migration } = loadWithStubs({
+    responses: [{ verdict: "SAFE", operation: "ADD COLUMN", table: "t" }],
+  });
+  const io = captureStdout();
+  await migration.run(opts(["analyze", "--connection", "c1", "--sql", "ALTER TABLE t ADD COLUMN y text", "--json"]), { stdout: io.stream });
+  const parsed = JSON.parse(io.out());
+  assert.equal(parsed.verdict, "SAFE");
+});
+
+// ─── 403 / 404 wrapping ─────────────────────────────────────────────────────
+
+test("migration wraps 403 with a permissions-shaped error", async () => {
+  for (const k of [
+    require.resolve("../api/client"),
+    require.resolve("./_session"),
+    require.resolve("./_connections"),
+    require.resolve("./migration"),
+  ]) {
+    delete require.cache[k];
+  }
+  class RealApiError extends Error {
+    constructor(message, { status, body } = {}) { super(message); this.status = status; this.body = body; }
+  }
+  const apiKey = require.resolve("../api/client");
+  require.cache[apiKey] = {
+    id: apiKey, filename: apiKey, loaded: true,
+    exports: {
+      ApiError: RealApiError,
+      async request() { throw new RealApiError("forbidden", { status: 403 }); },
+    },
+  };
+  const sessKey = require.resolve("./_session");
+  require.cache[sessKey] = {
+    id: sessKey, filename: sessKey, loaded: true,
+    exports: { resolveSession: () => ({ baseUrl: "http://test", token: "t" }) },
+  };
+  const connKey = require.resolve("./_connections");
+  require.cache[connKey] = {
+    id: connKey, filename: connKey, loaded: true,
+    exports: { resolveConnectionId: async () => "conn-x" },
+  };
+  const fresh = require("./migration");
+
+  await assert.rejects(
+    fresh.run(opts(["analyze", "--connection", "c1", "--sql", "ALTER TABLE t ADD COLUMN y text"]), { stdout: captureStdout().stream }),
+    /Access denied — migration analysis requires permissions/,
+  );
+});
+
+test("migration wraps 404 with the backend message", async () => {
+  for (const k of [
+    require.resolve("../api/client"),
+    require.resolve("./_session"),
+    require.resolve("./_connections"),
+    require.resolve("./migration"),
+  ]) {
+    delete require.cache[k];
+  }
+  class RealApiError extends Error {
+    constructor(message, { status, body } = {}) { super(message); this.status = status; this.body = body; }
+  }
+  const apiKey = require.resolve("../api/client");
+  require.cache[apiKey] = {
+    id: apiKey, filename: apiKey, loaded: true,
+    exports: {
+      ApiError: RealApiError,
+      async request() { throw new RealApiError("Connection not found.", { status: 404 }); },
+    },
+  };
+  const sessKey = require.resolve("./_session");
+  require.cache[sessKey] = {
+    id: sessKey, filename: sessKey, loaded: true,
+    exports: { resolveSession: () => ({ baseUrl: "http://test", token: "t" }) },
+  };
+  const connKey = require.resolve("./_connections");
+  require.cache[connKey] = {
+    id: connKey, filename: connKey, loaded: true,
+    exports: { resolveConnectionId: async () => "conn-x" },
+  };
+  const fresh = require("./migration");
+
+  await assert.rejects(
+    fresh.run(opts(["analyze", "--connection", "c1", "--sql", "ALTER TABLE t ADD COLUMN y text"]), { stdout: captureStdout().stream }),
+    /Connection not found\./,
+  );
+});

--- a/scripts/jtest.sh
+++ b/scripts/jtest.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# No JDK on the host — run Maven goals in the same JDK image the backend builds with.
+set -euo pipefail
+exec docker run --rm \
+  -v "$(git rev-parse --show-toplevel)/backend:/app" \
+  -v "$HOME/.m2:/root/.m2" \
+  -w /app maven:3-eclipse-temurin-25 \
+  mvn -q -o test "$@"

--- a/scripts/jtest.sh
+++ b/scripts/jtest.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 # No JDK on the host — run Maven goals in the same JDK image the backend builds with.
 set -euo pipefail
+# Docker socket mount + TESTCONTAINERS_HOST_OVERRIDE let Testcontainers (used by
+# PostgresMigrationRiskVerificationTest) start a sibling Postgres container and reach its
+# mapped port from inside this maven container. -o (offline) is dropped because it blocks
+# resolving new test dependencies against the local repo the first time they're added.
 exec docker run --rm \
   -v "$(git rev-parse --show-toplevel)/backend:/app" \
   -v "$HOME/.m2:/root/.m2" \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -e TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal \
+  -e TESTCONTAINERS_RYUK_DISABLED=true \
   -w /app maven:3-eclipse-temurin-25 \
-  mvn -q -o test "$@"
+  mvn -q test "$@"


### PR DESCRIPTION
## Pre-flight Migration Review (DDL safety)

Deterministic Postgres DDL risk analyzer, exposed as one MCP tool
(`analyze_migration`) and a `deepsql migration analyze` CLI command.
Answers "is this ALTER safe to run?" before it runs — no new UI.

### Why deterministic
Follows the convention already in this codebase: the database (or arithmetic
over its catalog) decides the verdict, the LLM narrates. Same split as
`IndexAdvisorService` (hypopg + pg_class) and `ExplainPlanService` (Postgres
produces the plan, the model interprets it).

Verified in practice: asked the same question, DeepSQL Agent answered from
recall that `DEFAULT gen_random_uuid()` "does not rewrite the whole table."
It does. That's the failure this replaces.

### Verification
Rules are proven against a real PostgreSQL 18 via Testcontainers —
`pg_relation_filenode()` for rewrites, `pg_locks` for lock modes. A rule that
disagrees with the engine means the rule is wrong. Confirmed non-vacuous: a
constant-returning `classify()` fails 4-5 of 9 cases.

Live-verified over HTTP: SAFE/DANGER verdicts, FK locking both tables,
fail-closed on garbage, and a real 403 for an unauthorized user.

### Findings worth knowing
- `now()` is **STABLE**, so `DEFAULT now()` does **not** rewrite. Volatile
  defaults (`random()`, `gen_random_uuid()`, `clock_timestamp()`) do.
- `ADD FOREIGN KEY` takes `ShareRowExclusiveLock` on the **referenced** table
  too — hence `locks` is a per-table array.
- JSqlParser 5.2 cannot parse `NOT VALID` or `CREATE INDEX CONCURRENTLY` —
  the very forms this tool recommends. A pre-parse shim strips them into flags.

### Fail closed
Unparseable SQL, multi-statement SQL, multi-clause ALTERs, unrecognised default
functions, `DROP CONSTRAINT`, and MySQL all yield UNKNOWN/CAUTION — never SAFE.

### Known limits
- `ALTER COLUMN TYPE` over-warns: same-family widening
  (`varchar(50)`→`varchar(100)`) is reported as a rewrite when it isn't.
  `DdlFacts` carries no old type. Documented and covered by a test that asserts
  both engine truth and the rule's claim.
- Postgres only. MySQL returns UNKNOWN rather than guessing.
- Volatility uses hardcoded sets; the live `pg_proc.provolatile` lookup is
  follow-up work. Unrecognised functions yield CAUTION, so it fails safe.

### Tests
55 Java (incl. Testcontainers engine verification), 291 JS,
`ConnectionScopedAuthorizationSafetyTest` green.

Every ruling made during implementation is recorded in
`docs/superpowers/specs/2026-09-04-preflight-migration-review-decisions.md`.



### New
<img width="673" height="259" alt="image" src="https://github.com/user-attachments/assets/a43a04b1-9b51-42df-936f-53aaa9388415" />
### Old
<img width="410" height="276" alt="image" src="https://github.com/user-attachments/assets/35481dd4-1cf8-4e0a-8a36-32acbe56fee2" />
