### PR TITLE
feat: add per-user digest preferences with role-aware personalization (PR1)

### DIFF
--- a/backend/src/main/java/com/dbaagent/controller/DigestPreferenceController.java
+++ b/backend/src/main/java/com/dbaagent/controller/DigestPreferenceController.java
@@ -1,0 +1,184 @@
+package com.dbaagent.controller;
+
+import com.dbaagent.model.DigestDeliveryMethod;
+import com.dbaagent.model.PersonaTag;
+import com.dbaagent.model.UserDigestPreference;
+import com.dbaagent.service.security.AccessControlService;
+import com.dbaagent.service.UserDigestPreferenceService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * REST controller for managing per-user digest preferences.
+ *
+ * <p>Users can manage their own digest subscriptions. Admins can manage any user's
+ * preferences via the admin endpoints in {@link SlackAdminController}.
+ */
+@RestController
+@RequestMapping("/digest/preferences")
+@RequiredArgsConstructor
+@Slf4j
+public class DigestPreferenceController {
+
+    private final UserDigestPreferenceService preferenceService;
+    private final AccessControlService accessControlService;
+
+    /**
+     * Get the current user's digest preferences.
+     */
+    @GetMapping
+    public ResponseEntity<List<UserDigestPreference>> getMyPreferences() {
+        String username = accessControlService.requireCurrentUsername();
+        return ResponseEntity.ok(preferenceService.getPreferencesForUser(username));
+    }
+
+    /**
+     * Create a new digest preference for the current user.
+     */
+    @PostMapping
+    public ResponseEntity<UserDigestPreference> createPreference(@RequestBody CreatePreferenceRequest request) {
+        String username = accessControlService.requireCurrentUsername();
+
+        DigestDeliveryMethod method = request.deliveryMethod != null
+            ? DigestDeliveryMethod.fromString(request.deliveryMethod)
+            : DigestDeliveryMethod.SLACK_DM;
+
+        PersonaTag persona = request.personaTag != null
+            ? PersonaTag.fromString(request.personaTag)
+            : null;
+
+        UserDigestPreference preference = preferenceService.createPreference(
+            username,
+            request.connectionId,
+            method,
+            persona,
+            request.cronExpression,
+            request.timezone
+        );
+
+        return ResponseEntity.ok(preference);
+    }
+
+    /**
+     * Update an existing preference.
+     */
+    @PutMapping("/{id}")
+    public ResponseEntity<UserDigestPreference> updatePreference(
+            @PathVariable Long id,
+            @RequestBody UpdatePreferenceRequest request) {
+
+        String username = accessControlService.requireCurrentUsername();
+
+        UserDigestPreference existing = preferenceService.getPreference(id)
+            .orElseThrow(() -> new IllegalArgumentException("Preference not found: " + id));
+
+        if (!existing.getUsername().equals(username) && !accessControlService.isCurrentUserAdmin()) {
+            throw new IllegalArgumentException("Cannot update another user's preference");
+        }
+
+        PersonaTag persona = request.personaTag != null
+            ? PersonaTag.fromString(request.personaTag)
+            : null;
+
+        UserDigestPreference updated = preferenceService.updatePreference(
+            id,
+            request.enabled,
+            persona,
+            request.cronExpression,
+            request.timezone
+        );
+
+        return ResponseEntity.ok(updated);
+    }
+
+    /**
+     * Enable or disable a preference.
+     */
+    @PatchMapping("/{id}/enabled")
+    public ResponseEntity<UserDigestPreference> setEnabled(
+            @PathVariable Long id,
+            @RequestBody Map<String, Boolean> body) {
+
+        String username = accessControlService.requireCurrentUsername();
+
+        UserDigestPreference existing = preferenceService.getPreference(id)
+            .orElseThrow(() -> new IllegalArgumentException("Preference not found: " + id));
+
+        if (!existing.getUsername().equals(username) && !accessControlService.isCurrentUserAdmin()) {
+            throw new IllegalArgumentException("Cannot update another user's preference");
+        }
+
+        Boolean enabled = body.get("enabled");
+        if (enabled == null) {
+            throw new IllegalArgumentException("Missing 'enabled' field");
+        }
+
+        UserDigestPreference updated = preferenceService.setEnabled(id, enabled);
+        return ResponseEntity.ok(updated);
+    }
+
+    /**
+     * Delete a preference.
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletePreference(@PathVariable Long id) {
+        String username = accessControlService.requireCurrentUsername();
+
+        UserDigestPreference existing = preferenceService.getPreference(id)
+            .orElseThrow(() -> new IllegalArgumentException("Preference not found: " + id));
+
+        if (!existing.getUsername().equals(username) && !accessControlService.isCurrentUserAdmin()) {
+            throw new IllegalArgumentException("Cannot delete another user's preference");
+        }
+
+        preferenceService.deletePreference(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * Get available persona tags.
+     */
+    @GetMapping("/persona-tags")
+    public ResponseEntity<List<Map<String, String>>> getPersonaTags() {
+        List<Map<String, String>> tags = List.of(
+            Map.of("value", "DBA", "label", PersonaTag.DBA.getDisplayName(), "description", PersonaTag.DBA.getDescription()),
+            Map.of("value", "APP_ENG", "label", PersonaTag.APP_ENG.getDisplayName(), "description", PersonaTag.APP_ENG.getDescription()),
+            Map.of("value", "DATA_ENG", "label", PersonaTag.DATA_ENG.getDisplayName(), "description", PersonaTag.DATA_ENG.getDescription()),
+            Map.of("value", "EXEC", "label", PersonaTag.EXEC.getDisplayName(), "description", PersonaTag.EXEC.getDescription())
+        );
+        return ResponseEntity.ok(tags);
+    }
+
+    /**
+     * Get available delivery methods.
+     */
+    @GetMapping("/delivery-methods")
+    public ResponseEntity<List<Map<String, String>>> getDeliveryMethods() {
+        List<Map<String, String>> methods = List.of(
+            Map.of("value", "SLACK_DM", "label", DigestDeliveryMethod.SLACK_DM.getDisplayName(), "description", DigestDeliveryMethod.SLACK_DM.getDescription()),
+            Map.of("value", "SLACK_CHANNEL", "label", DigestDeliveryMethod.SLACK_CHANNEL.getDisplayName(), "description", DigestDeliveryMethod.SLACK_CHANNEL.getDescription()),
+            Map.of("value", "EMAIL", "label", DigestDeliveryMethod.EMAIL.getDisplayName(), "description", DigestDeliveryMethod.EMAIL.getDescription())
+        );
+        return ResponseEntity.ok(methods);
+    }
+
+    public record CreatePreferenceRequest(
+        String connectionId,
+        String deliveryMethod,
+        String personaTag,
+        String cronExpression,
+        String timezone
+    ) {}
+
+    public record UpdatePreferenceRequest(
+        Boolean enabled,
+        String personaTag,
+        String cronExpression,
+        String timezone
+    ) {}
+}

--- a/backend/src/main/java/com/dbaagent/controller/SlackAdminController.java
+++ b/backend/src/main/java/com/dbaagent/controller/SlackAdminController.java
@@ -1,11 +1,15 @@
 package com.dbaagent.controller;
 
+import com.dbaagent.model.DigestDeliveryMethod;
+import com.dbaagent.model.PersonaTag;
 import com.dbaagent.model.SlackDigestConfig;
 import com.dbaagent.model.SlackDigestLog;
+import com.dbaagent.model.UserDigestPreference;
 import com.dbaagent.repository.SlackDigestConfigRepository;
 import com.dbaagent.repository.SlackDigestLogRepository;
 import com.dbaagent.service.SlackBotService;
 import com.dbaagent.service.SlackDailyDigestService;
+import com.dbaagent.service.UserDigestPreferenceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -14,8 +18,14 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 
+/**
+ * Admin endpoints for Slack bot and digest management.
+ *
+ * <p>Includes both global digest configuration and per-user preference management.
+ */
 @RestController
 @RequestMapping("/admin/slack")
 @RequiredArgsConstructor
