### PR TITLE
polish: Digest Preferences UI — connection names, one gear, first-run

### DIFF
--- a/backend/src/main/java/com/dbaagent/controller/DigestPreferenceController.java
+++ b/backend/src/main/java/com/dbaagent/controller/DigestPreferenceController.java
@@ -1,8 +1,11 @@
 package com.dbaagent.controller;
 
+import com.dbaagent.dto.DigestPreferenceResponse;
+import com.dbaagent.model.DatabaseConnection;
 import com.dbaagent.model.DigestDeliveryMethod;
 import com.dbaagent.model.PersonaTag;
 import com.dbaagent.model.UserDigestPreference;
+import com.dbaagent.repository.CredentialRepository;
 import com.dbaagent.service.DigestPreferenceSeedService;
 import com.dbaagent.service.security.AccessControlService;
 import com.dbaagent.service.UserDigestPreferenceService;
@@ -13,8 +16,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * REST controller for managing per-user digest preferences.
@@ -32,21 +39,23 @@ public class DigestPreferenceController {
     private final AccessControlService accessControlService;
     private final DigestPreferenceSeedService seedService;
     private final SlackDailyDigestService digestService;
+    private final CredentialRepository credentialRepository;
 
     /**
-     * Get the current user's digest preferences.
+     * Get the current user's digest preferences (includes connection display names).
      */
     @GetMapping
-    public ResponseEntity<List<UserDigestPreference>> getMyPreferences() {
+    public ResponseEntity<List<DigestPreferenceResponse>> getMyPreferences() {
         String username = accessControlService.requireCurrentUsername();
-        return ResponseEntity.ok(preferenceService.getPreferencesForUser(username));
+        List<UserDigestPreference> prefs = preferenceService.getPreferencesForUser(username);
+        return ResponseEntity.ok(toResponses(prefs));
     }
 
     /**
      * Create a new digest preference for the current user.
      */
     @PostMapping
-    public ResponseEntity<UserDigestPreference> createPreference(@RequestBody CreatePreferenceRequest request) {
+    public ResponseEntity<DigestPreferenceResponse> createPreference(@RequestBody CreatePreferenceRequest request) {
         String username = accessControlService.requireCurrentUsername();
 
         DigestDeliveryMethod method;
@@ -80,14 +89,14 @@ public class DigestPreferenceController {
             request.timezone
         );
 
-        return ResponseEntity.ok(preference);
+        return ResponseEntity.ok(toResponse(preference));
     }
 
     /**
      * Update an existing preference.
      */
     @PutMapping("/{id}")
-    public ResponseEntity<UserDigestPreference> updatePreference(
+    public ResponseEntity<DigestPreferenceResponse> updatePreference(
             @PathVariable Long id,
             @RequestBody UpdatePreferenceRequest request) {
 
@@ -112,14 +121,14 @@ public class DigestPreferenceController {
             request.timezone
         );
 
-        return ResponseEntity.ok(updated);
+        return ResponseEntity.ok(toResponse(updated));
     }
 
     /**
      * Enable or disable a preference.
      */
     @PatchMapping("/{id}/enabled")
-    public ResponseEntity<UserDigestPreference> setEnabled(
+    public ResponseEntity<DigestPreferenceResponse> setEnabled(
             @PathVariable Long id,
             @RequestBody Map<String, Boolean> body) {
 
@@ -138,7 +147,7 @@ public class DigestPreferenceController {
         }
 
         UserDigestPreference updated = preferenceService.setEnabled(id, enabled);
-        return ResponseEntity.ok(updated);
+        return ResponseEntity.ok(toResponse(updated));
     }
 
     /**
@@ -285,5 +294,59 @@ public class DigestPreferenceController {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, String>> handleBadRequest(IllegalArgumentException e) {
         return ResponseEntity.badRequest().body(Map.of("message", e.getMessage() != null ? e.getMessage() : "Bad request"));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Response mapping (connection display names)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private List<DigestPreferenceResponse> toResponses(List<UserDigestPreference> prefs) {
+        Map<String, String> namesById = resolveConnectionNames(prefs);
+        return prefs.stream()
+            .map(pref -> toResponse(pref, namesById))
+            .toList();
+    }
+
+    private DigestPreferenceResponse toResponse(UserDigestPreference pref) {
+        Map<String, String> namesById = resolveConnectionNames(List.of(pref));
+        return toResponse(pref, namesById);
+    }
+
+    private DigestPreferenceResponse toResponse(UserDigestPreference pref, Map<String, String> namesById) {
+        String connectionName = null;
+        if (pref.getConnectionId() != null) {
+            connectionName = namesById.get(pref.getConnectionId());
+        }
+        return DigestPreferenceResponse.builder()
+            .id(pref.getId())
+            .username(pref.getUsername())
+            .connectionId(pref.getConnectionId())
+            .connectionName(connectionName)
+            .enabled(pref.isEnabled())
+            .personaTag(pref.getPersonaTag() != null ? pref.getPersonaTag().name() : null)
+            .cronExpression(pref.getCronExpression())
+            .deliveryMethod(pref.getDeliveryMethod() != null ? pref.getDeliveryMethod().name() : null)
+            .timezone(pref.getTimezone())
+            .createdAt(pref.getCreatedAt())
+            .updatedAt(pref.getUpdatedAt())
+            .build();
+    }
+
+    private Map<String, String> resolveConnectionNames(List<UserDigestPreference> prefs) {
+        Set<String> ids = prefs.stream()
+            .map(UserDigestPreference::getConnectionId)
+            .filter(Objects::nonNull)
+            .filter(id -> !id.isBlank())
+            .collect(Collectors.toSet());
+        if (ids.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, String> names = new HashMap<>();
+        for (DatabaseConnection conn : credentialRepository.findAllById(ids)) {
+            if (conn.getId() != null && conn.getConnectionName() != null) {
+                names.put(conn.getId(), conn.getConnectionName());
+            }
+        }
+        return names;
     }
 }

--- a/backend/src/main/java/com/dbaagent/dto/DigestPreferenceResponse.java
+++ b/backend/src/main/java/com/dbaagent/dto/DigestPreferenceResponse.java
@@ -1,0 +1,26 @@
+package com.dbaagent.dto;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.LocalDateTime;
+
+/**
+ * API view of a {@code UserDigestPreference} with a human-readable connection name.
+ */
+@Value
+@Builder
+public class DigestPreferenceResponse {
+    Long id;
+    String username;
+    String connectionId;
+    /** Display name for {@link #connectionId}; null when unknown or preference is connection-wide. */
+    String connectionName;
+    boolean enabled;
+    String personaTag;
+    String cronExpression;
+    String deliveryMethod;
+    String timezone;
+    LocalDateTime createdAt;
+    LocalDateTime updatedAt;
+}

--- a/docs/DIGEST_PREFERENCES.md
+++ b/docs/DIGEST_PREFERENCES.md
@@ -86,7 +86,7 @@ Note: Do not claim EMAIL or WhatsApp delivery is available. These are planned fo
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/api/digest/preferences` | GET | Get current user's preferences |
+| `/api/digest/preferences` | GET | Get current user's preferences (includes `connectionName`) |
 | `/api/digest/preferences` | POST | Create a new preference |
 | `/api/digest/preferences/{id}` | PUT | Update a preference |
 | `/api/digest/preferences/{id}/enabled` | PATCH | Enable/disable |
@@ -134,16 +134,17 @@ To migrate from legacy singleton mode to per-user mode:
 
 The digest preferences are accessible from:
 
-1. **Digest Section** (sidebar): Click the bell icon (🔔) to open preferences panel
-2. **Preferences Panel**: Create, edit, enable/disable, delete preferences
+1. **Digest Section** (sidebar): Click the **gear** (⚙) to open the preferences panel — single entry point (no competing bell)
+2. **First-run**: Opening Digests with zero preferences (or none enabled) auto-opens the panel once (`localStorage` flag)
+3. **Preferences Panel**: Create, edit, enable/disable, delete preferences
 
 ### Preferences Panel Features
 
-- View all your digest subscriptions
+- Pref cards show **connection display names** (API `connectionName`, with client-side fallback from the connections list; UUID only if name is missing)
 - Toggle digests on/off per connection
-- Change persona without recreating
+- Change persona and schedule inline (compact controls — no duplicate meta labels)
 - Quick schedule presets (8 AM, 9 AM, Noon, etc.) — stored on the preference and honored by the minute-tick scheduler
-- Seed for all your connections at once
+- Seed for all your connections at once (`POST /api/digest/preferences/seed/me`)
 
 ## Database Schema
 

--- a/src/components/sections/DigestPreferencesPanel.jsx
+++ b/src/components/sections/DigestPreferencesPanel.jsx
@@ -1,9 +1,6 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import {
   X,
-  User,
-  Bell,
-  Clock,
   Check,
   AlertCircle,
   RefreshCw,
@@ -21,11 +18,37 @@ const CRON_PRESETS = [
   { label: '9 AM daily', value: '0 0 9 * * *' },
   { label: '10 AM daily', value: '0 0 10 * * *' },
   { label: 'Noon daily', value: '0 0 12 * * *' },
-  { label: 'Use global', value: null },
+  { label: 'Use global', value: '' },
 ]
 
+function cronPresetLabel(cronExpression) {
+  if (!cronExpression) return 'Use global'
+  const match = CRON_PRESETS.find((p) => p.value === cronExpression)
+  return match ? match.label : 'Custom'
+}
+
+/**
+ * Prefer API connectionName; else resolve from the connections list; else UUID.
+ */
+function resolveConnectionDisplayName(pref, connections, selectedConnection, connectionId) {
+  if (pref?.connectionName && String(pref.connectionName).trim()) {
+    return pref.connectionName
+  }
+  if (!pref?.connectionId) {
+    return 'All connections'
+  }
+  const fromList = connections?.find((c) => c.id === pref.connectionId)
+  if (fromList?.connectionName) {
+    return fromList.connectionName
+  }
+  if (pref.connectionId === connectionId && selectedConnection?.connectionName) {
+    return selectedConnection.connectionName
+  }
+  return pref.connectionId
+}
+
 export default function DigestPreferencesPanel({ onClose }) {
-  const { connectionId, selectedConnection } = useConnectionManager()
+  const { connectionId, selectedConnection, connections } = useConnectionManager()
   const [preferences, setPreferences] = useState([])
   const [personaTags, setPersonaTags] = useState([])
   const [status, setStatus] = useState(null)
@@ -63,6 +86,11 @@ export default function DigestPreferencesPanel({ onClose }) {
     load()
   }, [load])
 
+  const showSuccess = (msg) => {
+    setSuccessMsg(msg)
+    setTimeout(() => setSuccessMsg(null), 2500)
+  }
+
   const handleToggleEnabled = async (pref) => {
     try {
       const updated = await digestPreferencesAPI.setEnabled(pref.id, !pref.enabled)
@@ -87,6 +115,23 @@ export default function DigestPreferencesPanel({ onClose }) {
       showSuccess('Persona updated')
     } catch {
       setError('Failed to update persona')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleUpdateSchedule = async (pref, cronExpression) => {
+    setSaving(true)
+    try {
+      const updated = await digestPreferencesAPI.updatePreference(pref.id, {
+        cronExpression: cronExpression ?? '',
+      })
+      setPreferences((prev) =>
+        prev.map((p) => (p.id === pref.id ? updated : p))
+      )
+      showSuccess('Schedule updated')
+    } catch {
+      setError('Failed to update schedule')
     } finally {
       setSaving(false)
     }
@@ -155,14 +200,17 @@ export default function DigestPreferencesPanel({ onClose }) {
     setNewCron(preset.value || '')
   }
 
-  const showSuccess = (msg) => {
-    setSuccessMsg(msg)
-    setTimeout(() => setSuccessMsg(null), 2500)
-  }
-
   const currentConnectionPref = preferences.find(
     (p) => p.connectionId === connectionId
   )
+
+  const connectionNameById = useMemo(() => {
+    const map = {}
+    for (const c of connections || []) {
+      if (c?.id) map[c.id] = c.connectionName
+    }
+    return map
+  }, [connections])
 
   return (
     <div className={styles.panelOverlay} onClick={onClose}>
@@ -170,10 +218,10 @@ export default function DigestPreferencesPanel({ onClose }) {
         {/* Header */}
         <div className={styles.panelHeader}>
           <div className={styles.headerTitle}>
-            <Bell size={16} />
+            <Settings2 size={16} />
             <span>Digest Preferences</span>
           </div>
-          <button className={styles.iconBtn} onClick={onClose}>
+          <button className={styles.iconBtn} onClick={onClose} type="button">
             <X size={15} />
           </button>
         </div>
@@ -203,7 +251,7 @@ export default function DigestPreferencesPanel({ onClose }) {
             <div className={styles.errorBanner}>
               <AlertCircle size={14} />
               <span>{error}</span>
-              <button onClick={() => setError(null)}>×</button>
+              <button type="button" onClick={() => setError(null)}>×</button>
             </div>
           )}
 
@@ -216,7 +264,7 @@ export default function DigestPreferencesPanel({ onClose }) {
 
           {!loading && preferences.length === 0 && (
             <div className={styles.emptyState}>
-              <Bell size={28} color="#d1d5db" />
+              <Settings2 size={28} color="#d1d5db" />
               <h4>No digest preferences yet</h4>
               <p>
                 Set up personalized digests to receive database insights via Slack
@@ -227,6 +275,7 @@ export default function DigestPreferencesPanel({ onClose }) {
                   className={styles.seedBtn}
                   onClick={handleSeedForMe}
                   disabled={saving}
+                  type="button"
                 >
                   <Sparkles size={14} />
                   {saving ? 'Setting up...' : 'Set up for all my connections'}
@@ -235,6 +284,7 @@ export default function DigestPreferencesPanel({ onClose }) {
                   className={styles.createBtn}
                   onClick={() => setShowCreate(true)}
                   disabled={!connectionId}
+                  type="button"
                 >
                   <Plus size={14} />
                   Create for current connection
@@ -257,6 +307,7 @@ export default function DigestPreferencesPanel({ onClose }) {
                       ? 'Already configured for this connection'
                       : 'Add preference for current connection'
                   }
+                  type="button"
                 >
                   <Plus size={14} />
                 </button>
@@ -266,11 +317,21 @@ export default function DigestPreferencesPanel({ onClose }) {
                 <PreferenceCard
                   key={pref.id}
                   pref={pref}
+                  displayName={resolveConnectionDisplayName(
+                    {
+                      ...pref,
+                      connectionName:
+                        pref.connectionName || connectionNameById[pref.connectionId],
+                    },
+                    connections,
+                    selectedConnection,
+                    connectionId
+                  )}
                   personaTags={personaTags}
-                  selectedConnection={selectedConnection}
                   connectionId={connectionId}
                   onToggle={() => handleToggleEnabled(pref)}
                   onUpdatePersona={(tag) => handleUpdatePersona(pref, tag)}
+                  onUpdateSchedule={(cron) => handleUpdateSchedule(pref, cron)}
                   onDelete={() => handleDelete(pref)}
                 />
               ))}
@@ -282,19 +343,22 @@ export default function DigestPreferencesPanel({ onClose }) {
             <div className={styles.createForm}>
               <h4>New digest preference</h4>
               <p className={styles.createHint}>
-                For: {selectedConnection?.connectionName || connectionId || 'Select a connection'}
+                For:{' '}
+                {selectedConnection?.connectionName ||
+                  connectionId ||
+                  'Select a connection'}
               </p>
 
-              <label className={styles.fieldLabel}>Persona (optional)</label>
+              <label className={styles.fieldLabel}>Persona</label>
               <select
                 className={styles.select}
                 value={newPersona}
                 onChange={(e) => setNewPersona(e.target.value)}
               >
-                <option value="">Use my role only</option>
+                <option value="">Role-based (default)</option>
                 {personaTags.map((tag) => (
                   <option key={tag.value} value={tag.value}>
-                    {tag.label} — {tag.description}
+                    {tag.label}
                   </option>
                 ))}
               </select>
@@ -304,6 +368,7 @@ export default function DigestPreferencesPanel({ onClose }) {
                 {CRON_PRESETS.map((p) => (
                   <button
                     key={p.label}
+                    type="button"
                     className={`${styles.presetBtn} ${
                       newCronPreset === p.label ? styles.presetBtnActive : ''
                     }`}
@@ -336,6 +401,7 @@ export default function DigestPreferencesPanel({ onClose }) {
                 <button
                   className={styles.cancelBtn}
                   onClick={() => setShowCreate(false)}
+                  type="button"
                 >
                   Cancel
                 </button>
@@ -343,6 +409,7 @@ export default function DigestPreferencesPanel({ onClose }) {
                   className={styles.saveBtn}
                   onClick={handleCreate}
                   disabled={saving || !connectionId}
+                  type="button"
                 >
                   {saving ? 'Creating...' : 'Create preference'}
                 </button>
@@ -357,28 +424,17 @@ export default function DigestPreferencesPanel({ onClose }) {
 
 function PreferenceCard({
   pref,
+  displayName,
   personaTags,
-  selectedConnection,
   connectionId,
   onToggle,
   onUpdatePersona,
+  onUpdateSchedule,
   onDelete,
 }) {
   const isCurrentConnection = pref.connectionId === connectionId
-  const connName =
-    isCurrentConnection && selectedConnection
-      ? selectedConnection.connectionName
-      : pref.connectionId || 'All connections'
-
-  const personaLabel =
-    personaTags.find((t) => t.value === pref.personaTag)?.label || 'Role-based'
-
-  const deliveryLabel =
-    pref.deliveryMethod === 'SLACK_DM'
-      ? 'Slack DM'
-      : pref.deliveryMethod === 'SLACK_CHANNEL'
-      ? 'Channel'
-      : pref.deliveryMethod || 'Slack'
+  const scheduleValue = pref.cronExpression || ''
+  const knownSchedule = CRON_PRESETS.some((p) => p.value === scheduleValue)
 
   return (
     <div
@@ -388,51 +444,62 @@ function PreferenceCard({
     >
       <div className={styles.prefCardMain}>
         <div className={styles.prefCardHeader}>
-          <span className={styles.prefConnName}>{connName}</span>
+          <span className={styles.prefConnName} title={displayName}>
+            {displayName}
+          </span>
           {isCurrentConnection && (
             <span className={styles.currentBadge}>Current</span>
           )}
-          <span
-            className={`${styles.statusDot} ${
-              pref.enabled ? styles.statusDotActive : ''
-            }`}
-          />
         </div>
 
-        <div className={styles.prefCardMeta}>
-          <span className={styles.metaItem}>
-            <User size={12} />
-            {personaLabel}
-          </span>
-          <span className={styles.metaItem}>
-            <Bell size={12} />
-            {deliveryLabel}
-          </span>
-          {pref.cronExpression && (
-            <span className={styles.metaItem}>
-              <Clock size={12} />
-              Custom schedule
-            </span>
-          )}
+        <div className={styles.prefCardControls}>
+          <label className={styles.controlLabel}>
+            <span>Persona</span>
+            <select
+              className={styles.controlSelect}
+              value={pref.personaTag || ''}
+              onChange={(e) => onUpdatePersona(e.target.value)}
+              title="Persona"
+            >
+              <option value="">Role-based</option>
+              {personaTags.map((tag) => (
+                <option key={tag.value} value={tag.value}>
+                  {tag.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className={styles.controlLabel}>
+            <span>Schedule</span>
+            <select
+              className={styles.controlSelect}
+              value={knownSchedule ? scheduleValue : '__custom__'}
+              onChange={(e) => {
+                const v = e.target.value
+                if (v === '__custom__') return
+                onUpdateSchedule(v)
+              }}
+              title="Schedule"
+            >
+              {CRON_PRESETS.map((p) => (
+                <option key={p.label} value={p.value}>
+                  {p.label}
+                </option>
+              ))}
+              {!knownSchedule && (
+                <option value="__custom__">
+                  Custom ({cronPresetLabel(pref.cronExpression)})
+                </option>
+              )}
+            </select>
+          </label>
         </div>
       </div>
 
       <div className={styles.prefCardActions}>
-        <select
-          className={styles.personaSelect}
-          value={pref.personaTag || ''}
-          onChange={(e) => onUpdatePersona(e.target.value)}
-          title="Change persona"
-        >
-          <option value="">Role-based</option>
-          {personaTags.map((tag) => (
-            <option key={tag.value} value={tag.value}>
-              {tag.label}
-            </option>
-          ))}
-        </select>
-
         <button
+          type="button"
           className={`${styles.toggleBtn} ${
             pref.enabled ? styles.toggleBtnOn : ''
           }`}
@@ -443,6 +510,7 @@ function PreferenceCard({
         </button>
 
         <button
+          type="button"
           className={styles.deleteBtn}
           onClick={onDelete}
           title="Delete preference"

--- a/src/components/sections/DigestPreferencesPanel.module.css
+++ b/src/components/sections/DigestPreferencesPanel.module.css
@@ -353,6 +353,49 @@
   color: #6b7280;
 }
 
+.prefCardControls {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.controlLabel {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 10.5px;
+  font-weight: 600;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.controlSelect {
+  font-size: 12px;
+  font-weight: 500;
+  padding: 5px 8px;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  background: #fff;
+  color: #374151;
+  cursor: pointer;
+  min-width: 110px;
+  max-width: 160px;
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+.controlSelect:hover {
+  border-color: #d1d5db;
+}
+
+.controlSelect:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
+}
+
 .prefCardActions {
   display: flex;
   align-items: center;

--- a/src/components/sections/DigestSection.jsx
+++ b/src/components/sections/DigestSection.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
-import { Newspaper, RefreshCw, Settings, X, Check, Clock, AlertCircle, Zap, Bell } from 'lucide-react'
-import { slackDigestAPI } from '@/lib/api/client'
+import { Newspaper, RefreshCw, Settings, Check, Clock, AlertCircle, Zap } from 'lucide-react'
+import { slackDigestAPI, digestPreferencesAPI } from '@/lib/api/client'
 import { useConnectionManager } from '@/lib/hooks/useConnectionManager'
 import DigestPreferencesPanel from './DigestPreferencesPanel'
 import styles from './DigestSection.module.css'
@@ -160,114 +160,16 @@ function DigestSection({ section }) {
 }
 
 // ─────────────────────────────────────────────
-// Schedule config panel
-// ─────────────────────────────────────────────
-const PRESETS = [
-  { label: '8 AM daily', value: '0 0 8 * * *' },
-  { label: '9 AM daily', value: '0 0 9 * * *' },
-  { label: '10 AM daily', value: '0 0 10 * * *' },
-  { label: '6 AM daily', value: '0 0 6 * * *' },
-  { label: 'Noon daily', value: '0 0 12 * * *' },
-  { label: 'Custom', value: 'custom' },
-]
-
-function SchedulePanel({ onClose }) {
-  const [config, setConfig] = useState(null)
-  const [cron, setCron] = useState('')
-  const [preset, setPreset] = useState('custom')
-  const [saving, setSaving] = useState(false)
-  const [saved, setSaved] = useState(false)
-  const [error, setError] = useState(null)
-
-  useEffect(() => {
-    slackDigestAPI.getConfig().then(cfg => {
-      setConfig(cfg)
-      setCron(cfg.cronExpression ?? '0 0 9 * * *')
-      const match = PRESETS.find(p => p.value === cfg.cronExpression)
-      setPreset(match ? match.value : 'custom')
-    }).catch(() => setError('Could not load config'))
-  }, [])
-
-  const handlePreset = (value) => {
-    setPreset(value)
-    if (value !== 'custom') setCron(value)
-  }
-
-  const save = async () => {
-    setSaving(true)
-    setError(null)
-    try {
-      await slackDigestAPI.updateConfig({ cronExpression: cron })
-      setSaved(true)
-      setTimeout(() => setSaved(false), 2500)
-    } catch {
-      setError('Failed to save')
-    } finally {
-      setSaving(false)
-    }
-  }
-
-  return (
-    <div className={styles.panelOverlay} onClick={onClose}>
-      <div className={styles.panel} onClick={e => e.stopPropagation()}>
-        <div className={styles.panelHeader}>
-          <span className={styles.panelTitle}>Digest Schedule</span>
-          <button className={styles.iconBtn} onClick={onClose}><X size={15} /></button>
-        </div>
-
-        <div className={styles.panelBody}>
-          <p className={styles.panelHint}>
-            Choose when the daily digest is sent to Slack. Changes take effect on the next server restart.
-          </p>
-
-          <label className={styles.fieldLabel}>Quick presets</label>
-          <div className={styles.presets}>
-            {PRESETS.map(p => (
-              <button
-                key={p.value}
-                className={`${styles.presetBtn} ${preset === p.value ? styles.presetBtnActive : ''}`}
-                onClick={() => handlePreset(p.value)}
-              >
-                {p.label}
-              </button>
-            ))}
-          </div>
-
-          <label className={styles.fieldLabel}>Cron expression</label>
-          <input
-            className={styles.cronInput}
-            value={cron}
-            onChange={e => { setCron(e.target.value); setPreset('custom') }}
-            placeholder="0 0 9 * * *"
-            spellCheck={false}
-          />
-          <p className={styles.cronHint}>Format: seconds minutes hours day month weekday</p>
-
-          {error && <p className={styles.errorText}>{error}</p>}
-
-          <button
-            className={styles.saveBtn}
-            onClick={save}
-            disabled={saving || !cron}
-          >
-            {saving ? 'Saving…' : saved ? '✓ Saved' : 'Save schedule'}
-          </button>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-// ─────────────────────────────────────────────
 // Main section
 // ─────────────────────────────────────────────
+const DIGEST_PREFS_AUTOPEN_KEY = 'deepsql.digestPrefs.autoOpened.v1'
+
 export default function DigestFeedSection() {
   const { connectionId, selectedConnection } = useConnectionManager()
   const [digests, setDigests] = useState([])
   const [loading, setLoading] = useState(false)
   const [triggering, setTriggering] = useState(false)
   const [triggerMsg, setTriggerMsg] = useState(null)
-  const [showSettings, setShowSettings] = useState(false)
   const [showPreferences, setShowPreferences] = useState(false)
   const [error, setError] = useState(null)
 
@@ -299,6 +201,40 @@ export default function DigestFeedSection() {
   }, [connectionId])
 
   useEffect(() => { load() }, [load])
+
+  // First-run: auto-open Digest Preferences once when there are no prefs
+  // or none enabled. localStorage flag prevents repeat prompts.
+  useEffect(() => {
+    let cancelled = false
+    try {
+      if (localStorage.getItem(DIGEST_PREFS_AUTOPEN_KEY)) return
+    } catch {
+      return
+    }
+
+    digestPreferencesAPI
+      .getMyPreferences()
+      .then((prefs) => {
+        if (cancelled) return
+        const list = Array.isArray(prefs) ? prefs : []
+        const hasEnabled = list.some((p) => p?.enabled)
+        if (list.length === 0 || !hasEnabled) {
+          setShowPreferences(true)
+          try {
+            localStorage.setItem(DIGEST_PREFS_AUTOPEN_KEY, '1')
+          } catch {
+            // ignore quota / private mode
+          }
+        }
+      })
+      .catch(() => {
+        // Silent: first-run helper must not block the digest feed
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   const triggerNow = async () => {
     setTriggering(true)
@@ -357,14 +293,7 @@ export default function DigestFeedSection() {
           <button
             className={styles.actionBtn}
             onClick={() => setShowPreferences(true)}
-            title="My digest preferences"
-          >
-            <Bell size={14} />
-          </button>
-          <button
-            className={styles.actionBtn}
-            onClick={() => setShowSettings(true)}
-            title="Configure schedule"
+            title="Digest preferences"
           >
             <Settings size={14} />
           </button>
@@ -415,7 +344,6 @@ export default function DigestFeedSection() {
         )}
       </div>
 
-      {showSettings && <SchedulePanel onClose={() => setShowSettings(false)} />}
       {showPreferences && <DigestPreferencesPanel onClose={() => setShowPreferences(false)} />}
     </div>
   )


### PR DESCRIPTION
## Summary
- Pref cards show **human connection display names** instead of UUIDs (`connectionName` on the preferences list DTO; client falls back to the connections list, then UUID only if missing).
- Consolidate digest prefs entry to **one gear** in the Digest section (removed competing bell; legacy global Schedule panel removed from the top bar — schedule is per-preference in the prefs panel).
- Simplify persona / on-off / schedule UX in `DigestPreferencesPanel` (compact labeled controls, no duplicate meta row).
- **First-run**: opening Digests with zero prefs (or none enabled) auto-opens Digest Preferences once (`localStorage` key `deepsql.digestPrefs.autoOpened.v1`).

Keeps seed/me, persona, and enable/disable APIs.

## Acceptance
- [x] Cards show names (e.g. `ec2-replica`), not UUIDs, when the name is known
- [x] Single gear entry for Digest Preferences
- [x] Simplified persona / schedule / On-Off controls
- [x] First-run auto-open once when no/zero enabled prefs
- [x] Branch off latest `origin/main`; no force-push to main

## Test plan
- [ ] Open Digests → only one gear in the top bar; gear opens Digest Preferences
- [ ] Pref cards show connection names for all known connections (not only CURRENT)
- [ ] Toggle On/Off, change persona, change schedule presets; seed/me still works
- [ ] Clear `localStorage['deepsql.digestPrefs.autoOpened.v1']`, ensure zero enabled prefs → panel auto-opens once; reload does not reopen
- [ ] Backend: `GET /api/digest/preferences` includes `connectionName`