### PR TITLE
fix(digest): Run Now uses hybrid personalized path

### DIFF
--- a/backend/src/main/java/com/dbaagent/service/SlackDailyDigestService.java
+++ b/backend/src/main/java/com/dbaagent/service/SlackDailyDigestService.java
@@ -271,9 +271,12 @@ public class SlackDailyDigestService {
 
     public record TriggerResult(boolean triggered, String message) {}
 
-    /** Runs the digest in a virtual thread so the HTTP trigger returns immediately. */
+    /**
+     * Runs the hybrid digest in a virtual thread so the HTTP trigger returns immediately.
+     * Uses per-user personalized delivery when prefs exist; otherwise legacy broadcast.
+     */
     public void sendDailyDigestAsync() {
-        Thread.ofVirtual().name("digest-send").start(this::sendDailyDigest);
+        Thread.ofVirtual().name("digest-send").start(this::sendDailyDigestHybrid);
     }
 
     public TriggerResult triggerDigest() {
@@ -283,17 +286,21 @@ public class SlackDailyDigestService {
         }
 
         boolean slackEnabled = isSlackDeliveryEnabled();
+        boolean perUserMode = isPerUserModeEnabled();
         long bindingCount = channelBindingRepository.count();
-        if (!slackEnabled) {
-            sendDailyDigestAsync();
-            return new TriggerResult(true, "Digest generation started. Slack delivery is disabled in this environment.");
-        }
-        if (bindingCount == 0) {
-            sendDailyDigestAsync();
-            return new TriggerResult(true, "Digest generation started. No Slack channel bindings found, so it will only appear in the app.");
-        }
 
         sendDailyDigestAsync();
+
+        if (!slackEnabled) {
+            return new TriggerResult(true, "Digest generation started. Slack delivery is disabled in this environment.");
+        }
+        if (perUserMode) {
+            return new TriggerResult(true,
+                "Personalized digest delivery started (Slack DMs per user prefs when linked). Channel bindings are not required for DMs.");
+        }
+        if (bindingCount == 0) {
+            return new TriggerResult(true, "Digest generation started. No Slack channel bindings found, so it will only appear in the app.");
+        }
         return new TriggerResult(true, "Digest generation and Slack delivery are running in the background.");
     }
 

--- a/backend/src/test/java/com/dbaagent/service/DigestTriggerHybridTest.java
+++ b/backend/src/test/java/com/dbaagent/service/DigestTriggerHybridTest.java
@@ -1,0 +1,163 @@
+package com.dbaagent.service;
+
+import com.dbaagent.model.DatabaseConnection;
+import com.dbaagent.repository.AuthLoginChallengeRepository;
+import com.dbaagent.repository.CapacityForecastRepository;
+import com.dbaagent.repository.ConnectionAccessGrantRepository;
+import com.dbaagent.repository.DatabaseEventRepository;
+import com.dbaagent.repository.GrowthAnomalyRepository;
+import com.dbaagent.repository.LockContentionRepository;
+import com.dbaagent.repository.QueryFingerprintRepository;
+import com.dbaagent.repository.SchemaChangeRepository;
+import com.dbaagent.repository.SlackChannelBindingRepository;
+import com.dbaagent.repository.SlackDigestLogRepository;
+import com.dbaagent.repository.TableStatsHistoryRepository;
+import com.dbaagent.repository.UserDigestPreferenceRepository;
+import com.dbaagent.repository.UserRepository;
+import com.dbaagent.service.digest.DigestInsightAssemblerService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Admin Run Now / triggerDigest must use the hybrid personalized path,
+ * not legacy-only sendDailyDigest().
+ */
+@ExtendWith(MockitoExtension.class)
+class DigestTriggerHybridTest {
+
+    @Mock private SlackRuntimeSettingsService slackRuntimeSettingsService;
+    @Mock private SlackChannelBindingRepository channelBindingRepository;
+    @Mock private CredentialService credentialService;
+    @Mock private ConnectionService connectionService;
+    @Mock private PerformanceInsightsService performanceInsightsService;
+    @Mock private SlowQueryService slowQueryService;
+    @Mock private SlowQueryHistoryService slowQueryHistoryService;
+    @Mock private SlowQueryInsightsService slowQueryInsightsService;
+    @Mock private SlowQueryAnalyticsService slowQueryAnalyticsService;
+    @Mock private PerformanceActionAggregatorService actionAggregatorService;
+    @Mock private EnhancedSqlParserService sqlParserService;
+    @Mock private QueryExecutorService queryExecutorService;
+    @Mock private TableGrowthMonitoringService tableGrowthMonitoringService;
+    @Mock private SchemaChangeTrackingService schemaChangeTrackingService;
+    @Mock private TableStatsHistoryRepository tableStatsHistoryRepository;
+    @Mock private GrowthAnomalyRepository growthAnomalyRepository;
+    @Mock private CapacityForecastRepository capacityForecastRepository;
+    @Mock private SchemaChangeRepository schemaChangeRepository;
+    @Mock private SlackDigestLogRepository digestLogRepository;
+    @Mock private SlackUserLinkService slackUserLinkService;
+    @Mock private LockContentionRepository lockContentionRepository;
+    @Mock private QueryFingerprintRepository queryFingerprintRepository;
+    @Mock private DatabaseEventRepository databaseEventRepository;
+    @Mock private ConnectionAccessGrantRepository connectionAccessGrantRepository;
+    @Mock private AuthLoginChallengeRepository authLoginChallengeRepository;
+    @Mock private IndexAdvisorService indexAdvisorService;
+    @Mock private IndexRecommendationService indexRecommendationService;
+    @Mock private UserDigestPreferenceRepository preferenceRepository;
+    @Mock private DigestInsightAssemblerService assemblerService;
+    @Mock private UserRepository userRepository;
+
+    private SlackDailyDigestService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new SlackDailyDigestService(
+            slackRuntimeSettingsService,
+            channelBindingRepository,
+            credentialService,
+            connectionService,
+            performanceInsightsService,
+            slowQueryService,
+            slowQueryHistoryService,
+            slowQueryInsightsService,
+            slowQueryAnalyticsService,
+            actionAggregatorService,
+            sqlParserService,
+            queryExecutorService,
+            tableGrowthMonitoringService,
+            schemaChangeTrackingService,
+            tableStatsHistoryRepository,
+            growthAnomalyRepository,
+            capacityForecastRepository,
+            schemaChangeRepository,
+            digestLogRepository,
+            slackUserLinkService,
+            lockContentionRepository,
+            queryFingerprintRepository,
+            databaseEventRepository,
+            connectionAccessGrantRepository,
+            authLoginChallengeRepository,
+            indexAdvisorService,
+            indexRecommendationService,
+            preferenceRepository,
+            assemblerService,
+            userRepository
+        );
+    }
+
+    @Test
+    void sendDailyDigestAsync_invokesHybridNotLegacy() {
+        SlackDailyDigestService spyService = spy(service);
+        doNothing().when(spyService).sendDailyDigestHybrid();
+
+        spyService.sendDailyDigestAsync();
+
+        verify(spyService, timeout(3000)).sendDailyDigestHybrid();
+        verify(spyService, never()).sendDailyDigest();
+    }
+
+    @Test
+    void triggerDigest_withPrefsAndNoChannelBindings_mentionsPersonalizedDm() {
+        DatabaseConnection connection = new DatabaseConnection();
+        connection.setId("ec2-replica");
+        when(credentialService.getAllConnections()).thenReturn(List.of(connection));
+        when(channelBindingRepository.findAll()).thenReturn(List.of());
+        when(preferenceRepository.hasAnyPreferences()).thenReturn(true);
+        when(slackRuntimeSettingsService.current()).thenReturn(
+            new SlackRuntimeSettingsService.SlackRuntimeConfig(true, false, null, "xoxb-test", null, null));
+
+        SlackDailyDigestService spyService = spy(service);
+        doNothing().when(spyService).sendDailyDigestAsync();
+
+        SlackDailyDigestService.TriggerResult result = spyService.triggerDigest();
+
+        assertThat(result.triggered()).isTrue();
+        assertThat(result.message()).containsIgnoringCase("personalized");
+        assertThat(result.message()).containsIgnoringCase("DM");
+        assertThat(result.message()).doesNotContain("only appear in the app");
+        verify(spyService).sendDailyDigestAsync();
+    }
+
+    @Test
+    void triggerDigest_legacyWithoutBindings_stillMentionsChannelBindings() {
+        DatabaseConnection connection = new DatabaseConnection();
+        connection.setId("conn-1");
+        when(credentialService.getAllConnections()).thenReturn(List.of(connection));
+        when(channelBindingRepository.findAll()).thenReturn(List.of());
+        when(channelBindingRepository.count()).thenReturn(0L);
+        when(preferenceRepository.hasAnyPreferences()).thenReturn(false);
+        when(slackRuntimeSettingsService.current()).thenReturn(
+            new SlackRuntimeSettingsService.SlackRuntimeConfig(true, false, null, "xoxb-test", null, null));
+
+        SlackDailyDigestService spyService = spy(service);
+        doNothing().when(spyService).sendDailyDigestAsync();
+
+        SlackDailyDigestService.TriggerResult result = spyService.triggerDigest();
+
+        assertThat(result.triggered()).isTrue();
+        assertThat(result.message()).contains("No Slack channel bindings");
+        assertThat(result.message()).doesNotContainIgnoringCase("personalized");
+    }
+}


### PR DESCRIPTION
## Summary
- Wire admin **Run Now** / `POST /api/admin/slack/digest/trigger` through `sendDailyDigestAsync()` → `sendDailyDigestHybrid()` (per-user prefs / Slack DMs when present; legacy broadcast otherwise) instead of legacy-only `sendDailyDigest()`.
- Keep trigger response messaging honest: when prefs exist, mention personalized DMs and that channel bindings are not required for DMs.
- Add focused unit tests in `DigestTriggerHybridTest`.

Stayflexi GTM needs Run Now to DM per-user prefs (e.g. EXEC on ec2-replica). Tiny follow-up; does not mix with Digests prefs UX (#108).

## Test plan
- [x] `./mvnw -Dtest=DigestTriggerHybridTest test`
- [ ] Admin Digests → Run Now with per-user prefs and no channel bindings → personalized DM path runs; toast does not claim “only appear in the app”
- [ ] Legacy (no prefs) with no bindings → prior channel-binding message still shown