@@ -26,6 +36,7 @@ public class SlackAdminController {
     private final SlackDailyDigestService slackDailyDigestService;
     private final SlackDigestLogRepository digestLogRepository;
     private final SlackDigestConfigRepository digestConfigRepository;
+    private final UserDigestPreferenceService preferenceService;
 
     @GetMapping("/status")
     public ResponseEntity<Map<String, Object>> status() {
@@ -77,4 +88,123 @@ public class SlackAdminController {
         config.setUpdatedAt(LocalDateTime.now());
         return ResponseEntity.ok(digestConfigRepository.save(config));
     }
+
+    // ==================== PER-USER PREFERENCE MANAGEMENT ====================
+
+    /**
+     * Get digest preferences for a specific user.
+     */
+    @GetMapping("/digest/preferences/{username}")
+    public ResponseEntity<List<UserDigestPreference>> getUserPreferences(@PathVariable String username) {
+        return ResponseEntity.ok(preferenceService.getPreferencesForUser(username));
+    }
+
+    /**
+     * Get all users with enabled digest preferences.
+     */
+    @GetMapping("/digest/preferences/users")
+    public ResponseEntity<List<String>> getUsersWithPreferences() {
+        return ResponseEntity.ok(preferenceService.getUsersWithEnabledPreferences());
+    }
+
+    /**
+     * Get digest preference statistics.
+     */
+    @GetMapping("/digest/preferences/stats")
+    public ResponseEntity<Map<String, Object>> getPreferenceStats() {
+        boolean hasPreferences = preferenceService.hasAnyPreferences();
+        long enabledCount = preferenceService.countEnabled();
+        List<String> users = preferenceService.getUsersWithEnabledPreferences();
+
+        return ResponseEntity.ok(Map.of(
+            "hasAnyPreferences", hasPreferences,
+            "enabledCount", enabledCount,
+            "usersWithPreferences", users.size(),
+            "mode", hasPreferences ? "per-user" : "singleton"
+        ));
+    }
+
+    /**
+     * Create a digest preference for a user (admin can create for any user).
+     */
+    @PostMapping("/digest/preferences/{username}")
+    public ResponseEntity<UserDigestPreference> createUserPreference(
+            @PathVariable String username,
+            @RequestBody CreatePreferenceRequest request) {
+
+        DigestDeliveryMethod method = request.deliveryMethod != null
+            ? DigestDeliveryMethod.fromString(request.deliveryMethod)
+            : DigestDeliveryMethod.SLACK_DM;
+
+        PersonaTag persona = request.personaTag != null
+            ? PersonaTag.fromString(request.personaTag)
+            : null;
+
+        UserDigestPreference preference = preferenceService.createPreference(
+            username,
+            request.connectionId,
+            method,
+            persona,
+            request.cronExpression,
+            request.timezone
+        );
+
+        return ResponseEntity.ok(preference);
+    }
+
+    /**
+     * Update a user's digest preference.
+     */
+    @PutMapping("/digest/preferences/id/{id}")
+    public ResponseEntity<UserDigestPreference> updateUserPreference(
+            @PathVariable Long id,
+            @RequestBody UpdatePreferenceRequest request) {
+
+        PersonaTag persona = request.personaTag != null
+            ? PersonaTag.fromString(request.personaTag)
+            : null;
+
+        UserDigestPreference updated = preferenceService.updatePreference(
+            id,
+            request.enabled,
+            persona,
+            request.cronExpression,
+            request.timezone
+        );
+
+        return ResponseEntity.ok(updated);
+    }
+
+    /**
+     * Delete a user's digest preference.
+     */
+    @DeleteMapping("/digest/preferences/id/{id}")
+    public ResponseEntity<Void> deleteUserPreference(@PathVariable Long id) {
+        preferenceService.deletePreference(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * Delete all digest preferences for a user.
+     */
+    @DeleteMapping("/digest/preferences/{username}")
+    public ResponseEntity<Void> deleteAllUserPreferences(@PathVariable String username) {
+        preferenceService.deleteAllPreferencesForUser(username);
+        return ResponseEntity.noContent().build();
+    }
+
+    public record CreatePreferenceRequest(
+        String connectionId,
+        String deliveryMethod,
+        String personaTag,
+        String cronExpression,
+        String timezone
+    ) {}
+
+    public record UpdatePreferenceRequest(
+        Boolean enabled,
+        String personaTag,
+        String cronExpression,
+        String timezone
+    ) {}
 }

--- a/backend/src/main/java/com/dbaagent/model/DigestDeliveryMethod.java
+++ b/backend/src/main/java/com/dbaagent/model/DigestDeliveryMethod.java
@@ -1,0 +1,57 @@
+package com.dbaagent.model;
+
+/**
+ * Delivery method for digest notifications.
+ *
+ * <p>Determines how a user receives their personalized digest. Multiple methods
+ * can be enabled per user by creating multiple {@link UserDigestPreference} rows.
+ */
+public enum DigestDeliveryMethod {
+
+    /** Direct message via Slack. Requires user to be linked via SlackUserLink. */
+    SLACK_DM("Slack DM", "Direct message to your linked Slack account"),
+
+    /** Post to a Slack channel. Requires a SlackChannelBinding for the connection. */
+    SLACK_CHANNEL("Slack Channel", "Posted to a configured Slack channel"),
+
+    /** Email delivery. Uses the user's registered email address. */
+    EMAIL("Email", "Sent to your registered email address");
+
+    private final String displayName;
+    private final String description;
+
+    DigestDeliveryMethod(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Parse a delivery method leniently; returns null when unknown.
+     */
+    public static DigestDeliveryMethod fromString(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String normalized = value.trim().toUpperCase().replace("-", "_").replace(" ", "_");
+        return switch (normalized) {
+            case "SLACK_DM", "SLACKDM", "DM" -> SLACK_DM;
+            case "SLACK_CHANNEL", "SLACKCHANNEL", "CHANNEL" -> SLACK_CHANNEL;
+            case "EMAIL", "MAIL" -> EMAIL;
+            default -> {
+                try {
+                    yield DigestDeliveryMethod.valueOf(normalized);
+                } catch (IllegalArgumentException e) {
+                    yield null;
+                }
+            }
+        };
+    }
+}

--- a/backend/src/main/java/com/dbaagent/model/PersonaTag.java
+++ b/backend/src/main/java/com/dbaagent/model/PersonaTag.java
@@ -1,0 +1,65 @@
+package com.dbaagent.model;
+
+/**
+ * Persona tags for role-aware digest personalization.
+ *
+ * <p>These tags allow users to indicate their primary focus area beyond their RBAC role.
+ * A user's Role determines what they can access; their PersonaTag influences how content
+ * is prioritized and presented in digests.
+ *
+ * <p>For example, an ADMIN might set a {@code DBA} persona tag to receive digests
+ * emphasizing query performance and index recommendations rather than schema changes.
+ */
+public enum PersonaTag {
+
+    /** Database administrator: prioritize performance, tuning, and operational health. */
+    DBA("DBA", "Database Administrator — performance, tuning, and operational health"),
+
+    /** Application engineer: prioritize query patterns, ORM issues, and schema usage. */
+    APP_ENG("App Engineer", "Application Engineer — query patterns and schema usage"),
+
+    /** Data engineer: prioritize ETL patterns, data quality, and pipeline health. */
+    DATA_ENG("Data Engineer", "Data Engineer — ETL patterns and pipeline health"),
+
+    /** Executive: prioritize high-level summaries, costs, and strategic insights. */
+    EXEC("Executive", "Executive — costs, capacity, and strategic insights");
+
+    private final String displayName;
+    private final String description;
+
+    PersonaTag(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Parse a persona tag leniently; returns null when unknown.
+     */
+    public static PersonaTag fromString(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String normalized = value.trim().toUpperCase().replace("-", "_").replace(" ", "_");
+        return switch (normalized) {
+            case "DBA" -> DBA;
+            case "APP_ENG", "APPENG", "APP_ENGINEER", "APPLICATION_ENGINEER" -> APP_ENG;
+            case "DATA_ENG", "DATAENG", "DATA_ENGINEER" -> DATA_ENG;
+            case "EXEC", "EXECUTIVE" -> EXEC;
+            default -> {
+                try {
+                    yield PersonaTag.valueOf(normalized);
+                } catch (IllegalArgumentException e) {
+                    yield null;
+                }
+            }
+        };
+    }
+}

--- a/backend/src/main/java/com/dbaagent/model/SlackDigestConfig.java
+++ b/backend/src/main/java/com/dbaagent/model/SlackDigestConfig.java
@@ -6,6 +6,20 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+/**
+ * Global digest configuration (singleton row, id=1).
+ *
+ * <p>This table maintains backward compatibility with the original singleton design.
+ * The row with id=1 serves as the global default when a user has no specific
+ * {@link UserDigestPreference} configured.
+ *
+ * <h3>Resolution Order</h3>
+ * <ol>
+ *   <li>User-specific {@link UserDigestPreference} with custom cronExpression</li>
+ *   <li>User-specific {@link UserDigestPreference} without cronExpression → uses this global cron</li>
+ *   <li>No preferences at all → legacy broadcast using this global cron</li>
+ * </ol>
+ */
 @Entity
 @Table(name = "slack_digest_config")
 @Data
@@ -20,4 +34,11 @@ public class SlackDigestConfig {
 
     @Column(nullable = false)
     private LocalDateTime updatedAt = LocalDateTime.now();
+
+    /**
+     * Marks this as the global default configuration.
+     * Always true for the singleton row (id=1).
+     */
+    @Column(name = "is_global_default", nullable = false)
+    private boolean globalDefault = true;
 }

--- a/backend/src/main/java/com/dbaagent/model/SlackDigestLog.java
+++ b/backend/src/main/java/com/dbaagent/model/SlackDigestLog.java
@@ -6,8 +6,28 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+/**
+ * Log entry for digest deliveries.
+ *
+ * <p>Tracks each digest sent, including per-recipient details for role-aware digests.
+ * When {@code recipientUsername} is null, the entry represents a legacy/global digest
+ * sent to a channel rather than a personalized per-user digest.
+ *
+ * <h3>Delivery Types</h3>
+ * <ul>
+ *   <li><b>Legacy/Global</b>: channelId set, recipientUsername null — broadcast to channel</li>
+ *   <li><b>Per-user DM</b>: recipientUsername set, channelId is the DM channel ID</li>
+ *   <li><b>Per-user Email</b>: recipientUsername set, channelId null, deliveryMethod = EMAIL</li>
+ * </ul>
+ */
 @Entity
-@Table(name = "slack_digest_log")
+@Table(
+    name = "slack_digest_log",
+    indexes = {
+        @Index(name = "idx_slack_digest_log_recipient", columnList = "recipient_username, sent_at DESC"),
+        @Index(name = "idx_slack_digest_log_conn_recipient", columnList = "connection_id, recipient_username, sent_at DESC")
+    }
+)
 @Data
 @NoArgsConstructor
 public class SlackDigestLog {
@@ -33,4 +53,56 @@ public class SlackDigestLog {
 
     @Column(columnDefinition = "TEXT")
     private String errorMessage;
+
+    /**
+     * Username of the recipient for per-user digests.
+     * Null for legacy channel-broadcast digests.
+     */
+    @Column(name = "recipient_username", length = 255)
+    private String recipientUsername;
+
+    /**
+     * RBAC role of the recipient at time of delivery.
+     * Captured for audit trail; the user's role may change later.
+     */
+    @Column(name = "recipient_role", length = 64)
+    private String recipientRole;
+
+    /**
+     * Persona tag used for content prioritization in this digest.
+     * Null if no persona was applied (default role-based prioritization).
+     */
+    @Column(name = "persona_tag", length = 32)
+    @Enumerated(EnumType.STRING)
+    private PersonaTag personaTag;
+
+    /**
+     * Delivery method used for this digest.
+     * Defaults to SLACK_DM for backward compatibility with existing logs.
+     */
+    @Column(name = "delivery_method", length = 32)
+    @Enumerated(EnumType.STRING)
+    private DigestDeliveryMethod deliveryMethod;
+
+    /**
+     * Reference to the UserDigestPreference that triggered this delivery.
+     * Null for legacy/global digests or when preference was deleted.
+     */
+    @Column(name = "preference_id")
+    private Long preferenceId;
+
+    /**
+     * Whether this was a personalized digest (role-aware content).
+     * When false, the same content was sent to all recipients.
+     */
+    @Column(name = "personalized", nullable = false)
+    private boolean personalized = false;
+
+    /**
+     * Check if this is a per-user digest (vs legacy channel broadcast).
+     */
+    @Transient
+    public boolean isPerUserDelivery() {
+        return recipientUsername != null && !recipientUsername.isBlank();
+    }
 }

--- a/backend/src/main/java/com/dbaagent/model/UserDigestPreference.java
+++ b/backend/src/main/java/com/dbaagent/model/UserDigestPreference.java
@@ -1,0 +1,151 @@
+package com.dbaagent.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+/**
+ * Per-user digest preferences for role-aware, personalized digests.
+ *
+ * <p>Each row represents a single digest subscription for a user. A user can have
+ * multiple subscriptions (e.g., different connections, different delivery methods).
+ *
+ * <p>When no preferences exist for a user, the system falls back to the singleton
+ * {@link SlackDigestConfig} behavior for backward compatibility.
+ *
+ * <h3>Preference Resolution</h3>
+ * <ol>
+ *   <li>Look for enabled {@code UserDigestPreference} rows matching the user/connection</li>
+ *   <li>If found, use those preferences (cron, persona, delivery method)</li>
+ *   <li>If not found, fall back to global singleton behavior</li>
+ * </ol>
+ *
+ * <h3>Persona Tags</h3>
+ * <p>The {@code personaTag} is optional and allows content prioritization beyond the
+ * user's RBAC role. For example, an ADMIN with a DBA persona will see performance
+ * metrics emphasized over schema changes in their digest.
+ */
+@Entity
+@Table(
+    name = "user_digest_preference",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_user_digest_pref_user_conn_method",
+            columnNames = {"username", "connection_id", "delivery_method"}
+        )
+    },
+    indexes = {
+        @Index(name = "idx_user_digest_pref_username", columnList = "username"),
+        @Index(name = "idx_user_digest_pref_conn", columnList = "connection_id"),
+        @Index(name = "idx_user_digest_pref_enabled", columnList = "enabled, username")
+    }
+)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserDigestPreference {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * Username of the user this preference belongs to.
+     * References users.username (not enforced by FK to allow soft-deleted users).
+     */
+    @Column(name = "username", nullable = false, length = 255)
+    private String username;
+
+    /**
+     * Optional connection ID to scope this preference.
+     * When null, this preference applies to all connections the user has access to.
+     */
+    @Column(name = "connection_id", length = 36)
+    private String connectionId;
+
+    /**
+     * Whether digest delivery is enabled for this preference.
+     * Allows users to pause digests without deleting preferences.
+     */
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean enabled = true;
+
+    /**
+     * Optional persona tag for content prioritization.
+     * When null, content is prioritized based on the user's RBAC role alone.
+     */
+    @Column(name = "persona_tag", length = 32)
+    @Enumerated(EnumType.STRING)
+    private PersonaTag personaTag;
+
+    /**
+     * Optional cron expression for per-user schedule override.
+     * When null, uses the global SlackDigestConfig.cronExpression.
+     * Format: "second minute hour day-of-month month day-of-week"
+     */
+    @Column(name = "cron_expression", length = 100)
+    private String cronExpression;
+
+    /**
+     * Delivery method for this digest preference.
+     * Each method requires different prerequisites (e.g., SLACK_DM needs SlackUserLink).
+     */
+    @Column(name = "delivery_method", nullable = false, length = 32)
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private DigestDeliveryMethod deliveryMethod = DigestDeliveryMethod.SLACK_DM;
+
+    /**
+     * Optional timezone for schedule interpretation.
+     * When null, uses system default (typically UTC).
+     * Format: IANA timezone ID (e.g., "America/New_York", "Europe/London").
+     */
+    @Column(name = "timezone", length = 64)
+    private String timezone;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "updated_at", nullable = false)
+    @Builder.Default
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+    @PrePersist
+    void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        if (createdAt == null) {
+            createdAt = now;
+        }
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    /**
+     * Returns the effective cron expression, falling back to default if not set.
+     */
+    @Transient
+    public String getEffectiveCronExpression(String globalDefault) {
+        return cronExpression != null && !cronExpression.isBlank()
+            ? cronExpression
+            : globalDefault;
+    }
+
+    /**
+     * Check if this preference applies to a specific connection.
+     */
+    @Transient
+    public boolean appliesTo(String targetConnectionId) {
+        return connectionId == null || connectionId.equals(targetConnectionId);
+    }
+}

--- a/backend/src/main/java/com/dbaagent/repository/SlackDigestLogRepository.java
+++ b/backend/src/main/java/com/dbaagent/repository/SlackDigestLogRepository.java
@@ -4,12 +4,23 @@ import com.dbaagent.model.SlackDigestLog;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
+/**
+ * Repository for digest delivery logs.
+ *
+ * <p>Supports both legacy (channel-broadcast) and per-user digest queries.
+ */
 @Repository
 public interface SlackDigestLogRepository extends JpaRepository<SlackDigestLog, Long> {
+
+    // ==================== LEGACY QUERIES (channel-broadcast digests) ====================
 
     Page<SlackDigestLog> findAllByChannelIdIsNullOrderBySentAtDesc(Pageable pageable);
 
@@ -18,4 +29,66 @@ public interface SlackDigestLogRepository extends JpaRepository<SlackDigestLog, 
     Optional<SlackDigestLog> findTopByConnectionIdAndChannelIdIsNullOrderBySentAtDesc(String connectionId);
 
     long countByConnectionIdAndChannelIdIsNull(String connectionId);
+
+    // ==================== PER-USER DIGEST QUERIES ====================
+
+    /**
+     * Find all digests sent to a specific user, most recent first.
+     */
+    Page<SlackDigestLog> findByRecipientUsernameOrderBySentAtDesc(String recipientUsername, Pageable pageable);
+
+    /**
+     * Find the most recent digest sent to a user for a connection.
+     */
+    Optional<SlackDigestLog> findTopByConnectionIdAndRecipientUsernameOrderBySentAtDesc(
+        String connectionId,
+        String recipientUsername
+    );
+
+    /**
+     * Find all digests sent to a user for a connection.
+     */
+    Page<SlackDigestLog> findByConnectionIdAndRecipientUsernameOrderBySentAtDesc(
+        String connectionId,
+        String recipientUsername,
+        Pageable pageable
+    );
+
+    /**
+     * Count digests sent to a user.
+     */
+    long countByRecipientUsername(String recipientUsername);
+
+    /**
+     * Find recent failed deliveries for a user.
+     */
+    @Query("""
+        SELECT l FROM SlackDigestLog l
+        WHERE l.recipientUsername = :username
+          AND l.status = 'FAILED'
+          AND l.sentAt > :since
+        ORDER BY l.sentAt DESC
+        """)
+    List<SlackDigestLog> findRecentFailedForUser(
+        @Param("username") String username,
+        @Param("since") LocalDateTime since
+    );
+
+    /**
+     * Find the most recent digest for each user on a connection.
+     * Useful for showing "last digest" status in admin views.
+     */
+    @Query(value = """
+        SELECT DISTINCT ON (recipient_username) *
+        FROM slack_digest_log
+        WHERE connection_id = :connectionId
+          AND recipient_username IS NOT NULL
+        ORDER BY recipient_username, sent_at DESC
+        """, nativeQuery = true)
+    List<SlackDigestLog> findLatestPerUserForConnection(@Param("connectionId") String connectionId);
+
+    /**
+     * Count personalized vs non-personalized digests since a date.
+     */
+    long countByPersonalizedAndSentAtAfter(boolean personalized, LocalDateTime since);
 }

--- a/backend/src/main/java/com/dbaagent/repository/UserDigestPreferenceRepository.java
+++ b/backend/src/main/java/com/dbaagent/repository/UserDigestPreferenceRepository.java
@@ -1,0 +1,107 @@
+package com.dbaagent.repository;
+
+import com.dbaagent.model.DigestDeliveryMethod;
+import com.dbaagent.model.UserDigestPreference;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Repository for per-user digest preferences.
+ *
+ * <p>Provides queries for resolving digest preferences with fallback logic:
+ * <ol>
+ *   <li>User + connection-specific preference</li>
+ *   <li>User-wide preference (connectionId is null)</li>
+ *   <li>Global singleton fallback (handled in service layer)</li>
+ * </ol>
+ */
+@Repository
+public interface UserDigestPreferenceRepository extends JpaRepository<UserDigestPreference, Long> {
+
+    /**
+     * Find all enabled preferences for a user.
+     */
+    List<UserDigestPreference> findByUsernameAndEnabledTrue(String username);
+
+    /**
+     * Find all enabled preferences for a user and specific connection.
+     * Includes both connection-specific and user-wide (connectionId = null) preferences.
+     */
+    @Query("""
+        SELECT p FROM UserDigestPreference p
+        WHERE p.username = :username
+          AND p.enabled = true
+          AND (p.connectionId = :connectionId OR p.connectionId IS NULL)
+        ORDER BY p.connectionId DESC NULLS LAST
+        """)
+    List<UserDigestPreference> findEnabledForUserAndConnection(
+        @Param("username") String username,
+        @Param("connectionId") String connectionId
+    );
+
+    /**
+     * Find a specific preference by user, connection, and delivery method.
+     */
+    Optional<UserDigestPreference> findByUsernameAndConnectionIdAndDeliveryMethod(
+        String username,
+        String connectionId,
+        DigestDeliveryMethod deliveryMethod
+    );
+
+    /**
+     * Find all preferences for a user (enabled or not).
+     */
+    List<UserDigestPreference> findByUsernameOrderByConnectionIdAscCreatedAtDesc(String username);
+
+    /**
+     * Find all enabled preferences for a specific delivery method.
+     * Used to batch-send digests (e.g., all Slack DM recipients).
+     */
+    List<UserDigestPreference> findByEnabledTrueAndDeliveryMethod(DigestDeliveryMethod deliveryMethod);
+
+    /**
+     * Find all enabled preferences for a connection.
+     * Returns users who should receive a digest for this connection.
+     */
+    @Query("""
+        SELECT p FROM UserDigestPreference p
+        WHERE p.enabled = true
+          AND (p.connectionId = :connectionId OR p.connectionId IS NULL)
+        ORDER BY p.username
+        """)
+    List<UserDigestPreference> findEnabledForConnection(@Param("connectionId") String connectionId);
+
+    /**
+     * Find all distinct usernames with at least one enabled preference.
+     */
+    @Query("SELECT DISTINCT p.username FROM UserDigestPreference p WHERE p.enabled = true")
+    List<String> findDistinctUsernamesWithEnabledPreferences();
+
+    /**
+     * Check if a user has any digest preferences configured.
+     * Used to determine whether to fall back to singleton behavior.
+     */
+    boolean existsByUsername(String username);
+
+    /**
+     * Check if any per-user preferences exist at all.
+     * When false, the system operates entirely in singleton mode.
+     */
+    @Query("SELECT CASE WHEN COUNT(p) > 0 THEN true ELSE false END FROM UserDigestPreference p")
+    boolean hasAnyPreferences();
+
+    /**
+     * Delete all preferences for a user.
+     */
+    void deleteByUsername(String username);
+
+    /**
+     * Count enabled preferences.
+     */
+    long countByEnabledTrue();
+}

--- a/backend/src/main/java/com/dbaagent/service/SlackDailyDigestService.java
+++ b/backend/src/main/java/com/dbaagent/service/SlackDailyDigestService.java
@@ -25,7 +25,9 @@ import com.dbaagent.model.SlackDigestLog;
 import com.dbaagent.model.SlowQuery;
 import com.dbaagent.model.SlowQueryAnalysis;
 import com.dbaagent.model.TableStatsHistory;
+import com.dbaagent.model.UserDigestPreference;
 import com.dbaagent.repository.AuthLoginChallengeRepository;
+import com.dbaagent.repository.UserDigestPreferenceRepository;
 import com.dbaagent.repository.CapacityForecastRepository;
 import com.dbaagent.repository.ConnectionAccessGrantRepository;
 import com.dbaagent.repository.DatabaseEventRepository;
@@ -103,6 +105,7 @@ public class SlackDailyDigestService {
     private final AuthLoginChallengeRepository authLoginChallengeRepository;
     private final IndexAdvisorService indexAdvisorService;
     private final IndexRecommendationService indexRecommendationService;
+    private final UserDigestPreferenceRepository userDigestPreferenceRepository;
 
     private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("MMM d, yyyy");
     private static final int TOP_TABLES = 5;
@@ -352,6 +355,49 @@ public class SlackDailyDigestService {
         SlackRuntimeSettingsService.SlackRuntimeConfig config = slackRuntimeSettingsService.current();
         return config.enabled() && config.botToken() != null && !config.botToken().isBlank();
     }
+
+    /**
+     * Check if the system has per-user digest preferences configured.
+     * When true, digest delivery uses UserDigestPreference; when false, uses legacy
+     * channel-broadcast mode.
+     *
+     * <p>This is the foundation for role-aware digests (PR2). In PR1, this method
+     * allows the service to detect whether per-user mode is active, though the
+     * actual per-user delivery logic comes later.
+     */
+    public boolean isPerUserModeEnabled() {
+        return userDigestPreferenceRepository.hasAnyPreferences();
+    }
+
+    /**
+     * Get all enabled digest preferences for a connection.
+     * Returns users who should receive a digest for this connection based on their
+     * UserDigestPreference settings.
+     *
+     * <p>For PR1, this returns the preferences but the actual personalized delivery
+     * is implemented in PR2. The current digest flow continues using the legacy
+     * channel-broadcast approach.
+     *
+     * @param connectionId the connection to get recipients for
+     * @return list of enabled preferences, or empty if no per-user preferences exist
+     */
+    public List<UserDigestPreference> getDigestRecipients(String connectionId) {
+        return userDigestPreferenceRepository.findEnabledForConnection(connectionId);
+    }
+
+    /**
+     * Get digest mode summary for logging and debugging.
+     */
+    public DigestModeInfo getDigestModeInfo() {
+        boolean perUserMode = isPerUserModeEnabled();
+        long preferenceCount = perUserMode ? userDigestPreferenceRepository.countByEnabledTrue() : 0;
+        List<String> users = perUserMode
+            ? userDigestPreferenceRepository.findDistinctUsernamesWithEnabledPreferences()
+            : List.of();
+        return new DigestModeInfo(perUserMode, preferenceCount, users.size());
+    }
+
+    public record DigestModeInfo(boolean perUserMode, long enabledPreferences, int distinctUsers) {}
 
     private List<String> digestConnectionIds() {
         Set<String> ids = new HashSet<>();

--- a/backend/src/main/java/com/dbaagent/service/UserDigestPreferenceService.java
+++ b/backend/src/main/java/com/dbaagent/service/UserDigestPreferenceService.java
@@ -1,0 +1,223 @@
+package com.dbaagent.service;
+
+import com.dbaagent.model.DigestDeliveryMethod;
+import com.dbaagent.model.PersonaTag;
+import com.dbaagent.model.SlackDigestConfig;
+import com.dbaagent.model.UserDigestPreference;
+import com.dbaagent.repository.SlackDigestConfigRepository;
+import com.dbaagent.repository.UserDigestPreferenceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Service for managing per-user digest preferences.
+ *
+ * <p>Provides CRUD operations and preference resolution logic for role-aware digests.
+ * When no user-specific preferences exist, falls back to the global singleton config.
+ *
+ * <h3>Preference Resolution</h3>
+ * <ol>
+ *   <li>Connection-specific preference for the user</li>
+ *   <li>User-wide preference (connectionId = null)</li>
+ *   <li>Global singleton fallback</li>
+ * </ol>
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserDigestPreferenceService {
+
+    private final UserDigestPreferenceRepository preferenceRepository;
+    private final SlackDigestConfigRepository configRepository;
+
+    /**
+     * Get all preferences for a user.
+     */
+    public List<UserDigestPreference> getPreferencesForUser(String username) {
+        return preferenceRepository.findByUsernameOrderByConnectionIdAscCreatedAtDesc(username);
+    }
+
+    /**
+     * Get enabled preferences for a user and connection.
+     * Includes both connection-specific and user-wide preferences.
+     */
+    public List<UserDigestPreference> getEnabledPreferences(String username, String connectionId) {
+        return preferenceRepository.findEnabledForUserAndConnection(username, connectionId);
+    }
+
+    /**
+     * Get all users who should receive a digest for a connection.
+     */
+    public List<UserDigestPreference> getRecipientsForConnection(String connectionId) {
+        return preferenceRepository.findEnabledForConnection(connectionId);
+    }
+
+    /**
+     * Check if the system has any per-user preferences configured.
+     * When false, operates entirely in legacy singleton mode.
+     */
+    public boolean hasAnyPreferences() {
+        return preferenceRepository.hasAnyPreferences();
+    }
+
+    /**
+     * Check if a user has any digest preferences.
+     */
+    public boolean hasPreferences(String username) {
+        return preferenceRepository.existsByUsername(username);
+    }
+
+    /**
+     * Get the global default cron expression.
+     */
+    public String getGlobalCronExpression() {
+        return configRepository.findById(1L)
+            .map(SlackDigestConfig::getCronExpression)
+            .orElse("0 0 9 * * *");
+    }
+
+    /**
+     * Create or update a digest preference.
+     */
+    @Transactional
+    public UserDigestPreference savePreference(UserDigestPreference preference) {
+        preference.setUpdatedAt(LocalDateTime.now());
+        UserDigestPreference saved = preferenceRepository.save(preference);
+        log.info("Saved digest preference {} for user {} (conn={}, method={})",
+            saved.getId(), saved.getUsername(), saved.getConnectionId(), saved.getDeliveryMethod());
+        return saved;
+    }
+
+    /**
+     * Create a new preference for a user.
+     */
+    @Transactional
+    public UserDigestPreference createPreference(
+            String username,
+            String connectionId,
+            DigestDeliveryMethod deliveryMethod,
+            PersonaTag personaTag,
+            String cronExpression,
+            String timezone) {
+
+        Optional<UserDigestPreference> existing = preferenceRepository
+            .findByUsernameAndConnectionIdAndDeliveryMethod(username, connectionId, deliveryMethod);
+
+        if (existing.isPresent()) {
+            throw new IllegalArgumentException(
+                "Preference already exists for user=" + username +
+                ", connection=" + connectionId +
+                ", method=" + deliveryMethod
+            );
+        }
+
+        UserDigestPreference preference = UserDigestPreference.builder()
+            .username(username)
+            .connectionId(connectionId)
+            .enabled(true)
+            .personaTag(personaTag)
+            .cronExpression(cronExpression)
+            .deliveryMethod(deliveryMethod)
+            .timezone(timezone)
+            .build();
+
+        return savePreference(preference);
+    }
+
+    /**
+     * Update an existing preference.
+     */
+    @Transactional
+    public UserDigestPreference updatePreference(
+            Long preferenceId,
+            Boolean enabled,
+            PersonaTag personaTag,
+            String cronExpression,
+            String timezone) {
+
+        UserDigestPreference preference = preferenceRepository.findById(preferenceId)
+            .orElseThrow(() -> new IllegalArgumentException("Preference not found: " + preferenceId));
+
+        if (enabled != null) {
+            preference.setEnabled(enabled);
+        }
+        if (personaTag != null) {
+            preference.setPersonaTag(personaTag);
+        }
+        if (cronExpression != null) {
+            preference.setCronExpression(cronExpression.isBlank() ? null : cronExpression);
+        }
+        if (timezone != null) {
+            preference.setTimezone(timezone.isBlank() ? null : timezone);
+        }
+
+        return savePreference(preference);
+    }
+
+    /**
+     * Enable or disable a preference.
+     */
+    @Transactional
+    public UserDigestPreference setEnabled(Long preferenceId, boolean enabled) {
+        UserDigestPreference preference = preferenceRepository.findById(preferenceId)
+            .orElseThrow(() -> new IllegalArgumentException("Preference not found: " + preferenceId));
+
+        preference.setEnabled(enabled);
+        return savePreference(preference);
+    }
+
+    /**
+     * Delete a preference.
+     */
+    @Transactional
+    public void deletePreference(Long preferenceId) {
+        preferenceRepository.deleteById(preferenceId);
+        log.info("Deleted digest preference {}", preferenceId);
+    }
+
+    /**
+     * Delete all preferences for a user.
+     */
+    @Transactional
+    public void deleteAllPreferencesForUser(String username) {
+        preferenceRepository.deleteByUsername(username);
+        log.info("Deleted all digest preferences for user {}", username);
+    }
+
+    /**
+     * Get preference by ID.
+     */
+    public Optional<UserDigestPreference> getPreference(Long preferenceId) {
+        return preferenceRepository.findById(preferenceId);
+    }
+
+    /**
+     * Get count of enabled preferences.
+     */
+    public long countEnabled() {
+        return preferenceRepository.countByEnabledTrue();
+    }
+
+    /**
+     * Get all distinct users with enabled preferences.
+     */
+    public List<String> getUsersWithEnabledPreferences() {
+        return preferenceRepository.findDistinctUsernamesWithEnabledPreferences();
+    }
+
+    /**
+     * Resolve the effective cron expression for a preference.
+     */
+    public String resolveEffectiveCron(UserDigestPreference preference) {
+        if (preference.getCronExpression() != null && !preference.getCronExpression().isBlank()) {
+            return preference.getCronExpression();
+        }
+        return getGlobalCronExpression();
+    }
+}

--- a/backend/src/main/resources/db/migration/V120__create_user_digest_preference.sql
+++ b/backend/src/main/resources/db/migration/V120__create_user_digest_preference.sql
@@ -1,0 +1,100 @@
+-- V120: Per-user digest preferences with role-aware personalization
+--
+-- Migrates from singleton SlackDigestConfig to per-user preferences.
+-- The singleton row (id=1) remains for backward compatibility and serves as
+-- the global default when a user has no specific preferences configured.
+--
+-- This migration:
+-- 1. Creates user_digest_preference table for per-user preferences
+-- 2. Extends slack_digest_log with per-recipient tracking fields
+-- 3. Preserves existing singleton behavior as fallback
+
+-- ============================================================================
+-- 1. Create per-user digest preference table
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS user_digest_preference (
+    id                  BIGSERIAL PRIMARY KEY,
+    username            VARCHAR(255) NOT NULL,
+    connection_id       VARCHAR(36),
+    enabled             BOOLEAN NOT NULL DEFAULT TRUE,
+    persona_tag         VARCHAR(32),
+    cron_expression     VARCHAR(100),
+    delivery_method     VARCHAR(32) NOT NULL DEFAULT 'SLACK_DM',
+    timezone            VARCHAR(64),
+    created_at          TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMP NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT uk_user_digest_pref_user_conn_method
+        UNIQUE (username, connection_id, delivery_method)
+);
+
+COMMENT ON TABLE user_digest_preference IS
+    'Per-user digest subscription preferences. Each row is one delivery subscription.';
+COMMENT ON COLUMN user_digest_preference.username IS
+    'Username of the subscriber (references users.username)';
+COMMENT ON COLUMN user_digest_preference.connection_id IS
+    'Scoped to this connection, or NULL for all connections user can access';
+COMMENT ON COLUMN user_digest_preference.persona_tag IS
+    'Content prioritization persona: DBA, APP_ENG, DATA_ENG, EXEC';
+COMMENT ON COLUMN user_digest_preference.cron_expression IS
+    'Override schedule (uses global default when NULL)';
+COMMENT ON COLUMN user_digest_preference.delivery_method IS
+    'SLACK_DM, SLACK_CHANNEL, or EMAIL';
+COMMENT ON COLUMN user_digest_preference.timezone IS
+    'IANA timezone for schedule (e.g. America/New_York)';
+
+CREATE INDEX IF NOT EXISTS idx_user_digest_pref_username
+    ON user_digest_preference(username);
+CREATE INDEX IF NOT EXISTS idx_user_digest_pref_conn
+    ON user_digest_preference(connection_id);
+CREATE INDEX IF NOT EXISTS idx_user_digest_pref_enabled
+    ON user_digest_preference(enabled, username);
+
+
+-- ============================================================================
+-- 2. Extend slack_digest_log for per-recipient tracking
+-- ============================================================================
+
+-- Add per-recipient fields (nullable for backward compatibility)
+ALTER TABLE slack_digest_log
+    ADD COLUMN IF NOT EXISTS recipient_username VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS recipient_role VARCHAR(64),
+    ADD COLUMN IF NOT EXISTS persona_tag VARCHAR(32),
+    ADD COLUMN IF NOT EXISTS delivery_method VARCHAR(32),
+    ADD COLUMN IF NOT EXISTS preference_id BIGINT,
+    ADD COLUMN IF NOT EXISTS personalized BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN slack_digest_log.recipient_username IS
+    'Username of recipient (NULL for legacy channel-broadcast)';
+COMMENT ON COLUMN slack_digest_log.recipient_role IS
+    'RBAC role at delivery time (audit trail)';
+COMMENT ON COLUMN slack_digest_log.persona_tag IS
+    'Persona tag used for content prioritization';
+COMMENT ON COLUMN slack_digest_log.delivery_method IS
+    'SLACK_DM, SLACK_CHANNEL, or EMAIL';
+COMMENT ON COLUMN slack_digest_log.preference_id IS
+    'FK to user_digest_preference that triggered delivery';
+COMMENT ON COLUMN slack_digest_log.personalized IS
+    'TRUE if content was role-personalized';
+
+CREATE INDEX IF NOT EXISTS idx_slack_digest_log_recipient
+    ON slack_digest_log(recipient_username, sent_at DESC);
+CREATE INDEX IF NOT EXISTS idx_slack_digest_log_conn_recipient
+    ON slack_digest_log(connection_id, recipient_username, sent_at DESC);
+
+
+-- ============================================================================
+-- 3. Add global_default flag to slack_digest_config for clarity
+-- ============================================================================
+
+-- The singleton row now explicitly marks itself as the global default
+ALTER TABLE slack_digest_config
+    ADD COLUMN IF NOT EXISTS is_global_default BOOLEAN NOT NULL DEFAULT TRUE;
+
+COMMENT ON COLUMN slack_digest_config.is_global_default IS
+    'TRUE for the singleton row that serves as fallback';
+
+-- Ensure the singleton row exists and is marked as global default
+INSERT INTO slack_digest_config (id, cron_expression, updated_at, is_global_default)
+VALUES (1, '0 0 9 * * *', NOW(), TRUE)
+ON CONFLICT (id) DO UPDATE SET is_global_default = TRUE;

--- a/backend/src/test/java/com/dbaagent/model/DigestDeliveryMethodTest.java
+++ b/backend/src/test/java/com/dbaagent/model/DigestDeliveryMethodTest.java
@@ -1,0 +1,64 @@
+package com.dbaagent.model;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DigestDeliveryMethodTest {
+
+    @Test
+    void allDeliveryMethodsHaveDisplayNameAndDescription() {
+        for (DigestDeliveryMethod method : DigestDeliveryMethod.values()) {
+            assertThat(method.getDisplayName()).isNotBlank();
+            assertThat(method.getDescription()).isNotBlank();
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "SLACK_DM, SLACK_DM",
+        "slack_dm, SLACK_DM",
+        "SLACKDM, SLACK_DM",
+        "slackdm, SLACK_DM",
+        "DM, SLACK_DM",
+        "dm, SLACK_DM",
+        "SLACK_CHANNEL, SLACK_CHANNEL",
+        "slack_channel, SLACK_CHANNEL",
+        "SLACKCHANNEL, SLACK_CHANNEL",
+        "CHANNEL, SLACK_CHANNEL",
+        "EMAIL, EMAIL",
+        "email, EMAIL",
+        "MAIL, EMAIL",
+        "mail, EMAIL"
+    })
+    void fromString_parsesValidValues(String input, String expected) {
+        DigestDeliveryMethod result = DigestDeliveryMethod.fromString(input);
+        assertThat(result).isNotNull();
+        assertThat(result.name()).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   ", "invalid", "UNKNOWN", "SMS", "webhook"})
+    void fromString_returnsNullForInvalidValues(String input) {
+        assertThat(DigestDeliveryMethod.fromString(input)).isNull();
+    }
+
+    @Test
+    void slackDmHasExpectedValues() {
+        DigestDeliveryMethod dm = DigestDeliveryMethod.SLACK_DM;
+        assertThat(dm.getDisplayName()).isEqualTo("Slack DM");
+        assertThat(dm.getDescription()).contains("Slack");
+    }
+
+    @Test
+    void emailHasExpectedValues() {
+        DigestDeliveryMethod email = DigestDeliveryMethod.EMAIL;
+        assertThat(email.getDisplayName()).isEqualTo("Email");
+        assertThat(email.getDescription()).contains("email");
+    }
+}

--- a/backend/src/test/java/com/dbaagent/model/PersonaTagTest.java
+++ b/backend/src/test/java/com/dbaagent/model/PersonaTagTest.java
@@ -1,0 +1,68 @@
+package com.dbaagent.model;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PersonaTagTest {
+
+    @Test
+    void allPersonaTagsHaveDisplayNameAndDescription() {
+        for (PersonaTag tag : PersonaTag.values()) {
+            assertThat(tag.getDisplayName()).isNotBlank();
+            assertThat(tag.getDescription()).isNotBlank();
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "DBA, DBA",
+        "dba, DBA",
+        "Dba, DBA",
+        "APP_ENG, APP_ENG",
+        "app_eng, APP_ENG",
+        "APP-ENG, APP_ENG",
+        "app-eng, APP_ENG",
+        "appeng, APP_ENG",
+        "app_engineer, APP_ENG",
+        "application_engineer, APP_ENG",
+        "DATA_ENG, DATA_ENG",
+        "data_eng, DATA_ENG",
+        "DATA-ENG, DATA_ENG",
+        "dataeng, DATA_ENG",
+        "data_engineer, DATA_ENG",
+        "EXEC, EXEC",
+        "exec, EXEC",
+        "executive, EXEC"
+    })
+    void fromString_parsesValidValues(String input, String expected) {
+        PersonaTag result = PersonaTag.fromString(input);
+        assertThat(result).isNotNull();
+        assertThat(result.name()).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   ", "invalid", "UNKNOWN", "admin", "user"})
+    void fromString_returnsNullForInvalidValues(String input) {
+        assertThat(PersonaTag.fromString(input)).isNull();
+    }
+
+    @Test
+    void dbaPersonaTagHasExpectedValues() {
+        PersonaTag dba = PersonaTag.DBA;
+        assertThat(dba.getDisplayName()).isEqualTo("DBA");
+        assertThat(dba.getDescription()).contains("performance");
+    }
+
+    @Test
+    void execPersonaTagHasExpectedValues() {
+        PersonaTag exec = PersonaTag.EXEC;
+        assertThat(exec.getDisplayName()).isEqualTo("Executive");
+        assertThat(exec.getDescription()).contains("cost");
+    }
+}

--- a/backend/src/test/java/com/dbaagent/model/UserDigestPreferenceTest.java
+++ b/backend/src/test/java/com/dbaagent/model/UserDigestPreferenceTest.java
@@ -1,0 +1,147 @@
+package com.dbaagent.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserDigestPreferenceTest {
+
+    @Test
+    void builder_createsPreferenceWithDefaults() {
+        UserDigestPreference pref = UserDigestPreference.builder()
+            .username("alice")
+            .build();
+
+        assertThat(pref.getUsername()).isEqualTo("alice");
+        assertThat(pref.isEnabled()).isTrue();
+        assertThat(pref.getDeliveryMethod()).isEqualTo(DigestDeliveryMethod.SLACK_DM);
+        assertThat(pref.getConnectionId()).isNull();
+        assertThat(pref.getPersonaTag()).isNull();
+        assertThat(pref.getCronExpression()).isNull();
+        assertThat(pref.getTimezone()).isNull();
+        assertThat(pref.getCreatedAt()).isNotNull();
+        assertThat(pref.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    void builder_setsAllFields() {
+        UserDigestPreference pref = UserDigestPreference.builder()
+            .username("bob")
+            .connectionId("conn-123")
+            .enabled(false)
+            .personaTag(PersonaTag.DBA)
+            .cronExpression("0 0 8 * * *")
+            .deliveryMethod(DigestDeliveryMethod.EMAIL)
+            .timezone("America/New_York")
+            .build();
+
+        assertThat(pref.getUsername()).isEqualTo("bob");
+        assertThat(pref.getConnectionId()).isEqualTo("conn-123");
+        assertThat(pref.isEnabled()).isFalse();
+        assertThat(pref.getPersonaTag()).isEqualTo(PersonaTag.DBA);
+        assertThat(pref.getCronExpression()).isEqualTo("0 0 8 * * *");
+        assertThat(pref.getDeliveryMethod()).isEqualTo(DigestDeliveryMethod.EMAIL);
+        assertThat(pref.getTimezone()).isEqualTo("America/New_York");
+    }
+
+    @Test
+    void appliesTo_matchesSpecificConnection() {
+        UserDigestPreference pref = UserDigestPreference.builder()
+            .username("alice")
+            .connectionId("conn-123")
+            .build();
+
+        assertThat(pref.appliesTo("conn-123")).isTrue();
+        assertThat(pref.appliesTo("conn-456")).isFalse();
+        assertThat(pref.appliesTo(null)).isFalse();
+    }
+
+    @Test
+    void appliesTo_nullConnectionIdAppliesToAll() {
+        UserDigestPreference pref = UserDigestPreference.builder()
+            .username("alice")
+            .connectionId(null)
+            .build();
+
+        assertThat(pref.appliesTo("conn-123")).isTrue();
+        assertThat(pref.appliesTo("conn-456")).isTrue();
+        assertThat(pref.appliesTo(null)).isTrue();
+    }
+
+    @Test
+    void getEffectiveCronExpression_returnsCustomWhenSet() {
+        UserDigestPreference pref = UserDigestPreference.builder()
+            .username("alice")
+            .cronExpression("0 0 8 * * *")
+            .build();
+
+        String effective = pref.getEffectiveCronExpression("0 0 9 * * *");
+        assertThat(effective).isEqualTo("0 0 8 * * *");
+    }
+
+    @Test
+    void getEffectiveCronExpression_fallsBackToGlobalWhenNull() {
+        UserDigestPreference pref = UserDigestPreference.builder()
+            .username("alice")
+            .cronExpression(null)
+            .build();
+
+        String effective = pref.getEffectiveCronExpression("0 0 9 * * *");
+        assertThat(effective).isEqualTo("0 0 9 * * *");
+    }
+
+    @Test
+    void getEffectiveCronExpression_fallsBackToGlobalWhenBlank() {
+        UserDigestPreference pref = UserDigestPreference.builder()
+            .username("alice")
+            .cronExpression("   ")
+            .build();
+
+        String effective = pref.getEffectiveCronExpression("0 0 9 * * *");
+        assertThat(effective).isEqualTo("0 0 9 * * *");
+    }
+
+    @Test
+    void isPerUserDelivery_inSlackDigestLog() {
+        SlackDigestLog log = new SlackDigestLog();
+
+        assertThat(log.isPerUserDelivery()).isFalse();
+
+        log.setRecipientUsername("alice");
+        assertThat(log.isPerUserDelivery()).isTrue();
+
+        log.setRecipientUsername("   ");
+        assertThat(log.isPerUserDelivery()).isFalse();
+    }
+
+    @Test
+    void slackDigestLog_newFieldsHaveDefaults() {
+        SlackDigestLog log = new SlackDigestLog();
+
+        assertThat(log.getRecipientUsername()).isNull();
+        assertThat(log.getRecipientRole()).isNull();
+        assertThat(log.getPersonaTag()).isNull();
+        assertThat(log.getDeliveryMethod()).isNull();
+        assertThat(log.getPreferenceId()).isNull();
+        assertThat(log.isPersonalized()).isFalse();
+    }
+
+    @Test
+    void slackDigestLog_canSetPerUserFields() {
+        SlackDigestLog log = new SlackDigestLog();
+        log.setRecipientUsername("alice");
+        log.setRecipientRole("ADMIN");
+        log.setPersonaTag(PersonaTag.DBA);
+        log.setDeliveryMethod(DigestDeliveryMethod.SLACK_DM);
+        log.setPreferenceId(42L);
+        log.setPersonalized(true);
+
+        assertThat(log.getRecipientUsername()).isEqualTo("alice");
+        assertThat(log.getRecipientRole()).isEqualTo("ADMIN");
+        assertThat(log.getPersonaTag()).isEqualTo(PersonaTag.DBA);
+        assertThat(log.getDeliveryMethod()).isEqualTo(DigestDeliveryMethod.SLACK_DM);
+        assertThat(log.getPreferenceId()).isEqualTo(42L);
+        assertThat(log.isPersonalized()).isTrue();
+        assertThat(log.isPerUserDelivery()).isTrue();
+    }
+}

--- a/backend/src/test/java/com/dbaagent/service/SlackDailyDigestDemoPrintTest.java
+++ b/backend/src/test/java/com/dbaagent/service/SlackDailyDigestDemoPrintTest.java
@@ -72,6 +72,7 @@ class SlackDailyDigestDemoPrintTest {
     @Mock private AuthLoginChallengeRepository authLoginChallengeRepository;
     @Mock private IndexAdvisorService indexAdvisorService;
     @Mock private IndexRecommendationService indexRecommendationService;
+    @Mock private com.dbaagent.repository.UserDigestPreferenceRepository userDigestPreferenceRepository;
 
     private SlackDailyDigestService service;
 
@@ -87,7 +88,7 @@ class SlackDailyDigestDemoPrintTest {
             slackUserLinkService,
             lockContentionRepository, queryFingerprintRepository, databaseEventRepository,
             connectionAccessGrantRepository, authLoginChallengeRepository, indexAdvisorService,
-            indexRecommendationService
+            indexRecommendationService, userDigestPreferenceRepository
         );
     }
 

--- a/backend/src/test/java/com/dbaagent/service/SlackDailyDigestServiceTest.java
+++ b/backend/src/test/java/com/dbaagent/service/SlackDailyDigestServiceTest.java
@@ -69,6 +69,7 @@ class SlackDailyDigestServiceTest {
     @Mock private AuthLoginChallengeRepository authLoginChallengeRepository;
     @Mock private IndexAdvisorService indexAdvisorService;
     @Mock private IndexRecommendationService indexRecommendationService;
+    @Mock private com.dbaagent.repository.UserDigestPreferenceRepository userDigestPreferenceRepository;
 
     private SlackDailyDigestService service;
 
@@ -102,7 +103,8 @@ class SlackDailyDigestServiceTest {
             connectionAccessGrantRepository,
             authLoginChallengeRepository,
             indexAdvisorService,
-            indexRecommendationService
+            indexRecommendationService,
+            userDigestPreferenceRepository
         );
     }
 

--- a/backend/src/test/java/com/dbaagent/service/UserDigestPreferenceServiceTest.java
+++ b/backend/src/test/java/com/dbaagent/service/UserDigestPreferenceServiceTest.java
@@ -1,0 +1,261 @@
+package com.dbaagent.service;
+
+import com.dbaagent.model.DigestDeliveryMethod;
+import com.dbaagent.model.PersonaTag;
+import com.dbaagent.model.SlackDigestConfig;
+import com.dbaagent.model.UserDigestPreference;
+import com.dbaagent.repository.SlackDigestConfigRepository;
+import com.dbaagent.repository.UserDigestPreferenceRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserDigestPreferenceServiceTest {
+
+    @Mock
+    private UserDigestPreferenceRepository preferenceRepository;
+
+    @Mock
+    private SlackDigestConfigRepository configRepository;
+
+    private UserDigestPreferenceService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new UserDigestPreferenceService(preferenceRepository, configRepository);
+    }
+
+    @Test
+    void getPreferencesForUser_delegatesToRepository() {
+        List<UserDigestPreference> expected = List.of(
+            UserDigestPreference.builder().username("alice").build()
+        );
+        when(preferenceRepository.findByUsernameOrderByConnectionIdAscCreatedAtDesc("alice"))
+            .thenReturn(expected);
+
+        List<UserDigestPreference> result = service.getPreferencesForUser("alice");
+
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void hasAnyPreferences_delegatesToRepository() {
+        when(preferenceRepository.hasAnyPreferences()).thenReturn(true);
+        assertThat(service.hasAnyPreferences()).isTrue();
+
+        when(preferenceRepository.hasAnyPreferences()).thenReturn(false);
+        assertThat(service.hasAnyPreferences()).isFalse();
+    }
+
+    @Test
+    void getGlobalCronExpression_returnsSingletonCron() {
+        SlackDigestConfig config = new SlackDigestConfig();
+        config.setCronExpression("0 0 10 * * *");
+        when(configRepository.findById(1L)).thenReturn(Optional.of(config));
+
+        String result = service.getGlobalCronExpression();
+
+        assertThat(result).isEqualTo("0 0 10 * * *");
+    }
+
+    @Test
+    void getGlobalCronExpression_returnsDefaultWhenNoConfig() {
+        when(configRepository.findById(1L)).thenReturn(Optional.empty());
+
+        String result = service.getGlobalCronExpression();
+
+        assertThat(result).isEqualTo("0 0 9 * * *");
+    }
+
+    @Test
+    void createPreference_savesNewPreference() {
+        when(preferenceRepository.findByUsernameAndConnectionIdAndDeliveryMethod(
+            "alice", "conn-1", DigestDeliveryMethod.SLACK_DM))
+            .thenReturn(Optional.empty());
+        when(preferenceRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        UserDigestPreference result = service.createPreference(
+            "alice",
+            "conn-1",
+            DigestDeliveryMethod.SLACK_DM,
+            PersonaTag.DBA,
+            "0 0 8 * * *",
+            "America/New_York"
+        );
+
+        assertThat(result.getUsername()).isEqualTo("alice");
+        assertThat(result.getConnectionId()).isEqualTo("conn-1");
+        assertThat(result.getDeliveryMethod()).isEqualTo(DigestDeliveryMethod.SLACK_DM);
+        assertThat(result.getPersonaTag()).isEqualTo(PersonaTag.DBA);
+        assertThat(result.getCronExpression()).isEqualTo("0 0 8 * * *");
+        assertThat(result.getTimezone()).isEqualTo("America/New_York");
+        assertThat(result.isEnabled()).isTrue();
+
+        verify(preferenceRepository).save(any());
+    }
+
+    @Test
+    void createPreference_throwsWhenDuplicate() {
+        when(preferenceRepository.findByUsernameAndConnectionIdAndDeliveryMethod(
+            "alice", "conn-1", DigestDeliveryMethod.SLACK_DM))
+            .thenReturn(Optional.of(UserDigestPreference.builder().username("alice").build()));
+
+        assertThatThrownBy(() -> service.createPreference(
+            "alice", "conn-1", DigestDeliveryMethod.SLACK_DM, null, null, null
+        )).isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("already exists");
+    }
+
+    @Test
+    void updatePreference_updatesFields() {
+        UserDigestPreference existing = UserDigestPreference.builder()
+            .id(1L)
+            .username("alice")
+            .enabled(true)
+            .personaTag(PersonaTag.DBA)
+            .cronExpression("0 0 8 * * *")
+            .build();
+        when(preferenceRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(preferenceRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        UserDigestPreference result = service.updatePreference(
+            1L, false, PersonaTag.EXEC, "0 0 10 * * *", "Europe/London"
+        );
+
+        assertThat(result.isEnabled()).isFalse();
+        assertThat(result.getPersonaTag()).isEqualTo(PersonaTag.EXEC);
+        assertThat(result.getCronExpression()).isEqualTo("0 0 10 * * *");
+        assertThat(result.getTimezone()).isEqualTo("Europe/London");
+    }
+
+    @Test
+    void updatePreference_clearsFieldsWhenBlank() {
+        UserDigestPreference existing = UserDigestPreference.builder()
+            .id(1L)
+            .username("alice")
+            .cronExpression("0 0 8 * * *")
+            .timezone("America/New_York")
+            .build();
+        when(preferenceRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(preferenceRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        UserDigestPreference result = service.updatePreference(
+            1L, null, null, "", ""
+        );
+
+        assertThat(result.getCronExpression()).isNull();
+        assertThat(result.getTimezone()).isNull();
+    }
+
+    @Test
+    void updatePreference_throwsWhenNotFound() {
+        when(preferenceRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.updatePreference(999L, true, null, null, null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("not found");
+    }
+
+    @Test
+    void setEnabled_togglesEnableState() {
+        UserDigestPreference existing = UserDigestPreference.builder()
+            .id(1L)
+            .username("alice")
+            .enabled(true)
+            .build();
+        when(preferenceRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(preferenceRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        UserDigestPreference result = service.setEnabled(1L, false);
+
+        assertThat(result.isEnabled()).isFalse();
+    }
+
+    @Test
+    void deletePreference_delegatesToRepository() {
+        service.deletePreference(42L);
+
+        verify(preferenceRepository).deleteById(42L);
+    }
+
+    @Test
+    void deleteAllPreferencesForUser_delegatesToRepository() {
+        service.deleteAllPreferencesForUser("alice");
+
+        verify(preferenceRepository).deleteByUsername("alice");
+    }
+
+    @Test
+    void countEnabled_delegatesToRepository() {
+        when(preferenceRepository.countByEnabledTrue()).thenReturn(5L);
+
+        long result = service.countEnabled();
+
+        assertThat(result).isEqualTo(5L);
+    }
+
+    @Test
+    void resolveEffectiveCron_usesPreferenceCronWhenSet() {
+        UserDigestPreference pref = UserDigestPreference.builder()
+            .cronExpression("0 0 8 * * *")
+            .build();
+
+        String result = service.resolveEffectiveCron(pref);
+
+        assertThat(result).isEqualTo("0 0 8 * * *");
+    }
+
+    @Test
+    void resolveEffectiveCron_fallsBackToGlobalWhenNull() {
+        SlackDigestConfig config = new SlackDigestConfig();
+        config.setCronExpression("0 0 10 * * *");
+        when(configRepository.findById(1L)).thenReturn(Optional.of(config));
+
+        UserDigestPreference pref = UserDigestPreference.builder()
+            .cronExpression(null)
+            .build();
+
+        String result = service.resolveEffectiveCron(pref);
+
+        assertThat(result).isEqualTo("0 0 10 * * *");
+    }
+
+    @Test
+    void getEnabledPreferences_findsUserAndConnectionSpecificPrefs() {
+        List<UserDigestPreference> expected = List.of(
+            UserDigestPreference.builder().username("alice").connectionId("conn-1").build(),
+            UserDigestPreference.builder().username("alice").connectionId(null).build()
+        );
+        when(preferenceRepository.findEnabledForUserAndConnection("alice", "conn-1"))
+            .thenReturn(expected);
+
+        List<UserDigestPreference> result = service.getEnabledPreferences("alice", "conn-1");
+
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    void getRecipientsForConnection_findsAllEnabledForConnection() {
+        List<UserDigestPreference> expected = List.of(
+            UserDigestPreference.builder().username("alice").connectionId("conn-1").build(),
+            UserDigestPreference.builder().username("bob").connectionId(null).build()
+        );
+        when(preferenceRepository.findEnabledForConnection("conn-1")).thenReturn(expected);
+
+        List<UserDigestPreference> result = service.getRecipientsForConnection("conn-1");
+
+        assertThat(result).hasSize(2);
+    }
+}

--- a/docs/DIGEST_PREFERENCES.md
+++ b/docs/DIGEST_PREFERENCES.md
@@ -1,0 +1,159 @@
+# Per-User Digest Preferences
+
+This document describes the per-user digest preference system introduced to support role-aware, personalized database digests.
+
+## Overview
+
+DeepSQL's daily digest feature now supports **per-user preferences**, allowing each user to:
+
+- Choose their preferred **delivery method** (Slack DM, Slack channel, or email)
+- Set a **persona tag** for content prioritization (DBA, App Engineer, Data Engineer, Executive)
+- Configure a **custom schedule** (cron expression) per subscription
+- Subscribe to **specific connections** or all connections they have access to
+
+## Architecture
+
+### Data Model
+
+```
+┌─────────────────────────┐      ┌────────────────────────┐
+│   SlackDigestConfig     │      │  UserDigestPreference  │
+│   (singleton, id=1)     │      │  (per-user, per-conn)  │
+├─────────────────────────┤      ├────────────────────────┤
+│ cronExpression          │◄─────│ username               │
+│ updatedAt               │      │ connectionId (nullable)│
+│ isGlobalDefault = true  │      │ enabled                │
+└─────────────────────────┘      │ personaTag             │
+         │                       │ cronExpression         │
+         │                       │ deliveryMethod         │
+         │ fallback when no      │ timezone               │
+         │ preferences exist     │ createdAt / updatedAt  │
+         ▼                       └────────────────────────┘
+```
+
+### Resolution Order
+
+When delivering a digest, the system resolves preferences in this order:
+
+1. **User + Connection specific** — `UserDigestPreference` where `connectionId` matches
+2. **User-wide** — `UserDigestPreference` where `connectionId IS NULL`
+3. **Global fallback** — `SlackDigestConfig` singleton (legacy behavior)
+
+## Persona Tags
+
+Persona tags influence how digest content is prioritized:
+
+| Tag | Display Name | Focus Areas |
+|-----|--------------|-------------|
+| `DBA` | DBA | Performance tuning, index recommendations, operational health |
+| `APP_ENG` | App Engineer | Query patterns, ORM issues, schema usage |
+| `DATA_ENG` | Data Engineer | ETL patterns, data quality, pipeline health |
+| `EXEC` | Executive | High-level summaries, costs, capacity forecasts |
+
+A user's **RBAC role** determines what they can access; the **persona tag** influences how content is ranked and presented.
+
+## Delivery Methods
+
+| Method | Requires |
+|--------|----------|
+| `SLACK_DM` | User must be linked via SlackUserLink |
+| `SLACK_CHANNEL` | Connection must have a SlackChannelBinding |
+| `EMAIL` | User's registered email address |
+
+## API Endpoints
+
+### User Self-Service (`/digest/preferences`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/digest/preferences` | List my preferences |
+| `POST` | `/digest/preferences` | Create a new preference |
+| `PUT` | `/digest/preferences/{id}` | Update a preference |
+| `PATCH` | `/digest/preferences/{id}/enabled` | Enable/disable |
+| `DELETE` | `/digest/preferences/{id}` | Delete a preference |
+| `GET` | `/digest/preferences/persona-tags` | List available persona tags |
+| `GET` | `/digest/preferences/delivery-methods` | List available delivery methods |
+
+### Admin Management (`/admin/slack/digest/preferences`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/admin/slack/digest/preferences/{username}` | Get user's preferences |
+| `GET` | `/admin/slack/digest/preferences/users` | List users with preferences |
+| `GET` | `/admin/slack/digest/preferences/stats` | Get preference statistics |
+| `POST` | `/admin/slack/digest/preferences/{username}` | Create preference for user |
+| `PUT` | `/admin/slack/digest/preferences/id/{id}` | Update any preference |
+| `DELETE` | `/admin/slack/digest/preferences/id/{id}` | Delete any preference |
+| `DELETE` | `/admin/slack/digest/preferences/{username}` | Delete all user's preferences |
+
+## Creating a Preference
+
+### Request Body
+
+```json
+{
+  "connectionId": "uuid-of-connection",  // null for all connections
+  "deliveryMethod": "SLACK_DM",          // SLACK_DM, SLACK_CHANNEL, EMAIL
+  "personaTag": "DBA",                   // DBA, APP_ENG, DATA_ENG, EXEC
+  "cronExpression": "0 0 8 * * *",       // optional custom schedule
+  "timezone": "America/New_York"         // optional IANA timezone
+}
+```
+
+### Example: Create a DBA preference for all connections via Slack DM
+
+```bash
+curl -X POST http://localhost:8080/api/digest/preferences \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "deliveryMethod": "SLACK_DM",
+    "personaTag": "DBA"
+  }'
+```
+
+### Example: Create an executive preference for a specific connection via email at 8 AM EST
+
+```bash
+curl -X POST http://localhost:8080/api/digest/preferences \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "connectionId": "abc-123-def-456",
+    "deliveryMethod": "EMAIL",
+    "personaTag": "EXEC",
+    "cronExpression": "0 0 8 * * *",
+    "timezone": "America/New_York"
+  }'
+```
+
+## Migration from Singleton
+
+The singleton `SlackDigestConfig` (id=1) remains active and serves as the global default:
+
+- **No preferences exist** → Digest uses legacy channel-broadcast behavior
+- **Preferences exist** → Per-user delivery is used; users without preferences still get the legacy broadcast
+
+This ensures backward compatibility: existing deployments continue working without any configuration changes.
+
+## Audit Trail
+
+The `SlackDigestLog` table now tracks per-recipient delivery:
+
+| Field | Description |
+|-------|-------------|
+| `recipient_username` | Username of the recipient (null for legacy broadcast) |
+| `recipient_role` | RBAC role at delivery time |
+| `persona_tag` | Persona used for content prioritization |
+| `delivery_method` | How the digest was delivered |
+| `preference_id` | FK to the preference that triggered delivery |
+| `personalized` | Whether content was role-personalized |
+
+## Future Work (PR2)
+
+This PR (PR1) establishes the **data model and migration only**. The following features are planned for PR2:
+
+- **Role-aware content ranking** — Different insight prioritization per persona
+- **Per-user delivery execution** — Actually sending personalized digests
+- **Scheduled task per-user** — Respecting individual cron expressions
+- **Email delivery implementation** — Currently only Slack is implemented


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR1 for the "Thinking database — continuous-learning Brain + role-aware digests" theme. This change migrates Slack digest configuration from singleton-only to per-user/per-recipient digest preferences with roles.

## What Changed

### Data Model

- **`PersonaTag` enum** — Persona tags for content prioritization: `DBA`, `APP_ENG`, `DATA_ENG`, `EXEC`
- **`DigestDeliveryMethod` enum** — Delivery methods: `SLACK_DM`, `SLACK_CHANNEL`, `EMAIL`
- **`UserDigestPreference` entity** — Per-user digest subscriptions with:
  - Username and optional connection scope
  - Enable/disable toggle
  - Persona tag for content prioritization
  - Custom cron expression for per-user schedules
  - Delivery method preference
  - Timezone support
- **Extended `SlackDigestLog`** — New fields for per-delivery tracking:
  - `recipient_username` — Who received the digest
  - `recipient_role` — RBAC role at delivery time (audit trail)
  - `persona_tag` — Persona used for this delivery
  - `delivery_method` — How it was delivered
  - `preference_id` — FK to triggering preference
  - `personalized` — Whether content was role-personalized

### Services

- **`UserDigestPreferenceService`** — CRUD and preference resolution logic
- **Minimal hooks in `SlackDailyDigestService`**:
  - `isPerUserModeEnabled()` — Check if per-user preferences exist
  - `getDigestRecipients(connectionId)` — Get recipients for a connection
  - `getDigestModeInfo()` — Mode summary for debugging

### API Endpoints

**User Self-Service** (`/digest/preferences`):
| Method | Endpoint | Description |
|--------|----------|-------------|
| `GET` | `/digest/preferences` | List my preferences |
| `POST` | `/digest/preferences` | Create a preference |
| `PUT` | `/digest/preferences/{id}` | Update a preference |
| `PATCH` | `/digest/preferences/{id}/enabled` | Enable/disable |
| `DELETE` | `/digest/preferences/{id}` | Delete a preference |

**Admin Management** (`/admin/slack/digest/preferences`):
| Method | Endpoint | Description |
|--------|----------|-------------|
| `GET` | `/{username}` | Get user's preferences |
| `GET` | `/users` | List users with preferences |
| `GET` | `/stats` | Preference statistics |
| `POST` | `/{username}` | Create for any user |

### Migration

- **V120** creates `user_digest_preference` table
- Extends `slack_digest_log` with recipient/persona/delivery fields
- Adds `is_global_default` to `slack_digest_config`
- Backward compatible: singleton behavior preserved when no prefs exist

## Testing

- Unit tests for `PersonaTag` and `DigestDeliveryMethod` enum parsing
- Unit tests for `UserDigestPreference` entity behavior
- Unit tests for `UserDigestPreferenceService` CRUD and resolution logic
- Updated existing `SlackDailyDigestServiceTest` to include new repository

## Documentation

Added `docs/DIGEST_PREFERENCES.md` with:
- Architecture overview
- Preference resolution order
- Persona tag descriptions
- API usage examples

## Scope

**This PR (PR1)**: Data model + migration + API + minimal service hooks

**Next PR (PR2)**: Full role-aware content ranking and per-user delivery execution

## Acceptance Criteria

- [x] Schema/API/model supports two users with different roles/prefs on same connection
- [x] Cron/config is no longer singleton-only
- [x] Migration path from existing `id=1` singleton (backward compatible)
- [x] Tests for prefs model / migration behavior
- [x] Documentation for setting role prefs + schedule
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-765625e0-bc20-4241-a0d1-ac1876933784?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-765625e0-bc20-4241-a0d1-ac1876933784&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

